### PR TITLE
chore: bump version to 3.0.4 and refactor addon update checks

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opengameinstaller-gui",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "The front-facing GUI for OpenGameInstaller and the addon-server.",
   "type": "module",
   "private": false,

--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -5,7 +5,7 @@ import { exec, spawn } from 'child_process';
 import { processes, setupAddon, startAddon } from '../manager/manager.addon.js';
 import { __dirname } from '../manager/manager.paths.js';
 import { server, clients, port } from '../server/addon-server.js';
-import { sendIPCMessage, sendNotification } from '../main.js';
+import { sendNotification } from '../main.js';
 import axios from 'axios';
 import { AddonConnection } from '../server/AddonConnection.js';
 
@@ -48,9 +48,6 @@ export async function startAddons(): Promise<void> {
   }
   await Promise.allSettled(promises);
   console.log('All addons started');
-
-  // sendIPCMessage waits for client-ready-for-events (with timeout) before sending
-  sendIPCMessage('all-addons-started');
 }
 
 export async function restartAddonServer(): Promise<void> {

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -463,9 +463,16 @@ async function startAddonRuntime() {
   await startAddons();
 }
 
-function onMainAppReady() {
+async function onMainAppReady() {
   closeSplashWindow();
   if (!mainWindow || mainWindow.isDestroyed()) return;
+
+  // Run addon update check first so addon:update-available is sent before all-addons-started.
+  // That way the frontend receives updates in addonUpdates before the handler runs and can auto-update.
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    await checkForAddonUpdates(mainWindow);
+  }
+  sendIPCMessage('all-addons-started');
 
   // Register process-wide listeners only once
   if (!listenersRegistered) {
@@ -490,9 +497,6 @@ function onMainAppReady() {
   mainWindow?.show();
   mainWindow?.focus();
 
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    checkForAddonUpdates(mainWindow);
-  }
   if (ogiDebug()) {
     mainWindow?.webContents?.openDevTools();
   }

--- a/application/src/electron/startup.ts
+++ b/application/src/electron/startup.ts
@@ -706,17 +706,18 @@ async function checkForGitUpdates(repoPath: string): Promise<boolean> {
   });
 }
 
-export function checkForAddonUpdates(mainWindow: BrowserWindow) {
+export async function checkForAddonUpdates(mainWindow: BrowserWindow): Promise<void> {
   if (!fs.existsSync(join(__dirname, 'addons'))) {
     return;
   }
   const generalConfig = JSON.parse(
     fs.readFileSync(join(__dirname, 'config/option/general.json'), 'utf-8')
   );
-  const addons = generalConfig.addons;
+  const addons = generalConfig.addons as string[];
+  const promises: Promise<void>[] = [];
   for (const addon of addons) {
     let addonPath = '';
-    let addonName = addon.split(/\/|\\/).pop()!!;
+    const addonName = addon.split(/\/|\\/).pop()!!;
     if (addon.startsWith('local:')) {
       addonPath = addon.split('local:')[1];
     } else {
@@ -728,22 +729,24 @@ export function checkForAddonUpdates(mainWindow: BrowserWindow) {
       continue;
     }
 
-    new Promise<void>(async (resolve, _) => {
-      const isUpdate = await checkForGitUpdates(addonPath);
-      if (isUpdate) {
-        sendNotification({
-          message: `Addon ${addonName} has updates.`,
-          id: Math.random().toString(36).substring(7),
-          type: 'info',
-        });
-        mainWindow!!.webContents.send('addon:update-available', addon);
-        console.log(`Addon ${addonName} has updates.`);
-        resolve();
-      }
-      console.log(`Addon ${addonName} is up to date.`);
-      resolve();
-    });
+    promises.push(
+      (async () => {
+        const isUpdate = await checkForGitUpdates(addonPath);
+        if (isUpdate) {
+          sendNotification({
+            message: `Addon ${addonName} has updates.`,
+            id: Math.random().toString(36).substring(7),
+            type: 'info',
+          });
+          mainWindow?.webContents.send('addon:update-available', addon);
+          console.log(`Addon ${addonName} has updates.`);
+        } else {
+          console.log(`Addon ${addonName} is up to date.`);
+        }
+      })()
+    );
   }
+  await Promise.all(promises);
 }
 
 export async function removeCachedAppUpdates() {


### PR DESCRIPTION
- Updated package version in package.json.
- Refactored the onMainAppReady function to check for addon updates before signaling that all addons have started.
- Changed checkForAddonUpdates to be asynchronous and improved its handling of promises for better performance.
- Removed unnecessary IPC message sending from startAddons function.