### PR TITLE
Stop forcing default PROTONPATH for UMU launches

### DIFF
--- a/application/src/electron/handlers/handler.umu.ts
+++ b/application/src/electron/handlers/handler.umu.ts
@@ -37,6 +37,7 @@ const KNOWN_LAUNCH_ENV_VARS = new Set([
   'STORE',
 ]);
 const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=/;
+const UMU_PROTON_PLACEHOLDER = 'umu-proton';
 
 function shellQuote(arg: string): string {
   return `'${arg.replace(/'/g, `'\\''`)}'`;
@@ -63,6 +64,18 @@ function isKnownLaunchEnvAssignment(token: string): boolean {
   if (separatorIndex <= 0) return false;
   const key = token.slice(0, separatorIndex);
   return KNOWN_LAUNCH_ENV_VARS.has(key);
+}
+
+function normalizeProtonPathValue(
+  value?: string | null
+): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  if (normalized.toLowerCase() === UMU_PROTON_PLACEHOLDER) {
+    return undefined;
+  }
+  return normalized;
 }
 
 function parseLeadingLaunchEnvFromArguments(
@@ -193,6 +206,12 @@ export function getEffectiveLaunchEnv(
     const normalizedKey = key.trim();
     if (!normalizedKey) continue;
     if (value === undefined || value === null) continue;
+    if (normalizedKey === 'PROTONPATH') {
+      const protonPath = normalizeProtonPathValue(String(value));
+      if (!protonPath) continue;
+      sanitized[normalizedKey] = protonPath;
+      continue;
+    }
     sanitized[normalizedKey] = String(value);
   }
   return sanitized;
@@ -410,6 +429,7 @@ export async function launchWithUmu(
   ensureUmuPrefixBase();
 
   const { umuId, protonVersion, store } = libraryInfo.umu;
+  const protonPath = normalizeProtonPathValue(protonVersion);
   const gameId = convertUmuId(umuId);
   const winePrefix = getUmuWinePrefix(umuId);
   const launchEnv = getEffectiveLaunchEnv(libraryInfo);
@@ -424,8 +444,8 @@ export async function launchWithUmu(
     WINEPREFIX: winePrefix,
   };
 
-  if (protonVersion) {
-    env.PROTONPATH = protonVersion;
+  if (protonPath) {
+    env.PROTONPATH = protonPath;
   }
 
   if (store) {
@@ -450,7 +470,7 @@ export async function launchWithUmu(
     name: libraryInfo.name,
     gameId,
     winePrefix,
-    protonVersion: protonVersion,
+    protonVersion: protonPath,
     store: store || 'none',
     hasDllOverrides: dllOverrides.length > 0,
     environment: envSummary,
@@ -589,6 +609,7 @@ export async function installRedistributablesWithUmu(
   ensureUmuPrefixBase();
 
   const { umuId, protonVersion } = libraryInfo.umu || {};
+  const protonPath = normalizeProtonPathValue(protonVersion);
   const gameId = umuId ? convertUmuId(umuId) : 'umu-default';
   const winePrefix = umuId
     ? getUmuWinePrefix(umuId)
@@ -642,8 +663,8 @@ export async function installRedistributablesWithUmu(
           UMU_LOG: 'debug',
         };
 
-        if (protonVersion) {
-          env.PROTONPATH = protonVersion;
+        if (protonPath) {
+          env.PROTONPATH = protonPath;
         }
 
         let child: ReturnType<typeof spawn>;
@@ -656,7 +677,6 @@ export async function installRedistributablesWithUmu(
             {
               env: {
                 ...env,
-                PROTONPATH: protonVersion || 'UMU-Proton',
                 PWD: libraryInfo.cwd,
               },
               stdio: ['ignore', 'pipe', 'pipe'],
@@ -692,7 +712,6 @@ export async function installRedistributablesWithUmu(
           child = spawn(umuRunExecutable, [redistFile, ...silentFlags], {
             env: {
               ...env,
-              PROTONPATH: protonVersion || 'UMU-Proton',
               PWD: libraryInfo.cwd,
             },
             cwd: redistDir,
@@ -961,7 +980,6 @@ export async function installRedistributablesWithUmuForLegacy(
           UMU_LOG: 'debug',
           GAMEID: `umu-${steamAppId}`,
           WINEPREFIX: winePrefix,
-          PROTONPATH: 'UMU-Proton',
           PWD: libraryInfo.cwd,
         },
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -1060,7 +1078,6 @@ export async function installRedistributablesWithUmuForLegacy(
                 UMU_LOG: 'debug',
                 GAMEID: `umu-${steamAppId}`,
                 WINEPREFIX: winePrefix,
-                PROTONPATH: 'UMU-Proton',
                 PWD: libraryInfo.cwd,
               },
               stdio: ['ignore', 'pipe', 'pipe'],
@@ -1091,7 +1108,6 @@ export async function installRedistributablesWithUmuForLegacy(
               UMU_LOG: 'debug',
               GAMEID: `umu-${steamAppId}`,
               WINEPREFIX: winePrefix,
-              PROTONPATH: 'UMU-Proton',
               PWD: libraryInfo.cwd,
             },
             cwd: redistDir,
@@ -1267,7 +1283,7 @@ async function initializePrefixWithUmuRun(
 
   const gameId = convertUmuId(umuId);
   const cwd = libraryInfo.cwd || process.cwd();
-  const protonPath = libraryInfo.umu?.protonVersion || 'UMU-Proton';
+  const protonPath = normalizeProtonPathValue(libraryInfo.umu?.protonVersion);
 
   await new Promise<boolean>((resolve) => {
     let resolved = false;
@@ -1277,16 +1293,20 @@ async function initializePrefixWithUmuRun(
       resolve(result);
     };
 
+    const initChildEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      UMU_LOG: 'debug',
+      GAMEID: gameId,
+      WINEPREFIX: winePrefix,
+      PWD: cwd,
+    };
+    if (protonPath) {
+      initChildEnv.PROTONPATH = protonPath;
+    }
+
     const initChild = spawn(umuRunExecutable, [''], {
       cwd,
-      env: {
-        ...process.env,
-        UMU_LOG: 'debug',
-        GAMEID: gameId,
-        WINEPREFIX: winePrefix,
-        PROTONPATH: protonPath,
-        PWD: cwd,
-      },
+      env: initChildEnv,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     streamChildProcessOutput(initChild, logPrefix);

--- a/packages/ogi-addon/src/main.ts
+++ b/packages/ogi-addon/src/main.ts
@@ -175,8 +175,8 @@ export type SetupEventResponse = Omit<
      */
     dllOverrides?: string[];
     /**
-     * Optional Proton version to use (e.g., 'GE-Proton9-5', 'GE-Proton')
-     * If not specified, uses latest UMU-Proton
+     * Optional PROTONPATH override to use for UMU launches.
+     * Omit this unless you absolutely need a specific Proton build/path.
      */
     protonVersion?: string;
     /**

--- a/web/src/pages/docs/first-addon/umu-libraryinfo.md
+++ b/web/src/pages/docs/first-addon/umu-libraryinfo.md
@@ -22,7 +22,7 @@ The `umu` field in `LibraryInfo` (from `ogi-addon`) has this shape:
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
 | `umuId` | `string` | Yes | Unique ID for the game’s Wine prefix. Format: `steam:${number}` or `umu:${string \| number}`. |
-| `protonVersion` | `string` | No | Proton build to use (e.g. `UMU-Proton`). OGI default is `UMU-Proton` if omitted. |
+| `protonVersion` | `string` | No | Optional `PROTONPATH` override for UMU. Omit this unless you absolutely need a specific Proton build or path. |
 | `store` | `string` | No | Store identifier for UMU. |
 | `dllOverrides` | `string[]` | No | WINEDLLOVERRIDES-style overrides (e.g. `d3d11=n,b`). |
 | `winePrefixPath` | `string` | No | Set by OGI; do not set in addon. |
@@ -55,7 +55,6 @@ addon.on('setup', async (data, event) => {
     ...(isLinux && {
       umu: {
         umuId: `umu:${data.appID}` as const,
-        protonVersion: 'UMU-Proton', // optional
         store: data.storefront ?? 'unknown',
       },
     }),
@@ -64,6 +63,8 @@ addon.on('setup', async (data, event) => {
 ```
 
 If your catalog is Steam-based and you have a Steam app ID, you can use `umuId: \`steam:${steamAppId}\`` so the prefix aligns with Steam’s compat data naming.
+
+In most addons, do not set `protonVersion` at all. Let UMU handle its normal Proton selection unless your game only works with a specific override and you know the target environment provides it.
 
 ## Legacy mode
 
@@ -97,7 +98,7 @@ If your game needs Visual C++ runtimes, .NET, or other redistributables, you can
 
 ## Summary
 
-- **Linux + want library launch:** Return `umu: { umuId: 'steam:...' | 'umu:...' }` (and optionally `protonVersion`, `store`, `dllOverrides`) from `setup`.
+- **Linux + want library launch:** Return `umu: { umuId: 'steam:...' | 'umu:...' }` from `setup`, plus optional `store` and `dllOverrides`. Only add `protonVersion` when you truly need a specific override.
 - **Linux + Steam launch (legacy):** Omit `umu` (or set `legacyMode: true`).
 - **Windows / native:** Omit `umu`; it is ignored on non-Linux.
 - **Update setup:** Preserve `currentLibraryInfo.umu` when resolving so the game stays on UMU.

--- a/web/src/pages/docs/guide/umu.md
+++ b/web/src/pages/docs/guide/umu.md
@@ -17,7 +17,7 @@ UMU is an open-source launcher from [Open-Wine-Components](https://github.com/Op
 - **First-time setup**: When you install a Windows game on Linux, OGI configures it to use UMU. If UMU isn’t installed yet, OGI will download it the first time you launch a game or run setup.
 - **Per-game prefixes**: Each game gets its own Wine prefix under `~/.ogi-wine-prefixes/`. This keeps game data and dependencies separate and avoids conflicts.
 - **In-app library**: You can launch UMU-backed games from the OpenGameInstaller library. No need to add them to Steam or use Game Mode for the library.
-- **Proton**: UMU uses Proton (e.g. **UMU-Proton**) to run the game. OGI sets the prefix and environment for you.
+- **Proton**: UMU handles the Proton runtime. Addons should usually avoid forcing a `PROTONPATH` override unless a game truly requires one.
 
 ## Do I need Steam or SteamTinkerLaunch?
 


### PR DESCRIPTION
- Treat `protonVersion` as an optional `PROTONPATH` override
- Avoid injecting placeholder Proton paths in launch and docs