### PR TITLE
Restore UMU migration prompt gating

### DIFF
--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -74,7 +74,7 @@
     const needsUmu = !libraryInfo.umu;
     return isLinux && isWindowsExecutable && needsUmu;
   });
-  let needsUmuMigration = $derived(needsUmuSetup && libraryInfo.umu);
+  let needsUmuMigration = $derived(needsUmuSetup);
 
   async function doesLinkExist(url: string | undefined) {
     if (!url) return false;


### PR DESCRIPTION
## Summary
- Restore the UMU migration prompt to appear whenever UMU setup is needed.
- Remove the extra `libraryInfo.umu` condition so the migration state matches the setup flow.
- Keep the change scoped to `PlayPage.svelte`.

## Testing
- Not run (PR description only).
- Verified the diff is limited to a single condition change in `application/src/frontend/components/PlayPage.svelte`.