### PR TITLE
fix(typecheck): configuration modal select element types

### DIFF
--- a/application/src/frontend/components/modal/ConfigurationModal.svelte
+++ b/application/src/frontend/components/modal/ConfigurationModal.svelte
@@ -105,7 +105,10 @@
 
     for (const key of Object.keys(activeScreen.config)) {
       const option = activeScreen.config[key];
-      const el = document.getElementById(key) as HTMLInputElement | null;
+      const el = document.getElementById(key) as
+        | HTMLInputElement
+        | HTMLSelectElement
+        | null;
       if (!el) continue;
 
       if (isNumberOption(option)) {
@@ -118,8 +121,7 @@
         (option.allowedValues?.length ?? 0) > 0
       ) {
         const allowed = option.allowedValues!;
-        const selectValue =
-          (el as HTMLSelectElement).value || String(data[key] ?? '');
+        const selectValue = el.value || String(data[key] ?? '');
         data[key] =
           selectValue && allowed.includes(selectValue)
             ? selectValue


### PR DESCRIPTION
## Summary
- Fixes a `svelte-check` type error in `ConfigurationModal.svelte` when collecting form data for string options with `allowedValues` (rendered as `<select>`).
- Widens `getElementById` typing to `HTMLInputElement | HTMLSelectElement` and reads `.value` without an invalid cast.

## Test plan
- [x] `bun run typecheck` passes (0 errors)
- [ ] Open an addon configuration screen with a dropdown/select field and submit successfully


Made with [Cursor](https://cursor.com)