### PR TITLE
Track remote launch state in renderer

### DIFF
--- a/application/src/electron/preload.mts
+++ b/application/src/electron/preload.mts
@@ -497,6 +497,15 @@ ipcRenderer.on(
 );
 
 ipcRenderer.on(
+  'game:launch-requested',
+  wrap((_, arg) => {
+    document.dispatchEvent(
+      new CustomEvent('game:launch-requested', { detail: arg })
+    );
+  })
+);
+
+ipcRenderer.on(
   'game:launch',
   wrap((_, arg) => {
     document.dispatchEvent(new CustomEvent('game:launch', { detail: arg }));

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -88,7 +88,7 @@
   let openedGameConfiguration = $state(false);
 
   async function launchGame() {
-    if ($gamesLaunched[libraryInfo.appID] === 'launched') return;
+    if ($gamesLaunched[libraryInfo.appID]) return;
     if (!playButton) return;
     console.log('Launching game with appID: ' + libraryInfo.appID);
     playButton.setAttribute('data-error', 'false');
@@ -96,7 +96,7 @@
     // Fire of the addon launch-app event first
 
     gamesLaunched.update((games) => {
-      games[libraryInfo.appID] = 'launched';
+      games[libraryInfo.appID] = 'launching';
       return games;
     });
 
@@ -181,6 +181,18 @@
       console.log('Error launching game');
       playButton.disabled = false;
       playButton.querySelector('p')!!.textContent = 'ERROR';
+      playButton.querySelector('svg')!!.style.display = 'none';
+      return;
+    }
+    if (games[libraryInfo.appID] === 'launching') {
+      playButton.disabled = true;
+      playButton.querySelector('p')!!.textContent = 'WAITING';
+      playButton.querySelector('svg')!!.style.display = 'none';
+      return;
+    }
+    if (games[libraryInfo.appID] === 'launched') {
+      playButton.disabled = true;
+      playButton.querySelector('p')!!.textContent = 'PLAYING';
       playButton.querySelector('svg')!!.style.display = 'none';
     }
   });
@@ -484,6 +496,13 @@
           </p>
         </div>
       </div>
+    {:else if $gamesLaunched[libraryInfo.appID] === 'launching'}
+      <button
+        class="px-6 py-3 flex border-none rounded-lg justify-center bg-success items-center gap-2 cursor-not-allowed transition-colors duration-200 text-overlay-text"
+        disabled
+      >
+        <p class="font-archivo font-semibold text-overlay-text">WAITING</p>
+      </button>
     {:else if $gamesLaunched[libraryInfo.appID] === 'launched'}
       <button
         class="px-6 py-3 flex border-none rounded-lg justify-center bg-success items-center gap-2 cursor-not-allowed transition-colors duration-200 text-overlay-text"

--- a/application/src/frontend/managers/GameManager.svelte
+++ b/application/src/frontend/managers/GameManager.svelte
@@ -14,6 +14,14 @@
   const isShortcutLaunchForGame = (appID: number) =>
     shortcutLaunchGameId !== null && shortcutLaunchGameId === appID;
 
+  document.addEventListener('game:launch-requested', (event: Event) => {
+    const appID = (event as CustomEvent).detail.id;
+    gamesLaunched.update((games) => {
+      games[appID] = 'launching';
+      return games;
+    });
+  });
+
   document.addEventListener('game:launch', (event: Event) => {
     const appID = (event as CustomEvent).detail.id;
     gamesLaunched.update((games) => {

--- a/application/src/frontend/store.ts
+++ b/application/src/frontend/store.ts
@@ -154,8 +154,9 @@ export const launchOverlayPlayPageReady: Writable<number | undefined> =
   writable(undefined);
 export const launchGameTrigger: Writable<number | undefined> =
   writable(undefined);
-export const gamesLaunched: Writable<Record<string, 'launched' | 'error'>> =
-  writable({});
+export const gamesLaunched: Writable<
+  Record<string, 'launching' | 'launched' | 'error'>
+> = writable({});
 export type Views =
   | 'config'
   | 'clientoptions'


### PR DESCRIPTION
## Summary
- notify the frontend when the renderer requests or completes remote launches so the UI can enter a launching state and avoid duplicate starts
- extend `gamesLaunched` state to include a `launching` marker, flip it to `launched`/`error` based on outcomes, and show waiting/playing buttons accordingly

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual feedback when launching a game with a waiting indicator
  * Play button is now disabled during the launch process to prevent accidental duplicate launches
  * Improved launch state management for better stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->