### PR TITLE
Harden workflow permissions and release gating

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,12 +9,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     permissions:
-      contents: write
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch full history for consistency
+          persist-credentials: false
 
       - name: Check for changes in application directory
         id: check_changes
@@ -111,7 +112,7 @@ jobs:
     permissions:
       contents: write
     name: Create Github Release
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -119,6 +120,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch full history to access tag annotations
+          persist-credentials: false
 
       - name: Extract commit message body
         id: commit_body

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,16 +11,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-     
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -79,51 +80,6 @@ jobs:
           name: typecheck-results
           path: errors.txt
           if-no-files-found: ignore
-
-      - name: Post review on errors
-        if: steps.errors.outputs.has_errors == 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const MAX_BODY = 60000;
-            let errors = '';
-            if (fs.existsSync('errors.txt')) {
-              errors = fs.readFileSync('errors.txt', 'utf8');
-            }
-            if (errors.length > MAX_BODY) {
-              errors = errors.slice(0, MAX_BODY) + '\n...truncated';
-            }
-            const pullNumber = context.eventName === 'workflow_run'
-              ? (context.payload.workflow_run?.pull_requests?.length > 0
-                  ? context.payload.workflow_run.pull_requests[0].number
-                  : null)
-              : context.issue.number;
-            if (pullNumber == null) {
-              console.log('Skipping review: no PR number available');
-              return;
-            }
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-              event: 'REQUEST_CHANGES',
-              body: `❌ **Typecheck Failed**\n\nPlease fix the following type errors:\n\n\`\`\`\n${errors}\n\`\`\``
-            });
-
-      - name: Approve review on success
-        if: steps.errors.outputs.has_errors == 'false' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pullNumber = context.payload.pull_request?.number || context.issue.number;
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-              event: 'APPROVE',
-              body: '✅ **Typecheck Passed** - All type checks successful!'
-            });
 
       - name: Fail if typecheck failed
         if: steps.typecheck.outcome == 'failure'


### PR DESCRIPTION
## Summary
- Reduce workflow permissions to read-only where write access is not required.
- Disable credential persistence in checkout steps to limit token exposure.
- Restrict release creation to tagged push events only.
- Remove typecheck review automation that posted PR reviews from the workflow.

## Testing
- Not run (workflow-only changes).
- Reviewed updated workflow permissions and trigger conditions for build/release and typecheck jobs.
- Confirmed release job still runs on tag pushes and the typecheck job still fails the workflow on typecheck errors.