### PR TITLE
fix(ci): fix Windows self-overwrite error in build workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -59,7 +59,13 @@ jobs:
           bun-version: 1.3.8
       - name: Install Dependencies
         if: steps.check_changes.outputs.has_application_changes == 'true'
-        run: bun install --frozen-lockfile && cp -r ./node_modules/electron ./application/node_modules/electron && mkdir -p ./updater/node_modules && cp -r ./node_modules/electron ./updater/node_modules/electron
+        shell: bash
+        run: |
+          bun install --frozen-lockfile
+          mkdir -p ./application/node_modules ./updater/node_modules
+          rm -rf ./application/node_modules/electron ./updater/node_modules/electron
+          cp -r ./node_modules/electron ./application/node_modules/electron
+          cp -r ./node_modules/electron ./updater/node_modules/electron
 
       - name: Build Release Client
         if: steps.check_changes.outputs.has_application_changes == 'true'


### PR DESCRIPTION
Switches the Install Dependencies step to use  and adds  before  to avoid the PowerShell  self-overwrite error on Windows when sub-workspace node_modules are already linked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process efficiency for the release workflow by optimizing dependency installation and electron module handling across application and updater directories.

**Note:** This is an internal infrastructure update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->