### PR TITLE
improve NixOS support across the application

### DIFF
--- a/.github/workflows/update-flake-hash.yml
+++ b/.github/workflows/update-flake-hash.yml
@@ -1,0 +1,80 @@
+name: Update flake.nix hash
+
+# Runs automatically after a release is published (including pre-releases).
+# Downloads the Linux AppImage, computes its sha256, and patches flake.nix so
+# that `nix build` / `nix run` always reflect the latest release.
+on:
+  release:
+    types: [published, prereleased]
+
+permissions:
+  contents: write
+
+jobs:
+  update-flake:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository (main branch)
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Extract version from release tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"   # strip leading 'v'
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for AppImage asset to be available
+        run: |
+          URL="https://github.com/Nat3z/OpenGameInstaller/releases/download/${{ steps.version.outputs.tag }}/OpenGameInstaller-linux-pt.AppImage"
+          echo "Waiting for: $URL"
+          for i in $(seq 1 20); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L --head "$URL")
+            if [ "$STATUS" = "200" ] || [ "$STATUS" = "302" ]; then
+              echo "AppImage is available (HTTP $STATUS)"
+              break
+            fi
+            echo "Attempt $i/20 — HTTP $STATUS, retrying in 30s..."
+            sleep 30
+          done
+
+      - name: Download AppImage and compute sha256 hash
+        id: hash
+        run: |
+          URL="https://github.com/Nat3z/OpenGameInstaller/releases/download/${{ steps.version.outputs.tag }}/OpenGameInstaller-linux-pt.AppImage"
+          curl -fSL -o appimage.AppImage "$URL"
+          # Compute sha256 in nix SRI format: sha256-<base64>
+          HASH_B64=$(openssl dgst -sha256 -binary appimage.AppImage | base64 -w0)
+          echo "hash=sha256-${HASH_B64}" >> "$GITHUB_OUTPUT"
+          echo "Computed hash: sha256-${HASH_B64}"
+
+      - name: Patch flake.nix
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          HASH="${{ steps.hash.outputs.hash }}"
+
+          # Update appVersion
+          sed -i "s/appVersion = \"[^\"]*\"/appVersion = \"${VERSION}\"/" flake.nix
+
+          # Update the hash line (handles both placeholder and real hashes)
+          sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"${HASH}\"|" flake.nix
+
+          echo "--- flake.nix diff ---"
+          git diff flake.nix
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add flake.nix
+          if git diff --staged --quiet; then
+            echo "flake.nix is already up to date — nothing to commit."
+          else
+            git commit -m "chore: update flake.nix to v${{ steps.version.outputs.version }}"
+            git push origin master
+          fi

--- a/.github/workflows/update-flake-hash.yml
+++ b/.github/workflows/update-flake-hash.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out repository (main branch)
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
 
       - name: Extract version from release tag
@@ -76,5 +76,5 @@ jobs:
             echo "flake.nix is already up to date — nothing to commit."
           else
             git commit -m "chore: update flake.nix to v${{ steps.version.outputs.version }}"
-            git push origin master
+            git push origin main
           fi

--- a/.github/workflows/update-flake-hash.yml
+++ b/.github/workflows/update-flake-hash.yml
@@ -33,21 +33,31 @@ jobs:
         run: |
           URL="https://github.com/Nat3z/OpenGameInstaller/releases/download/${{ steps.version.outputs.tag }}/OpenGameInstaller-linux-pt.AppImage"
           echo "Waiting for: $URL"
+          FOUND=0
           for i in $(seq 1 20); do
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L --head "$URL")
             if [ "$STATUS" = "200" ] || [ "$STATUS" = "302" ]; then
               echo "AppImage is available (HTTP $STATUS)"
+              FOUND=1
               break
             fi
             echo "Attempt $i/20 — HTTP $STATUS, retrying in 30s..."
             sleep 30
           done
+          if [ "$FOUND" = "0" ]; then
+            echo "ERROR: AppImage asset was not available after 20 attempts. Aborting."
+            exit 1
+          fi
 
       - name: Download AppImage and compute sha256 hash
         id: hash
         run: |
           URL="https://github.com/Nat3z/OpenGameInstaller/releases/download/${{ steps.version.outputs.tag }}/OpenGameInstaller-linux-pt.AppImage"
           curl -fSL -o appimage.AppImage "$URL"
+          if [ ! -s appimage.AppImage ]; then
+            echo "ERROR: Downloaded AppImage is missing or empty. Aborting."
+            exit 1
+          fi
           # Compute sha256 in nix SRI format: sha256-<base64>
           HASH_B64=$(openssl dgst -sha256 -binary appimage.AppImage | base64 -w0)
           echo "hash=sha256-${HASH_B64}" >> "$GITHUB_OUTPUT"

--- a/application/src/electron/handlers/handler.app.ts
+++ b/application/src/electron/handlers/handler.app.ts
@@ -12,6 +12,7 @@ import { clients } from '../server/addon-server.js';
 import { registerSteamHandlers } from './handler.steam.js';
 import { registerLibraryHandlers } from './handler.library.js';
 import { registerRedistributableHandlers } from './handler.redists.js';
+import { IS_NIXOS } from '../startup.js';
 
 /**
  * Escapes a string for safe use in shell commands by escaping special characters
@@ -178,6 +179,9 @@ export default function handler(mainWindow: Electron.BrowserWindow) {
 
   ipcMain.handle('app:get-os', () => {
     return process.platform;
+  });
+  ipcMain.handle('app:is-nixos', () => {
+    return IS_NIXOS;
   });
   ipcMain.handle('app:screen-input', async (_, data) => {
     currentScreens.set(data.id, data.data);

--- a/application/src/electron/handlers/handler.oobe.ts
+++ b/application/src/electron/handlers/handler.oobe.ts
@@ -7,67 +7,10 @@ import axios from 'axios';
 import { sendNotification, sendIPCMessage } from '../main.js';
 import { IS_NIXOS, STEAMTINKERLAUNCH_PATH } from '../startup.js';
 import os from 'os';
-import { spawn } from 'child_process';
 
 function sendOOBELog(content: string) {
   sendIPCMessage('oobe:log', content);
   console.log('[oobe]' + content);
-}
-
-function spawnAndHook(
-  options: {
-    stdout?: (data: string) => void;
-    stderr?: (data: string) => void;
-    onClose?: (code: number) => void;
-    onError?: (err: Error) => void;
-    cwd?: string;
-  },
-  command: Parameters<typeof spawn>[0],
-  args: Parameters<typeof spawn>[1]
-) {
-  const spawnOptions = options.cwd ? { cwd: options.cwd } : {};
-  sendOOBELog('running: ' + command + ' ' + args.join(' '));
-  const childProcess = spawn(command, args, spawnOptions);
-  let stdout = '';
-  let stderr = '';
-
-  if (childProcess.stdout) {
-    childProcess.stdout.on('data', (data: Buffer) => {
-      const dataStr = data.toString();
-      stdout += dataStr;
-      if (options.stdout) {
-        options.stdout(dataStr);
-      }
-    });
-  }
-
-  if (childProcess.stderr) {
-    childProcess.stderr.on('data', (data: Buffer) => {
-      const dataStr = data.toString();
-      stderr += dataStr;
-      if (options.stderr) {
-        options.stderr(dataStr);
-      }
-    });
-  }
-
-  if (options.onClose) {
-    childProcess.on('close', (code: number) => {
-      options.onClose?.(code);
-    });
-  }
-
-  if (options.onError) {
-    childProcess.on('error', (err: Error) => {
-      options.onError?.(err);
-    });
-  }
-
-  return {
-    process: childProcess,
-    stdout,
-    stderr,
-  };
 }
 
 export default function OOBEHandler() {
@@ -354,9 +297,11 @@ export default function OOBEHandler() {
     } else if (process.platform === 'linux') {
       // check if steamtinkerlaunch is installed in that path
       if (!fs.existsSync(STEAMTINKERLAUNCH_PATH)) {
+        const nixosMsg = IS_NIXOS
+          ? 'SteamTinkerLaunch is not installed. On NixOS, add "steamtinkerlaunch" to your system packages.'
+          : 'SteamTinkerLaunch is not installed. Please install it manually.';
         sendNotification({
-          message:
-            'SteamTinkerLaunch is not installed. You are not on a supported OS. Please install it manually.',
+          message: nixosMsg,
           id: Math.random().toString(36).substring(7),
           type: 'error',
         });
@@ -444,7 +389,7 @@ export default function OOBEHandler() {
       } else if (process.platform === 'linux' && IS_NIXOS) {
         sendNotification({
           message:
-            'Bun is not installed. You are not on a supported OS. Please install it manually.',
+            'Bun is not installed. On NixOS, add "bun" to your system packages or run: nix-env -iA nixpkgs.bun',
           id: Math.random().toString(36).substring(7),
           type: 'error',
         });
@@ -471,104 +416,12 @@ export default function OOBEHandler() {
       );
     }
 
-    // if on linux, check if flatpak is installed and wine is installed
+    // on linux, UMU launcher handles Wine/Proton compatibility automatically.
+    // UMU is auto-installed and managed by the built-in updater — no manual wine setup is needed.
     if (process.platform === 'linux') {
-      const flatpakInstalled = await new Promise<boolean>((resolve, _) => {
-        exec('flatpak --version', (err, stdout, _) => {
-          if (err) {
-            resolve(false);
-          }
-          sendOOBELog(stdout);
-          resolve(true);
-        });
-      });
-      if (!flatpakInstalled) {
-        sendNotification({
-          message:
-            'Flatpak is not installed. Please install Wine through Flatpak for redistributables to work.',
-          id: Math.random().toString(36).substring(7),
-          type: 'error',
-        });
-        cleanlyDownloadedAll = false;
-      } else {
-        const wineInstalled = await new Promise<boolean>((resolve, _) => {
-          exec('flatpak run org.winehq.Wine --help', (err, stdout, _) => {
-            if (err) {
-              resolve(false);
-            }
-            sendOOBELog(stdout);
-            resolve(true);
-          });
-        });
-        if (!wineInstalled) {
-          // install wine through flatpak
-          const result = await new Promise<boolean>((resolve) =>
-            spawnAndHook(
-              {
-                stdout: (data) => {
-                  sendOOBELog(data);
-                },
-                stderr: (data) => {
-                  sendOOBELog(data);
-                },
-                onClose: (code) => {
-                  sendOOBELog('wine process exited with code ' + code);
-                  if (code !== 0) {
-                    resolve(false);
-                    return;
-                  }
-                  resolve(true);
-                },
-                onError: (err) => {
-                  sendOOBELog(`Error: ${err}`);
-                },
-                cwd: __dirname,
-              },
-              'flatpak',
-              [
-                'install',
-                '--system',
-                '-y',
-                'flathub',
-                'org.winehq.Wine/x86_64/stable-25.08',
-              ]
-            )
-          );
-          if (!result) {
-            sendNotification({
-              message: 'Failed to install wine through flatpak.',
-              id: Math.random().toString(36).substring(7),
-              type: 'error',
-            });
-            cleanlyDownloadedAll = false;
-          } else {
-            // run flatpak run org.winehq.Wine --help to see if it works
-            const wineInstalled = await new Promise<boolean>((resolve, _) => {
-              exec('flatpak run org.winehq.Wine --help', (err, stdout, _) => {
-                if (err) {
-                  resolve(false);
-                }
-                sendOOBELog(stdout);
-                resolve(true);
-              });
-            });
-            if (!wineInstalled) {
-              sendNotification({
-                message: 'Failed to install wine through flatpak.',
-                id: Math.random().toString(36).substring(7),
-                type: 'error',
-              });
-              cleanlyDownloadedAll = false;
-            } else {
-              sendNotification({
-                message: 'Successfully installed wine through flatpak.',
-                id: Math.random().toString(36).substring(7),
-                type: 'info',
-              });
-            }
-          }
-        }
-      }
+      sendOOBELog(
+        'Wine compatibility is handled automatically by UMU launcher (auto-installed).'
+      );
     }
     return [cleanlyDownloadedAll, requireRestart];
   });

--- a/application/src/electron/handlers/handler.umu.ts
+++ b/application/src/electron/handlers/handler.umu.ts
@@ -13,7 +13,7 @@ import { generateNotificationId } from './helpers.app/notifications.js';
 import { getSilentInstallFlags } from './helpers.app/install-flags.js';
 import { sendNotification } from '../main.js';
 import { __dirname } from '../manager/manager.paths.js';
-import { downloadLatestUmu } from '../startup.js';
+import { downloadLatestUmu, SYSTEM_UMU_PATH } from '../startup.js';
 
 /**
  * Get the UMU prefix base directory
@@ -27,7 +27,17 @@ function getUmuPrefixBase(): string {
   return path.join(home, '.ogi-wine-prefixes');
 }
 
-const umuRunExecutable = path.join(__dirname, 'bin', 'umu', 'umu-run');
+/**
+ * Get the umu-run executable path.
+ * On NixOS (or any system where umu-run is in PATH), prefer the system-provided binary.
+ * Falls back to the bundled binary managed by the built-in updater.
+ */
+function getUmuRunExecutable(): string {
+  if (SYSTEM_UMU_PATH) {
+    return SYSTEM_UMU_PATH;
+  }
+  return path.join(__dirname, 'bin', 'umu', 'umu-run');
+}
 const KNOWN_LAUNCH_ENV_VARS = new Set([
   'WINEPREFIX',
   'WINEDLLOVERRIDES',
@@ -247,7 +257,7 @@ function streamChildProcessOutput(
 }
 
 export function getUmuRunExecutablePath(): string {
-  return umuRunExecutable;
+  return getUmuRunExecutable();
 }
 
 /**
@@ -281,7 +291,7 @@ export function buildUmuWrapperCommandTemplate(
  */
 export async function isUmuInstalled(): Promise<boolean> {
   try {
-    if (fs.existsSync(umuRunExecutable)) {
+    if (fs.existsSync(getUmuRunExecutable())) {
       return true;
     }
     return false;
@@ -459,11 +469,11 @@ export async function launchWithUmu(
   });
 
   return new Promise((resolve) => {
-    console.log("[umu] command i'm running: ", umuRunExecutable, [
+    console.log("[umu] command i'm running: ", getUmuRunExecutable(), [
       exePath,
       ...parsedLaunchArgs,
     ]);
-    const child = spawn(umuRunExecutable, [exePath, ...parsedLaunchArgs], {
+    const child = spawn(getUmuRunExecutable(), [exePath, ...parsedLaunchArgs], {
       cwd: libraryInfo.cwd,
       env: {
         ...env,
@@ -653,7 +663,7 @@ export async function installRedistributablesWithUmu(
         if (redistributable.path === 'winetricks') {
           // Use winetricks verb
           child = spawn(
-            umuRunExecutable,
+            getUmuRunExecutable(),
             ['winetricks', '-q', redistributable.name],
             {
               env: {
@@ -691,7 +701,7 @@ export async function installRedistributablesWithUmu(
           // Determine silent install flags
           const silentFlags = getSilentInstallFlags(redistFile);
 
-          child = spawn(umuRunExecutable, [redistFile, ...silentFlags], {
+          child = spawn(getUmuRunExecutable(), [redistFile, ...silentFlags], {
             env: {
               ...env,
               PROTONPATH: protonVersion || 'UMU-Latest',
@@ -955,7 +965,7 @@ export async function installRedistributablesWithUmuForLegacy(
 
   const initSuccess = await new Promise<boolean>((resolve) => {
     const initChild = spawn(
-      umuRunExecutable,
+      getUmuRunExecutable(),
       ['wine', 'cmd', '/c', 'echo', 'Prefix initialized'],
       {
         env: {
@@ -1054,7 +1064,7 @@ export async function installRedistributablesWithUmuForLegacy(
         if (redistributable.path === 'winetricks') {
           // Use winetricks verb via UMU
           child = spawn(
-            umuRunExecutable,
+            getUmuRunExecutable(),
             ['winetricks', '-q', redistributable.name],
             {
               env: {
@@ -1087,7 +1097,7 @@ export async function installRedistributablesWithUmuForLegacy(
           const redistFile = path.basename(redistPath);
           const silentFlags = getSilentInstallFlags(redistFile);
 
-          child = spawn(umuRunExecutable, [redistFile, ...silentFlags], {
+          child = spawn(getUmuRunExecutable(), [redistFile, ...silentFlags], {
             env: {
               ...process.env,
               UMU_LOG: 'debug',
@@ -1279,7 +1289,7 @@ async function initializePrefixWithUmuRun(
       resolve(result);
     };
 
-    const initChild = spawn(umuRunExecutable, [''], {
+    const initChild = spawn(getUmuRunExecutable(), [''], {
       cwd,
       env: {
         ...process.env,

--- a/application/src/electron/manager/manager.addon.ts
+++ b/application/src/electron/manager/manager.addon.ts
@@ -6,6 +6,7 @@ import exec from 'child_process';
 import { addonSecret } from '../server/constants.js';
 import { clients } from '../server/addon-server.js';
 import { AddonConnection } from '../server/AddonConnection.js';
+import { IS_NIXOS } from '../startup.js';
 
 export let processes: {
   [key: string]: exec.ChildProcess;
@@ -247,6 +248,7 @@ async function executeScript(
   return new Promise((resolve, reject) => {
     let bunPath = '';
     // if on windows, then use C:\Users\username\.bun\bin\bun.exe
+    // if on nixos, bun is a system package on PATH — use it directly
     // if on linux, then use ~/.bun/bin/bun
     if (process.platform === 'win32') {
       if (!process.env.USERPROFILE) {
@@ -258,6 +260,8 @@ async function executeScript(
         return reject();
       }
       bunPath = join(process.env.USERPROFILE || '', '.bun', 'bin', 'bun.exe');
+    } else if (IS_NIXOS) {
+      bunPath = 'bun';
     } else {
       if (!process.env.HOME) {
         sendNotification({

--- a/application/src/electron/preload.mts
+++ b/application/src/electron/preload.mts
@@ -252,6 +252,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('app:remove-app', appid)
     ),
     getOS: wrap(() => ipcRenderer.invoke('app:get-os')),
+    isNixOS: wrap(() => ipcRenderer.invoke('app:is-nixos')),
     isOnline: wrap(() => ipcRenderer.invoke('app:is-online')),
     request: wrap(
       (

--- a/application/src/electron/startup.ts
+++ b/application/src/electron/startup.ts
@@ -333,9 +333,9 @@ export let STEAMTINKERLAUNCH_PATH = join(
 // On NixOS, prefer the system-installed umu-run over the bundled one
 export let SYSTEM_UMU_PATH: string | null = null;
 
-async function fetch_STLPath() {
+async function fetchStlPath() {
   return new Promise<void>((resolve) => {
-    exec('which steamtinkerlaunch', (error, stdout) => {
+    exec('command -v steamtinkerlaunch', (error, stdout) => {
       if (error) {
         console.error(`exec error: ${error}`);
         resolve();
@@ -354,7 +354,7 @@ async function fetch_STLPath() {
 
 async function fetchSystemUmuPath() {
   return new Promise<void>((resolve) => {
-    exec('which umu-run', (error, stdout) => {
+    exec('command -v umu-run', (error, stdout) => {
       if (!error && stdout.trim()) {
         SYSTEM_UMU_PATH = stdout.trim();
         console.log('[umu] Found system umu-run at: ' + SYSTEM_UMU_PATH);
@@ -366,7 +366,7 @@ async function fetchSystemUmuPath() {
 
 console.log('NIXOS: ' + IS_NIXOS);
 if (IS_NIXOS) {
-  await fetch_STLPath();
+  await fetchStlPath();
   await fetchSystemUmuPath();
 }
 if (STEAMTINKERLAUNCH_PATH === '') {

--- a/application/src/electron/startup.ts
+++ b/application/src/electron/startup.ts
@@ -243,6 +243,13 @@ export function startUmuBackgroundUpdater() {
     return;
   }
 
+  // On NixOS with system umu-run, skip the background updater entirely.
+  // The system package manager (nix) is responsible for keeping it updated.
+  if (IS_NIXOS && SYSTEM_UMU_PATH) {
+    console.log('[umu] NixOS with system umu-run detected, skipping background updater');
+    return;
+  }
+
   if (umuBackgroundCheckTimeout || umuBackgroundCheckInterval) {
     return;
   }
@@ -281,24 +288,38 @@ export function stopUmuBackgroundUpdater() {
   }
 }
 
-// check if NixOS using command -v nixos-rebuild
+// Detect NixOS by checking /etc/os-release, /run/current-system, and nixos-rebuild in PATH
 export const IS_NIXOS = await (() => {
   return new Promise<boolean>((resolve) => {
+    // First: check /etc/os-release for ID=nixos (fast, no subprocess)
     try {
-      exec('command -v nixos-rebuild', (error, stderr) => {
-        if (error) {
-          console.error(`exec error: ${error}`);
-          resolve(false);
-          return;
-        }
-        if (stderr.includes('nixos-rebuild')) {
+      if (fs.existsSync('/etc/os-release')) {
+        const osRelease = fs.readFileSync('/etc/os-release', 'utf-8');
+        if (/^ID\s*=\s*"?nixos"?/m.test(osRelease)) {
           resolve(true);
           return;
         }
-        resolve(false);
+      }
+    } catch {
+      // Fall through to next check
+    }
+
+    // Second: check /run/current-system which is NixOS-specific
+    if (fs.existsSync('/run/current-system')) {
+      resolve(true);
+      return;
+    }
+
+    // Third: fall back to subprocess check
+    try {
+      exec('command -v nixos-rebuild', (error, stdout) => {
+        if (error) {
+          resolve(false);
+          return;
+        }
+        resolve(stdout.trim().length > 0);
       });
-    } catch (error) {
-      console.error(`exec error: ${error}`);
+    } catch {
       resolve(false);
     }
   });
@@ -308,29 +329,46 @@ export let STEAMTINKERLAUNCH_PATH = join(
   __dirname,
   'bin/steamtinkerlaunch/steamtinkerlaunch'
 );
+
+// On NixOS, prefer the system-installed umu-run over the bundled one
+export let SYSTEM_UMU_PATH: string | null = null;
+
 async function fetch_STLPath() {
   return new Promise<void>((resolve) => {
-    exec('which steamtinkerlaunch', (error, stdout, stderr) => {
+    exec('which steamtinkerlaunch', (error, stdout) => {
       if (error) {
         console.error(`exec error: ${error}`);
-        resolve();
-        return;
-      }
-      if (stderr) {
-        console.error(`stderr: ${stderr}`);
         resolve();
         return;
       }
 
       // The path will be returned as a string in stdout.
       const path = stdout.trim(); // Remove any extra newlines or spaces.
-      STEAMTINKERLAUNCH_PATH = path;
+      if (path) {
+        STEAMTINKERLAUNCH_PATH = path;
+      }
       resolve();
     });
   });
 }
+
+async function fetchSystemUmuPath() {
+  return new Promise<void>((resolve) => {
+    exec('which umu-run', (error, stdout) => {
+      if (!error && stdout.trim()) {
+        SYSTEM_UMU_PATH = stdout.trim();
+        console.log('[umu] Found system umu-run at: ' + SYSTEM_UMU_PATH);
+      }
+      resolve();
+    });
+  });
+}
+
 console.log('NIXOS: ' + IS_NIXOS);
-if (IS_NIXOS) await fetch_STLPath();
+if (IS_NIXOS) {
+  await fetch_STLPath();
+  await fetchSystemUmuPath();
+}
 if (STEAMTINKERLAUNCH_PATH === '') {
   STEAMTINKERLAUNCH_PATH = join(
     __dirname,

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -30,10 +30,11 @@
 
   // Get OS platform
   $effect(() => {
-    window.electronAPI.app.getOS().then((os) => {
+    Promise.all([
+      window.electronAPI.app.getOS(),
+      window.electronAPI.app.isNixOS(),
+    ]).then(([os, nix]) => {
       platform = os;
-    });
-    window.electronAPI.app.isNixOS().then((nix) => {
       isNixOS = nix;
     });
   });

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -26,11 +26,15 @@
   let { exitPlayPage, gameInfo, onFinish }: Props = $props();
 
   let platform = $state<string>('');
+  let isNixOS = $state(false);
 
   // Get OS platform
   $effect(() => {
     window.electronAPI.app.getOS().then((os) => {
       platform = os;
+    });
+    window.electronAPI.app.isNixOS().then((nix) => {
+      isNixOS = nix;
     });
   });
 
@@ -215,7 +219,7 @@
     <SectionModal class="mt-4">
       <div class="flex gap-3 flex-row">
         <ButtonModal text="Save" variant="primary" onclick={pushChanges} />
-        {#if platform === 'linux' || platform === 'darwin'}
+        {#if (platform === 'linux' || platform === 'darwin') && !isNixOS}
           <ButtonModal
             text="Add to Steam"
             variant="secondary"

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -61,6 +61,7 @@
     appUpdates.requiredReadds.some((r) => r.appID === libraryInfo.appID)
   );
   let os = $state('');
+  let isNixOS = $state(false);
   let isMigratingToUmu = $state(false);
   let needsUmuSetup = $derived.by(() => {
     const isLinux = os === 'linux';
@@ -313,6 +314,7 @@
 
   onMount(async () => {
     os = await window.electronAPI.app.getOS();
+    isNixOS = await window.electronAPI.app.isNixOS();
 
     // Set up the header back button
     console.log('PlayPage mounted, setting header back button');
@@ -607,8 +609,8 @@
     </div>
   {/if}
 
-  <!-- Steam Re-add Banner -->
-  {#if requiresSteamReadd}
+  <!-- Steam Re-add Banner (not shown on NixOS since Add to Steam is unsupported) -->
+  {#if requiresSteamReadd && !isNixOS}
     <div
       class="bg-accent-lighter rounded-lg p-5 mx-0 mt-6 flex flex-col gap-3"
       in:fly={{ y: -20, duration: 300 }}

--- a/application/src/frontend/global.d.ts
+++ b/application/src/frontend/global.d.ts
@@ -149,6 +149,7 @@ interface Window {
       launchGame: (appid: string) => Promise<void>;
       removeApp: (appid: number) => Promise<void>;
       getOS: () => Promise<string>;
+      isNixOS: () => Promise<boolean>;
       isOnline: () => Promise<boolean>;
       request: (
         method: string,

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
           };
           # Make the system umu-run visible inside the AppImage sandbox so OGI's
           # NixOS detection can find it without downloading a bundled copy.
-          extraPkgs = pkgs: [ pkgs.umu-launcher pkgs.bun ];
+          extraPkgs = pkgs: [ pkgs.umu-launcher pkgs.bun pkgs.unzip pkgs.unrar ];
         };
     in
     {
@@ -88,6 +88,9 @@
             pkgs.umu-launcher
             # bun is required at runtime for OGI's JS execution layer
             pkgs.bun
+            # archive extraction tools used by addons
+            pkgs.unzip
+            pkgs.unrar
           ];
         };
       };
@@ -118,6 +121,10 @@
 
                   # UMU launcher — OGI prefers the system binary on NixOS
                   umu-launcher
+
+                  # Archive extraction tools used by addons
+                  unzip
+                  unrar
 
                   # Native build toolchain
                   pkg-config

--- a/flake.nix
+++ b/flake.nix
@@ -14,61 +14,129 @@
   outputs = { self, nixpkgs, devenv, systems, ... } @ inputs:
     let
       forEachSystem = nixpkgs.lib.genAttrs (import systems);
+
+      # ── Version ──────────────────────────────────────────────────────────────
+      # Bump this and update `hash` below whenever a new release is cut.
+      appVersion = "3.0.5";
+
+      # ── Production package builder ───────────────────────────────────────────
+      # Wraps the pre-built x86_64 Linux AppImage for NixOS compatibility.
+      # Only usable on Linux; `packages.${system}.default` is only set when
+      # `pkgs.stdenv.isLinux` is true.
+      mkOgiPackage = pkgs:
+        pkgs.appimageTools.wrapType2 {
+          pname = "opengameinstaller";
+          version = appVersion;
+          src = pkgs.fetchurl {
+            url = "https://github.com/Nat3z/OpenGameInstaller/releases/download/v${appVersion}/OpenGameInstaller-linux-pt.AppImage";
+            # After bumping appVersion, obtain the correct hash with:
+            #   nix store prefetch-file --hash-type sha256 <url>
+            # or simply run `nix build` — Nix will print the right hash.
+            hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+          };
+          # Make the system umu-run visible inside the AppImage sandbox so OGI's
+          # NixOS detection can find it without downloading a bundled copy.
+          extraPkgs = pkgs: [ pkgs.umu-launcher ];
+        };
     in
     {
-      packages = forEachSystem (system: {
-        devenv-up = self.devShells.${system}.default.config.procfileScript;
-        devenv-test = self.devShells.${system}.default.config.test;
-      });
+      # ── Production packages ──────────────────────────────────────────────────
+      # `nix build` / `nix profile install` on Linux:
+      #   nix build github:Nat3z/OpenGameInstaller
+      packages = forEachSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          # devenv helpers (kept from the original flake)
+          devenv-up   = self.devShells.${system}.default.config.procfileScript;
+          devenv-test = self.devShells.${system}.default.config.test;
+        } // nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          default = mkOgiPackage pkgs;
+        }
+      );
 
-      devShells = forEachSystem
-        (system:
-          let
-            pkgs = nixpkgs.legacyPackages.${system};
-          in
-          {
-            default = devenv.lib.mkShell {
-              inherit inputs pkgs;
-              modules = [
-                {
-                  # https://devenv.sh/reference/options/
-                  packages = with pkgs; [
-                    # Runtime dependencies for the app on NixOS
-                    electron
-                    bun
-                    git
-                    libglibutil
+      # ── nix run ──────────────────────────────────────────────────────────────
+      # Launch without installing:
+      #   nix run github:Nat3z/OpenGameInstaller
+      apps = forEachSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          default = {
+            type    = "app";
+            program = "${self.packages.${system}.default}/bin/opengameinstaller";
+          };
+        }
+      );
 
-                    # Wine for running Windows redistributables
-                    wineWowPackages.stable
+      # ── NixOS module ─────────────────────────────────────────────────────────
+      # Add to your NixOS configuration:
+      #
+      #   inputs.opengameinstaller.url = "github:Nat3z/OpenGameInstaller";
+      #
+      #   { inputs, ... }: {
+      #     imports = [ inputs.opengameinstaller.nixosModules.default ];
+      #     programs.opengameinstaller.enable = true;
+      #   }
+      nixosModules.default = { config, pkgs, lib, ... }: {
+        options.programs.opengameinstaller.enable =
+          lib.mkEnableOption "OpenGameInstaller — open-source game installer and launcher";
 
-                    # SteamTinkerLaunch (used for Steam shortcut management on non-NixOS)
-                    # On NixOS we skip "Add to Steam" so this is only for dev reference
-                    steamtinkerlaunch
+        config = lib.mkIf config.programs.opengameinstaller.enable {
+          environment.systemPackages = [
+            (mkOgiPackage pkgs)
+            # umu-launcher is used directly by OGI on NixOS for Wine/Proton
+            # compatibility; declaring it here ensures it survives GC.
+            pkgs.umu-launcher
+          ];
+        };
+      };
 
-                    # UMU launcher — preferred over the bundled auto-download on NixOS
-                    umu-launcher
+      # ── Development shells ───────────────────────────────────────────────────
+      # Enter with:  nix develop
+      devShells = forEachSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = devenv.lib.mkShell {
+            inherit inputs pkgs;
+            modules = [
+              {
+                # https://devenv.sh/reference/options/
+                packages = with pkgs; [
+                  # Runtime deps mirroring what production users need
+                  electron
+                  bun
+                  git
+                  libglibutil
 
-                    # Native build tools
-                    pkg-config
-                    gcc
-                  ];
+                  # Wine for running Windows redistributables
+                  wineWowPackages.stable
 
-                  enterShell = ''
-                    echo "OpenGameInstaller dev shell"
-                    echo "  bun:              $(bun --version)"
-                    echo "  git:              $(git --version)"
-                    echo "  electron:         available via ELECTRON_OVERRIDE_DIST_PATH"
-                    echo "  umu-run:          $(which umu-run 2>/dev/null || echo 'not found')"
-                    echo "  wine:             $(wine --version 2>/dev/null || echo 'not found')"
-                    echo ""
-                    echo "NixOS users: 'Add to Steam' is disabled — use umu-run for game compatibility."
-                  '';
+                  # SteamTinkerLaunch (reference only — Add to Steam is
+                  # disabled on NixOS, but useful for dev investigation)
+                  steamtinkerlaunch
 
-                  env.ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron}/bin/";
-                }
-              ];
-            };
-          });
+                  # UMU launcher — OGI prefers the system binary on NixOS
+                  umu-launcher
+
+                  # Native build toolchain
+                  pkg-config
+                  gcc
+                ];
+
+                enterShell = ''
+                  echo "OpenGameInstaller dev shell (v${appVersion})"
+                  echo "  bun:     $(bun --version)"
+                  echo "  git:     $(git --version)"
+                  echo "  umu-run: $(which umu-run 2>/dev/null || echo 'not found')"
+                  echo "  wine:    $(wine --version 2>/dev/null || echo 'not found')"
+                  echo ""
+                  echo "NixOS: 'Add to Steam' is disabled; use umu-run for compatibility."
+                '';
+
+                env.ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron}/bin/";
+              }
+            ];
+          };
+        }
+      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
           };
           # Make the system umu-run visible inside the AppImage sandbox so OGI's
           # NixOS detection can find it without downloading a bundled copy.
-          extraPkgs = pkgs: [ pkgs.umu-launcher ];
+          extraPkgs = pkgs: [ pkgs.umu-launcher pkgs.bun ];
         };
     in
     {
@@ -86,6 +86,8 @@
             # umu-launcher is used directly by OGI on NixOS for Wine/Proton
             # compatibility; declaring it here ensures it survives GC.
             pkgs.umu-launcher
+            # bun is required at runtime for OGI's JS execution layer
+            pkgs.bun
           ];
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
                   electron
                   bun
                   git
-                  libglibutil
+                  libglibutil # provides GLib utilities required by Electron's GLib bindings at runtime
 
                   # Wine for running Windows redistributables
                   wineWowPackages.stable

--- a/flake.nix
+++ b/flake.nix
@@ -33,16 +33,38 @@
                 {
                   # https://devenv.sh/reference/options/
                   packages = with pkgs; [
-                    hello
-                    libglibutil
+                    # Runtime dependencies for the app on NixOS
                     electron
+                    bun
+                    git
+                    libglibutil
+
+                    # Wine for running Windows redistributables
+                    wineWowPackages.stable
+
+                    # SteamTinkerLaunch (used for Steam shortcut management on non-NixOS)
+                    # On NixOS we skip "Add to Steam" so this is only for dev reference
+                    steamtinkerlaunch
+
+                    # UMU launcher — preferred over the bundled auto-download on NixOS
+                    umu-launcher
+
+                    # Native build tools
+                    pkg-config
+                    gcc
                   ];
 
                   enterShell = ''
-                    hello
+                    echo "OpenGameInstaller dev shell"
+                    echo "  bun:              $(bun --version)"
+                    echo "  git:              $(git --version)"
+                    echo "  electron:         available via ELECTRON_OVERRIDE_DIST_PATH"
+                    echo "  umu-run:          $(which umu-run 2>/dev/null || echo 'not found')"
+                    echo "  wine:             $(wine --version 2>/dev/null || echo 'not found')"
+                    echo ""
+                    echo "NixOS users: 'Add to Steam' is disabled — use umu-run for game compatibility."
                   '';
 
-                  processes.hello.exec = "hello";
                   env.ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron}/bin/";
                 }
               ];


### PR DESCRIPTION
- Fix NixOS detection: check /etc/os-release and /run/current-system before falling back to subprocess; fix misleading variable name (stderr → stdout) in exec callback

- Add system UMU detection on NixOS: detect umu-run in PATH and export SYSTEM_UMU_PATH; skip background auto-updater when system UMU is used (nix manages updates instead); handler.umu.ts prefers system umu-run over the bundled one via getUmuRunExecutable()

- Disable "Add to Steam" on NixOS: expose IS_NIXOS to the frontend via app:is-nixos IPC; hide the button in GameConfiguration and PlayPage (SteamTinkerLaunch doesn't work on the read-only NixOS file system)

- Replace OOBE flatpak wine step with UMU: remove the flatpak/wine detection and install flow entirely — UMU handles Wine/Proton compatibility automatically and is already auto-installed

- Improve NixOS error messages: Bun and SteamTinkerLaunch errors now give NixOS-specific instructions (nix-env / system packages) instead of the generic "not a supported OS" message

- Improve flake.nix dev shell: add bun, git, wine, steamtinkerlaunch, umu-launcher, and pkg-config; print a helpful summary on shell entry

https://claude.ai/code/session_015CFafjEWfoMZjVPWv8dBXo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NixOS detection and support with automatic system UMU launcher integration.
  * Implemented NixOS module for improved package management.
  * Simplified Wine/Flatpak setup—now automatic via UMU launcher on Linux.

* **Changes**
  * "Add to Steam" and Steam Re-add features are disabled on NixOS.

* **Chores**
  * Automated version updates upon release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->