### PR TITLE
fix: allow typecheck workflow to continue for error reporting

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Run typecheck
         id: typecheck
+        continue-on-error: true
         run: |
           set -o pipefail
           bun run typecheck 2>&1 | tee typecheck-output.txt
@@ -98,3 +99,7 @@ jobs:
               event: 'REQUEST_CHANGES',
               body: `❌ **Typecheck Failed**\n\nPlease fix the following type errors:\n\n\`\`\`\n${errors}\n\`\`\``
             });
+
+      - name: Fail if typecheck failed
+        if: steps.typecheck.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
- Add 'continue-on-error: true' to Run typecheck step so it doesn't hard-fail the job
- This allows Extract errors, Upload results, and Post review steps to run (they have 'if: always()')
- Add final 'Fail if typecheck failed' step to maintain job failure status
- Now PR reviews will be posted even when typecheck fails
- Fixes upload artifact and post review on errors not running when typecheck fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance error handling and reporting during type checking validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->