### PR TITLE
Normalize Real-Debrid host parameter handling

### DIFF
--- a/application/src/electron/handlers/handler.realdebrid.ts
+++ b/application/src/electron/handlers/handler.realdebrid.ts
@@ -10,6 +10,24 @@ import { __dirname } from '@/electron/manager/manager.paths.js';
 let realDebridClient = new RealDebrid({
   apiKey: 'UNSET',
 });
+
+function getRealDebridHost(host: unknown): string | undefined {
+  if (typeof host === 'string') {
+    return host;
+  }
+
+  if (
+    host &&
+    typeof host === 'object' &&
+    'host' in host &&
+    typeof host.host === 'string'
+  ) {
+    return host.host;
+  }
+
+  return undefined;
+}
+
 export default function handler(mainWindow: Electron.BrowserWindow) {
   ipcMain.handle('real-debrid:set-key', async (_, arg) => {
     realDebridClient = new RealDebrid({
@@ -34,7 +52,10 @@ export default function handler(mainWindow: Electron.BrowserWindow) {
   });
 
   ipcMain.handle('real-debrid:add-magnet', async (_, arg) => {
-    const torrentAdded = await realDebridClient.addMagnet(arg.url, arg.host);
+    const torrentAdded = await realDebridClient.addMagnet(
+      arg.url,
+      getRealDebridHost(arg.host)
+    );
     return torrentAdded;
   });
 
@@ -148,7 +169,10 @@ export default function handler(mainWindow: Electron.BrowserWindow) {
       }
       console.log('Downloaded torrent! Now adding to readDebrid');
 
-      const data = await realDebridClient.addTorrent(torrentData as ReadStream);
+      const data = await realDebridClient.addTorrent(
+        torrentData as ReadStream,
+        getRealDebridHost(arg.host)
+      );
       console.log('Added torrent to real-debrid!');
       return data;
     } catch (except) {

--- a/application/src/electron/preload.mts
+++ b/application/src/electron/preload.mts
@@ -1,7 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
 import { contextBridge, ipcRenderer } from 'electron';
 import { LibraryInfo } from 'ogi-addon';
-import type { $Hosts } from 'real-debrid-js';
 
 // === Debug: Events Processed/sec Counter ===
 let dbg_eventsProcessed = 0;
@@ -138,12 +137,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     unrestrictLink: wrap((link: string) =>
       ipcRenderer.invoke('real-debrid:unrestrict-link', link)
     ),
-    addMagnet: wrap((url: string, host: $Hosts) =>
+    addMagnet: wrap((url: string, host?: string) =>
       ipcRenderer.invoke('real-debrid:add-magnet', { url, host })
     ),
     getHosts: wrap(() => ipcRenderer.invoke('real-debrid:get-hosts')),
     updateKey: wrap(() => ipcRenderer.invoke('real-debrid:update-key')),
-    addTorrent: wrap((torrent: string, host: $Hosts) =>
+    addTorrent: wrap((torrent: string, host?: string) =>
       ipcRenderer.invoke('real-debrid:add-torrent', { torrent, host })
     ),
     selectTorrent: wrap((torrent: string) =>

--- a/application/src/frontend/global.d.ts
+++ b/application/src/frontend/global.d.ts
@@ -70,8 +70,14 @@ interface Window {
       getUserInfo: () => Promise<$UserInfo>;
       unrestrictLink: (link: string) => Promise<$UnrestrictLink>;
       getHosts: () => Promise<$Hosts[]>;
-      addMagnet: (url: string, host: $Hosts) => Promise<$AddTorrentOrMagnet>;
-      addTorrent: (torrent: string) => Promise<$AddTorrentOrMagnet>;
+      addMagnet: (
+        url: string,
+        host?: string
+      ) => Promise<$AddTorrentOrMagnet>;
+      addTorrent: (
+        torrent: string,
+        host?: string
+      ) => Promise<$AddTorrentOrMagnet>;
       selectTorrent: (torrent: string) => Promise<boolean>;
       isTorrentReady: (id: string) => Promise<boolean>;
       getTorrentInfo: (id: string) => Promise<$TorrentInfo>;

--- a/application/src/frontend/lib/downloads/services/RealDebridService.ts
+++ b/application/src/frontend/lib/downloads/services/RealDebridService.ts
@@ -3,8 +3,6 @@ import type { SearchResultWithAddon } from '@/frontend/lib/tasks/runner';
 import { currentDownloads } from '@/frontend/store';
 import { getDownloadPath } from '@/frontend/lib/core/fs';
 import { listenUntilDownloadReady } from '@/frontend/lib/downloads/events';
-import type { $Hosts } from 'real-debrid-js';
-
 /**
  * Handles magnet/torrent downloads that should be routed through Real-Debrid.
  */
@@ -34,10 +32,12 @@ export class RealDebridService extends BaseService {
     const tempId = this.queueRequestDownload(result, appID, 'realdebrid');
 
     try {
+      const preferredHost = hosts[0]?.host;
+
       if (result.downloadType === 'magnet') {
-        await this.handleMagnetDownload(result, appID, tempId, hosts[0]);
+        await this.handleMagnetDownload(result, appID, tempId, preferredHost);
       } else if (result.downloadType === 'torrent') {
-        await this.handleTorrentDownload(result, appID, tempId);
+        await this.handleTorrentDownload(result, appID, tempId, preferredHost);
       }
     } catch (err) {
       console.error('Failed to start Real-Debrid download:', err);
@@ -61,7 +61,7 @@ export class RealDebridService extends BaseService {
     result: SearchResultWithAddon,
     appID: number,
     tempId: string,
-    host: $Hosts
+    host?: string
   ): Promise<void> {
     if (result.downloadType !== 'magnet') return;
 
@@ -152,7 +152,8 @@ export class RealDebridService extends BaseService {
   private async handleTorrentDownload(
     result: SearchResultWithAddon,
     appID: number,
-    tempId: string
+    tempId: string,
+    host?: string
   ): Promise<void> {
     if (result.downloadType !== 'torrent') return;
 
@@ -167,7 +168,8 @@ export class RealDebridService extends BaseService {
 
     // add torrent link
     const torrent = await window.electronAPI.realdebrid.addTorrent(
-      result.downloadURL
+      result.downloadURL,
+      host
     );
     const isReady = await window.electronAPI.realdebrid.isTorrentReady(
       torrent.id

--- a/packages/real-debrid/src/main.ts
+++ b/packages/real-debrid/src/main.ts
@@ -88,6 +88,20 @@ export type $AddTorrentOrMagnet = z.infer<typeof AddTorrentOrMagnetZod>;
 export type $TorrentInfo = z.infer<typeof TorrentInfoZod>;
 
 const REAL_DEBRID_API_URL = 'https://api.real-debrid.com/rest/1.0';
+type RealDebridHostInput = string | { host: string } | undefined;
+
+function normalizeHost(host: RealDebridHostInput): string | undefined {
+  if (!host) {
+    return undefined;
+  }
+
+  if (typeof host === 'string') {
+    return host;
+  }
+
+  return typeof host.host === 'string' ? host.host : undefined;
+}
+
 export default class RealDebrid {
   constructor(public configuration: RealDebridConfiguration) {}
 
@@ -115,7 +129,9 @@ export default class RealDebrid {
   public async unrestrictLink(link: string, password: string = '') {
     const formData = new URLSearchParams();
     formData.append('link', link);
-    formData.append('password', password);
+    if (password) {
+      formData.append('password', password);
+    }
     const response = await axios(`${REAL_DEBRID_API_URL}/unrestrict/link`, {
       method: 'POST',
       headers: {
@@ -138,11 +154,12 @@ export default class RealDebrid {
     return result;
   }
 
-  public async addTorrent(torrent: ReadStream, host?: string) {
+  public async addTorrent(torrent: ReadStream, host?: RealDebridHostInput) {
     // set the type to binary
     const url = new URL(`${REAL_DEBRID_API_URL}/torrents/addTorrent`);
-    if (host) {
-      url.searchParams.append('host', host);
+    const normalizedHost = normalizeHost(host);
+    if (normalizedHost) {
+      url.searchParams.append('host', normalizedHost);
     }
     const response = await axios(url.toString(), {
       method: 'PUT',
@@ -186,11 +203,12 @@ export default class RealDebrid {
     return result;
   }
 
-  public async addMagnet(magnet: string, host?: string) {
+  public async addMagnet(magnet: string, host?: RealDebridHostInput) {
     const formData = new URLSearchParams();
     formData.append('magnet', magnet);
-    if (host) {
-      formData.append('host', host);
+    const normalizedHost = normalizeHost(host);
+    if (normalizedHost) {
+      formData.append('host', normalizedHost);
     }
     const response = await axios(`${REAL_DEBRID_API_URL}/torrents/addMagnet`, {
       method: 'POST',
@@ -228,7 +246,11 @@ export default class RealDebrid {
         validateStatus: () => true,
       }
     );
-    if (response.status === 200 || response.status === 204) {
+    if (
+      response.status === 200 ||
+      response.status === 202 ||
+      response.status === 204
+    ) {
       return true;
     }
     const errorMessage =


### PR DESCRIPTION
## Summary
- Normalize Real-Debrid `host` values before sending them from the UI, IPC layer, and service layer.
- Allow `addMagnet` and `addTorrent` to accept either a host string or an object with a `host` field, matching the values returned by the API.
- Improve Real-Debrid request handling by omitting empty passwords and treating `202 Accepted` as a successful `selectFile` response.

## Testing
- Not run.
- Verified type signatures were updated across preload, global declarations, and the Real-Debrid service to pass host strings through consistently.
- Reviewed the request-building paths for `addMagnet` and `addTorrent` to confirm host normalization happens before the API call.