### PR TITLE
Fix recently played section layout with consistent height and width

### DIFF
--- a/application/src/frontend/views/LibraryView.svelte
+++ b/application/src/frontend/views/LibraryView.svelte
@@ -163,7 +163,7 @@
               class="flex gap-4 flex-row flex-nowrap overflow-x-hidden pt-8 -mt-8 pb-6 -mb-6 overflow-y-hidden px-4"
             >
               {#each recentlyPlayed as app, index (app.appID)}
-                <div class="library-entry-shell grow basis-0 min-w-0">
+                <div class="library-entry-shell w-1/5 shrink-0">
                   <button
                     data-library-item
                     class="library-entry w-full border-none relative transition-all shadow-lg hover:shadow-xl rounded-lg overflow-hidden bg-surface"


### PR DESCRIPTION
Replace grow/basis-0 flex sizing with a fixed w-1/5 width on each card,
matching the all-games grid column width. This ensures cards are always
the same size regardless of how many recently played items exist.

https://claude.ai/code/session_01M6QGQFYuE3HhQ6BhjY2RRA