### PR TITLE
fix: restore recently played list update when a game is launched

### DIFF
--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -13,7 +13,7 @@
     clearHeaderBackButton,
     createNotification,
   } from '../store';
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, tick } from 'svelte';
   import SettingsFilled from '../Icons/SettingsFilled.svelte';
   import GameConfiguration from './GameConfiguration.svelte';
   import { fly } from 'svelte/transition';
@@ -112,16 +112,16 @@
       });
     } catch (error) {
       console.error(error);
-      playButton.disabled = false;
-      playButton.setAttribute('data-error', 'true');
-      playButton.querySelector('p')!!.textContent = 'ERROR';
-      playButton.querySelector('svg')!!.style.display = 'none';
-
-      // remove the game from the gamesLaunched state
+      // remove the game from the gamesLaunched state first so the play button is restored
       gamesLaunched.update((games) => {
         delete games[libraryInfo.appID];
         return games;
       });
+      // wait for the DOM to update so playButton is restored
+      await tick();
+      if (playButton) {
+        playButton.setAttribute('data-error', 'true');
+      }
       return;
     }
 
@@ -130,8 +130,6 @@
     await window.electronAPI.app.launchGame('' + libraryInfo.appID);
 
     console.log('launchGame complete');
-
-    playButton.querySelector('p')!!.textContent = 'PLAYING';
     if (!window.electronAPI.fs.exists('./internals')) {
       window.electronAPI.fs.mkdir('./internals');
       window.electronAPI.fs.write(


### PR DESCRIPTION
After the pre/post launch event refactor, `gamesLaunched` was set to 'launching' before the async `safeFetch`/`launchGame` awaits. This caused Svelte to unmount the play button and set `playButton` to undefined. The stale `playButton.querySelector('p')!!.textContent = 'PLAYING'` call after the awaits then threw a TypeError, silently preventing `apps.json` from being updated and breaking the recently played list ordering.

Fix by removing the now-redundant `playButton` text mutation after launch (the template and `gamesLaunched` store already handle the 'PLAYING' UI), and restructuring the pre-launch error catch block to clear `gamesLaunched` first (restoring the play button to the DOM) before conditionally setting the error attribute via `tick()`.

https://claude.ai/code/session_017qF5QrZeTYwL4Uem3UjKVV