### PR TITLE
Gracefully terminate addon and app child processes

### DIFF
--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -8,6 +8,14 @@ import { server, clients, port } from '../server/addon-server.js';
 import { sendNotification } from '../main.js';
 import axios from 'axios';
 import { AddonConnection } from '../server/AddonConnection.js';
+import { terminateProcessTree } from '../lib/processes.js';
+
+async function stopAddonProcesses(): Promise<void> {
+  for (const processPath of Object.keys(processes)) {
+    await terminateProcessTree(processes[processPath], processPath);
+    delete processes[processPath];
+  }
+}
 
 export async function startAddons(): Promise<void> {
   // start all of the addons
@@ -56,11 +64,7 @@ export async function restartAddonServer(): Promise<void> {
   server.close();
   clients.clear();
   // stop all of the addons
-  for (const process of Object.keys(processes)) {
-    console.log(`Killing process ${process}`);
-    const killed = processes[process].kill('SIGKILL');
-    console.log(`Killed process ${process}: ${killed}`);
-  }
+  await stopAddonProcesses();
   // start the server and wait for it to be listening before starting addons
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
@@ -206,10 +210,7 @@ export default function AddonManagerHandler(mainWindow: BrowserWindow) {
 
   ipcMain.handle('clean-addons', async (_) => {
     // stop all of the addons
-    for (const process of Object.keys(processes)) {
-      console.log(`Killing process ${process}`);
-      processes[process].kill('SIGKILL');
-    }
+    await stopAddonProcesses();
 
     // delete all of the addons
     fs.rmSync(join(__dirname, 'addons/'), { recursive: true, force: true });
@@ -240,10 +241,7 @@ export default function AddonManagerHandler(mainWindow: BrowserWindow) {
     }
 
     // stop all of the addons
-    for (const process of Object.keys(processes)) {
-      console.log(`Killing process ${process}`);
-      processes[process].kill('SIGKILL');
-    }
+    await stopAddonProcesses();
 
     // pull all of the addons
     if (!fs.existsSync(join(__dirname, 'addons/'))) {

--- a/application/src/electron/lib/processes.ts
+++ b/application/src/electron/lib/processes.ts
@@ -1,0 +1,236 @@
+import { execFile, type ChildProcess } from 'child_process';
+
+type ProcessEntry = {
+  pid: number;
+  ppid: number;
+};
+
+const FORCE_KILL_TIMEOUT_MS = 1500;
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function execFileAsync(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    return error?.code !== 'ESRCH';
+  }
+}
+
+async function getUnixProcessTable(): Promise<ProcessEntry[]> {
+  const stdout = await execFileAsync('ps', ['-eo', 'pid=,ppid=']);
+
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split(/\s+/))
+    .map(([pid, ppid]) => ({
+      pid: Number.parseInt(pid, 10),
+      ppid: Number.parseInt(ppid, 10),
+    }))
+    .filter((entry) => Number.isFinite(entry.pid) && Number.isFinite(entry.ppid));
+}
+
+async function getWindowsProcessTable(): Promise<ProcessEntry[]> {
+  const stdout = await execFileAsync('powershell.exe', [
+    '-NoProfile',
+    '-Command',
+    'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId | ConvertTo-Json -Compress',
+  ]);
+
+  const raw = stdout.trim();
+  if (!raw) {
+    return [];
+  }
+
+  const parsed = JSON.parse(raw) as
+    | { ProcessId?: number; ParentProcessId?: number }
+    | Array<{ ProcessId?: number; ParentProcessId?: number }>;
+
+  const rows = Array.isArray(parsed) ? parsed : [parsed];
+
+  return rows
+    .map((row) => ({
+      pid: Number(row.ProcessId),
+      ppid: Number(row.ParentProcessId),
+    }))
+    .filter((entry) => Number.isFinite(entry.pid) && Number.isFinite(entry.ppid));
+}
+
+async function getProcessTable(): Promise<ProcessEntry[]> {
+  if (process.platform === 'win32') {
+    return getWindowsProcessTable();
+  }
+  return getUnixProcessTable();
+}
+
+function getDescendantPids(rootPid: number, table: ProcessEntry[]): number[] {
+  const childrenByParent = new Map<number, number[]>();
+
+  for (const entry of table) {
+    const children = childrenByParent.get(entry.ppid) ?? [];
+    children.push(entry.pid);
+    childrenByParent.set(entry.ppid, children);
+  }
+
+  const descendants: number[] = [];
+  const walk = (pid: number) => {
+    const children = childrenByParent.get(pid) ?? [];
+    for (const childPid of children) {
+      walk(childPid);
+      descendants.push(childPid);
+    }
+  };
+
+  walk(rootPid);
+  return descendants;
+}
+
+function getProcessPid(target: ChildProcess | number | null | undefined) {
+  if (typeof target === 'number') {
+    return target;
+  }
+
+  return target?.pid ?? null;
+}
+
+function killUnixPids(pids: number[], signal: NodeJS.Signals) {
+  for (const pid of pids) {
+    if (!pid || pid === process.pid) {
+      continue;
+    }
+
+    try {
+      process.kill(pid, signal);
+    } catch (error: any) {
+      if (error?.code !== 'ESRCH') {
+        console.error(
+          `[processes] Failed to send ${signal} to PID ${pid}:`,
+          error
+        );
+      }
+    }
+  }
+}
+
+async function killWindowsPid(
+  pid: number,
+  options?: {
+    includeTree?: boolean;
+  }
+) {
+  const args = ['/PID', String(pid), '/F'];
+  if (options?.includeTree !== false) {
+    args.push('/T');
+  }
+
+  try {
+    await execFileAsync('taskkill', args);
+  } catch (error: any) {
+    const output = `${error?.stdout ?? ''}\n${error?.stderr ?? ''}`.toLowerCase();
+    if (
+      !output.includes('not found') &&
+      !output.includes('no running instance') &&
+      !output.includes('not running')
+    ) {
+      console.error(`[processes] Failed to taskkill PID ${pid}:`, error);
+    }
+  }
+}
+
+export async function terminateProcessTree(
+  target: ChildProcess | number | null | undefined,
+  label = 'process'
+): Promise<void> {
+  const pid = getProcessPid(target);
+  if (!pid || pid === process.pid) {
+    return;
+  }
+
+  if (!isProcessAlive(pid)) {
+    return;
+  }
+
+  console.log(`[processes] Terminating ${label} (PID ${pid})`);
+
+  if (process.platform === 'win32') {
+    await killWindowsPid(pid);
+    return;
+  }
+
+  let trackedPids = [pid];
+  try {
+    const table = await getProcessTable();
+    trackedPids = [...getDescendantPids(pid, table), pid];
+  } catch (error) {
+    console.error(
+      `[processes] Failed to inspect descendants for ${label} (PID ${pid}), falling back to direct kill:`,
+      error
+    );
+  }
+
+  killUnixPids(trackedPids, 'SIGTERM');
+  await wait(FORCE_KILL_TIMEOUT_MS);
+
+  const remaining = trackedPids.filter((trackedPid) => isProcessAlive(trackedPid));
+  if (remaining.length > 0) {
+    console.warn(
+      `[processes] Force killing ${label}; still alive after SIGTERM: ${remaining.join(', ')}`
+    );
+    killUnixPids(remaining, 'SIGKILL');
+  }
+}
+
+export async function terminateCurrentProcessChildren(): Promise<void> {
+  let table: ProcessEntry[] = [];
+  try {
+    table = await getProcessTable();
+  } catch (error) {
+    console.error('[processes] Failed to inspect child processes:', error);
+    return;
+  }
+
+  const descendantPids = getDescendantPids(process.pid, table).filter(
+    (pid) => pid !== process.pid
+  );
+
+  if (descendantPids.length === 0) {
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    for (const pid of descendantPids) {
+      await killWindowsPid(pid, { includeTree: false });
+    }
+    return;
+  }
+
+  killUnixPids(descendantPids, 'SIGTERM');
+  await wait(FORCE_KILL_TIMEOUT_MS);
+
+  const remaining = descendantPids.filter((pid) => isProcessAlive(pid));
+  if (remaining.length > 0) {
+    console.warn(
+      `[processes] Force killing child processes after SIGTERM: ${remaining.join(', ')}`
+    );
+    killUnixPids(remaining, 'SIGKILL');
+  }
+}

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -10,7 +10,6 @@ import {
 import { applicationAddonSecret } from './server/constants.js';
 import { app, BrowserWindow, globalShortcut, ipcMain, shell } from 'electron';
 import fs, { existsSync, readFileSync } from 'fs';
-import { processes } from './manager/manager.addon.js';
 import { stopClient } from './manager/manager.webtorrent.js';
 import type { ConfigurationFile } from 'ogi-addon/config';
 import AppEventHandler from './handlers/handler.app.js';
@@ -39,6 +38,7 @@ import {
   type ExecuteWrapperResult,
 } from './handlers/handler.library.js';
 import { loadLibraryInfo } from './handlers/helpers.app/library.js';
+import { terminateCurrentProcessChildren } from './lib/processes.js';
 // import steamworks from 'steamworks.js';
 
 /**
@@ -310,6 +310,9 @@ ipcMain.on('get-version', (event) => {
 export let torrentIntervals: NodeJS.Timeout[] = [];
 
 let mainWindow: BrowserWindow | null;
+let shutdownCleanupPromise: Promise<void> | null = null;
+let shutdownCleanupCompleted = false;
+let quittingAfterCleanup = false;
 
 // Flag to ensure process-wide listeners are registered only once
 let listenersRegistered = false;
@@ -613,6 +616,47 @@ async function startAppFlow(win: BrowserWindow) {
   }
 }
 
+async function performAppShutdownCleanup(): Promise<void> {
+  if (shutdownCleanupCompleted) {
+    return;
+  }
+
+  if (shutdownCleanupPromise) {
+    return shutdownCleanupPromise;
+  }
+
+  shutdownCleanupPromise = (async () => {
+    try {
+      stopUmuBackgroundUpdater();
+
+      console.log('Stopping torrent client...');
+      await stopClient();
+
+      console.log('Terminating child processes...');
+      await terminateCurrentProcessChildren();
+
+      for (const interval of torrentIntervals) {
+        clearInterval(interval);
+      }
+
+      if (server.listening) {
+        console.log('Stopping server...');
+        await new Promise<void>((resolve) => {
+          server.close(() => {
+            resolve();
+          });
+        });
+      }
+    } catch (error) {
+      console.error('Error during cleanup:', error);
+    } finally {
+      shutdownCleanupCompleted = true;
+    }
+  })();
+
+  return shutdownCleanupPromise;
+}
+
 function focusMainWindow(): boolean {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return false;
@@ -880,46 +924,24 @@ app.on('ready', async () => {
 });
 
 // Quit when all windows are closed.
-app.on('window-all-closed', async function () {
+app.on('window-all-closed', function () {
   // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform === 'darwin') {
     return;
   }
 
-  // Perform cleanup before quitting
-  try {
-    stopUmuBackgroundUpdater();
+  app.quit();
+});
 
-    // stop torrenting
-    console.log('Stopping torrent client...');
-    await stopClient();
-
-    // stop all of the addons
-    for (const process of Object.keys(processes)) {
-      console.log(`Killing process ${process}`);
-      processes[process].kill('SIGKILL');
-    }
-
-    // stopping all of the torrent intervals
-    for (const interval of torrentIntervals) {
-      clearInterval(interval);
-    }
-
-    // stop the server (only if it was listening to avoid hang)
-    if (server.listening) {
-      console.log('Stopping server...');
-      await new Promise<void>((resolve) => {
-        server.close(() => {
-          resolve();
-        });
-      });
-    }
-  } catch (error) {
-    console.error('Error during cleanup:', error);
+app.on('before-quit', async (event) => {
+  if (shutdownCleanupCompleted || quittingAfterCleanup) {
+    return;
   }
 
-  // Now quit the application
+  event.preventDefault();
+  await performAppShutdownCleanup();
+  quittingAfterCleanup = true;
   app.quit();
 });
 

--- a/application/src/electron/manager/manager.addon.ts
+++ b/application/src/electron/manager/manager.addon.ts
@@ -300,6 +300,7 @@ async function executeScript(
     });
 
     child.on('close', (code: number) => {
+      delete processes[addonPath];
       if (code !== 0) {
         // write the error to a log file
         console.error(
@@ -316,6 +317,7 @@ async function executeScript(
     });
 
     child.on('error', (err: Error) => {
+      delete processes[addonPath];
       console.error(err);
       reject(err);
     });


### PR DESCRIPTION
## Summary
- Added shared process-termination helpers to stop addon and app child processes with a tree-aware shutdown path.
- Replaced direct `SIGKILL` loops with cleanup flows that attempt `SIGTERM` first, then escalate if processes remain alive.
- Moved app shutdown cleanup into a `before-quit` path so torrent clients, intervals, server, and child processes are torn down in one place.
- Ensure addon process entries are removed from tracking when they exit or error.

## Testing
- Not run.
- Manual checks not performed in this workspace.