### PR TITLE
feat: added 'clearOldFilesBeforeUpdate' prop to system

### DIFF
--- a/application/src/electron/server/api/addons.ts
+++ b/application/src/electron/server/api/addons.ts
@@ -203,6 +203,7 @@ const procedures: Record<string, Procedure<any>> = {
         name: z.string(),
         appID: z.unknown(),
         usedRealDebrid: z.boolean(),
+        clearOldFilesBeforeUpdate: z.boolean().optional(),
         storefront: z.string(),
         multiPartFiles: z
           .array(
@@ -239,6 +240,7 @@ const procedures: Record<string, Procedure<any>> = {
             appID: input.appID,
             type: input.type,
             usedRealDebrid: input.usedRealDebrid,
+            clearOldFilesBeforeUpdate: input.clearOldFilesBeforeUpdate,
             storefront: input.storefront,
             name: input.name,
             multiPartFiles: input.multiPartFiles,

--- a/application/src/frontend/lib/downloads/services/RequestService.ts
+++ b/application/src/frontend/lib/downloads/services/RequestService.ts
@@ -105,6 +105,7 @@ export class RequestService extends BaseService {
       name: result.name,
       isUpdate: result.isUpdate,
       updateVersion: result.updateVersion,
+      clearOldFilesBeforeUpdate: result.clearOldFilesBeforeUpdate,
     };
 
     // Remove the temporary requesting download

--- a/application/src/frontend/lib/setup/setup.ts
+++ b/application/src/frontend/lib/setup/setup.ts
@@ -43,6 +43,7 @@ export function createSetupPayload(
     type: downloadedItem.downloadType,
     name: downloadedItem.name,
     usedRealDebrid: downloadedItem.usedDebridService !== undefined,
+    clearOldFilesBeforeUpdate: downloadedItem.clearOldFilesBeforeUpdate,
     appID: downloadedItem.appID,
     storefront: downloadedItem.storefront,
     for: forType,
@@ -110,6 +111,7 @@ export function handleSetupError(
     type: downloadedItem.downloadType as 'direct' | 'torrent' | 'magnet',
     name: downloadedItem.name,
     usedRealDebrid: downloadedItem.usedDebridService !== undefined,
+    clearOldFilesBeforeUpdate: downloadedItem.clearOldFilesBeforeUpdate,
     appID: downloadedItem.appID,
     storefront: downloadedItem.storefront,
     multiPartFiles:

--- a/application/src/frontend/lib/tasks/runner.ts
+++ b/application/src/frontend/lib/tasks/runner.ts
@@ -11,6 +11,7 @@ export type SearchResultWithAddon = SearchResult & {
   // Update-specific optional fields
   isUpdate?: boolean;
   updateVersion?: string;
+  clearOldFilesBeforeUpdate?: boolean;
 } & (
     | {
         downloadType: 'task';

--- a/application/src/frontend/store.ts
+++ b/application/src/frontend/store.ts
@@ -43,6 +43,7 @@ export type DownloadStatusAndInfo = SearchResult & {
   // Update-specific properties
   isUpdate?: boolean;
   updateVersion?: string;
+  clearOldFilesBeforeUpdate?: boolean;
   // Manifest data from the search result, passed to the setup handler
   manifest?: Record<string, unknown>;
 };

--- a/packages/ogi-addon/package.json
+++ b/packages/ogi-addon/package.json
@@ -3,7 +3,7 @@
   "module": "./build/main.mjs",
   "type": "module",
   "main": "./build/main.cjs",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "exports": {
     ".": {
       "import": {

--- a/packages/ogi-addon/src/SearchEngine.ts
+++ b/packages/ogi-addon/src/SearchEngine.ts
@@ -1,6 +1,12 @@
 type BaseRequiredFields = {
   name: string;
   manifest?: Record<string, any>;
+  /**
+   * Update-only hint for OGI's setup stage.
+   * When false, OGI keeps existing files in place instead of moving them to `old_files`
+   * before running update setup. Defaults to true/undefined behavior.
+   */
+  clearOldFilesBeforeUpdate?: boolean;
 };
 
 export type SearchResult = BaseRequiredFields &

--- a/packages/ogi-addon/src/main.ts
+++ b/packages/ogi-addon/src/main.ts
@@ -206,6 +206,7 @@ export interface EventListenerTypes {
       type: 'direct' | 'torrent' | 'magnet' | 'empty';
       name: string;
       usedRealDebrid: boolean;
+      clearOldFilesBeforeUpdate?: boolean;
       multiPartFiles?: {
         name: string;
         downloadURL: string;

--- a/test-addon/main.ts
+++ b/test-addon/main.ts
@@ -166,6 +166,7 @@ addon.on('search', ({ storefront, appID, for: searchFor }, event) => {
         name: 'Magnet Test',
         downloadType: 'magnet',
         filename: 'Big Buck Bunny',
+        clearOldFilesBeforeUpdate: false,
         downloadURL:
           'magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fbig-buck-bunny.torrent',
       },
@@ -198,6 +199,17 @@ addon.on('search', ({ storefront, appID, for: searchFor }, event) => {
         manifest: {
           t: 'Smalelr File',
         },
+      },
+      {
+        name: '100 MB File',
+        downloadType: 'direct',
+        files: [
+          {
+            name: '100 MB File',
+            downloadURL: 'https://ash-speed.hetzner.com/100MB.bin',
+          },
+        ],
+        clearOldFilesBeforeUpdate: false,
       },
       {
         name: 'Multi-Part Test',

--- a/web/src/pages/docs/first-addon/adding-game-updates.md
+++ b/web/src/pages/docs/first-addon/adding-game-updates.md
@@ -73,6 +73,8 @@ addon.on('search', async (query, event) => {
           targetVersion: '1.2.0',
           patchType: 'incremental',
         },
+        // Keep existing files in place for incremental patchers.
+        clearOldFilesBeforeUpdate: false,
       },
     ]);
     return;
@@ -92,10 +94,11 @@ addon.on('setup', async (data, event) => {
   event.defer();
 
   if (data.for === 'update') {
-    const { path, currentLibraryInfo, manifest } = data;
+    const { path, currentLibraryInfo, manifest, clearOldFilesBeforeUpdate } = data;
 
     // Apply patch/update files in `path`...
     // You can use currentLibraryInfo + manifest to decide strategy.
+    // clearOldFilesBeforeUpdate reflects the selected source option.
 
     event.resolve({
       version: String(manifest?.targetVersion ?? '1.2.0'),
@@ -117,6 +120,10 @@ addon.on('setup', async (data, event) => {
 ```
 
 ## Important behavior to know
+
+- Control whether OGI stages files into `old_files` before update setup:
+  - Set `clearOldFilesBeforeUpdate: false` in your update `search` result when you need in-place patching.
+  - OGI defaults to staging existing files when the property is omitted.
 
 - Return the exact target version in update setup:
   - OGI validates the version returned by `setup` against the selected update target.

--- a/web/src/pages/docs/first-addon/setup-app.md
+++ b/web/src/pages/docs/first-addon/setup-app.md
@@ -19,6 +19,7 @@ addon.on(
       type,
       name,
       usedRealDebrid,
+      clearOldFilesBeforeUpdate,
       appID,
       storefront,
       multiPartFiles,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional configuration option to control whether existing files are staged before updates, enabling in-place patching behavior when configured.

* **Documentation**
  * Updated documentation with setup event payload information and guidance on the file staging option.

* **Chores**
  * Bumped addon package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->