### PR TITLE
refactor: centralize system updates

### DIFF
--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -27,8 +27,6 @@ import {
   convertLibrary,
   IS_NIXOS,
   startupEnvironmentReady,
-  startUmuBackgroundUpdater,
-  stopUmuBackgroundUpdater,
   STEAMTINKERLAUNCH_PATH,
 } from '@/electron/startup.js';
 import AddonManagerHandler, {
@@ -815,8 +813,6 @@ app.on('ready', async () => {
     }
   }
 
-  startUmuBackgroundUpdater();
-
   if (gameIdToLaunch !== null) {
     console.log(
       `[app] Steam shortcut launch detected for game ${gameIdToLaunch}`
@@ -872,8 +868,6 @@ app.on('window-all-closed', async function () {
 
   // Perform cleanup before quitting
   try {
-    stopUmuBackgroundUpdater();
-
     // stop torrenting
     console.log('Stopping torrent client...');
     await stopClient();

--- a/application/src/electron/startup-runner.ts
+++ b/application/src/electron/startup-runner.ts
@@ -1,9 +1,7 @@
 import { app, BrowserWindow } from 'electron';
 import { join } from 'path';
-import {
-  checkIfInstallerUpdateAvailable,
-  type UpdaterCallbacks,
-} from '@/electron/updater.js';
+import type { UpdaterCallbacks } from '@/electron/updater.js';
+import { createDefaultSystemUpdateManager } from '@/electron/system-updater.js';
 import {
   restoreBackup,
   removeCachedAppUpdates,
@@ -157,8 +155,8 @@ export async function runStartupTasks(
       }
     }
 
-    // Check for installer/setup updates with splash screen callbacks
-    updateSplashStatus('Checking for updates...');
+    // Dedicated online system update task (installer/setup, UMU, and future system updaters)
+    updateSplashStatus('Checking for system updates...');
     const updaterCallbacks: UpdaterCallbacks = {
       onStatus: (text: string, subtext?: string) => {
         updateSplashStatus(text, subtext);
@@ -167,7 +165,9 @@ export async function runStartupTasks(
         updateSplashProgress(current, total, speed);
       },
     };
-    await checkIfInstallerUpdateAvailable(updaterCallbacks);
+    await createDefaultSystemUpdateManager().updateOnlineSystem(
+      updaterCallbacks
+    );
 
     // Final status before main window loads
     updateSplashStatus('Starting application...');

--- a/application/src/electron/system-updater.ts
+++ b/application/src/electron/system-updater.ts
@@ -72,8 +72,13 @@ export class SetupAppImageUpdater implements SystemUpdater {
   }
 
   async update(callbacks: UpdaterCallbacks): Promise<SystemUpdateResult> {
-    await checkIfInstallerUpdateAvailable(callbacks);
-    return { id: this.id, success: true };
+    const result = await checkIfInstallerUpdateAvailable(callbacks);
+    return {
+      id: this.id,
+      success: result.success,
+      updated: result.updated,
+      error: result.error,
+    };
   }
 }
 

--- a/application/src/electron/system-updater.ts
+++ b/application/src/electron/system-updater.ts
@@ -1,0 +1,104 @@
+import { getEffectiveOnlineState } from '@/electron/lib/online.js';
+import {
+  checkIfInstallerUpdateAvailable,
+  type UpdaterCallbacks,
+} from '@/electron/updater.js';
+import { downloadLatestUmu } from '@/electron/startup.js';
+
+export type SystemUpdateResult = {
+  id: string;
+  success: boolean;
+  updated?: boolean;
+  error?: string;
+};
+
+export interface SystemUpdater {
+  id: string;
+  label: string;
+  shouldRun(): boolean | Promise<boolean>;
+  update(callbacks: UpdaterCallbacks): Promise<SystemUpdateResult>;
+}
+
+export class SystemUpdateManager {
+  private updaters: SystemUpdater[] = [];
+
+  constructor(updaters: SystemUpdater[] = []) {
+    this.updaters = [...updaters];
+  }
+
+  register(updater: SystemUpdater): void {
+    this.updaters.push(updater);
+  }
+
+  async updateOnlineSystem(
+    callbacks: UpdaterCallbacks
+  ): Promise<SystemUpdateResult[]> {
+    const onlineState = getEffectiveOnlineState();
+    if (!onlineState.effectiveOnline) {
+      console.log(
+        `[system-updater] Offline mode enabled (${onlineState.reason}), skipping updates`
+      );
+      return [];
+    }
+
+    const results: SystemUpdateResult[] = [];
+    for (const updater of this.updaters) {
+      const shouldRun = await updater.shouldRun();
+      if (!shouldRun) {
+        console.log(`[system-updater] Skipping ${updater.id}`);
+        continue;
+      }
+
+      callbacks.onStatus(`Checking ${updater.label} updates...`);
+      try {
+        results.push(await updater.update(callbacks));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[system-updater] ${updater.id} failed:`, error);
+        results.push({ id: updater.id, success: false, error: message });
+      }
+    }
+
+    return results;
+  }
+}
+
+export class SetupAppImageUpdater implements SystemUpdater {
+  id = 'setup-appimage';
+  label = 'installer';
+
+  shouldRun(): boolean {
+    return true;
+  }
+
+  async update(callbacks: UpdaterCallbacks): Promise<SystemUpdateResult> {
+    await checkIfInstallerUpdateAvailable(callbacks);
+    return { id: this.id, success: true };
+  }
+}
+
+export class UmuLauncherUpdater implements SystemUpdater {
+  id = 'umu-launcher';
+  label = 'UMU launcher';
+
+  shouldRun(): boolean {
+    return process.platform === 'linux';
+  }
+
+  async update(): Promise<SystemUpdateResult> {
+    const result = await downloadLatestUmu();
+    return {
+      id: this.id,
+      success: result.success,
+      updated: result.updated,
+      error: result.error,
+    };
+  }
+}
+
+export function createDefaultSystemUpdateManager(): SystemUpdateManager {
+  return new SystemUpdateManager([
+    new SetupAppImageUpdater(),
+    new UmuLauncherUpdater(),
+  ]);
+}

--- a/application/src/electron/updater.ts
+++ b/application/src/electron/updater.ts
@@ -35,6 +35,12 @@ export interface UpdaterCallbacks {
   onProgress: (current: number, total: number, speed: string) => void;
 }
 
+export type InstallerUpdateResult = {
+  success: boolean;
+  updated: boolean;
+  error?: string;
+};
+
 const filesToBackup = ['config', 'addons', 'library', 'internals'];
 // Directories to skip during backup (addon dependencies will be reinstalled)
 const dirsToSkip = ['node_modules'];
@@ -441,9 +447,11 @@ async function applyBlockmapPatch(params: {
     oldOffset += oldFile.sizes[i];
   }
 
-  const sourceFd = openSync(params.sourceArtifact, 'r');
-  const outFd = openSync(params.outputArtifact, 'w');
+  let sourceFd: number | null = null;
+  let outFd: number | null = null;
   try {
+    sourceFd = openSync(params.sourceArtifact, 'r');
+    outFd = openSync(params.outputArtifact, 'w');
     let writeOffset = newFile.offset || 0;
     const misses: Array<{ offset: number; size: number }> = [];
 
@@ -496,8 +504,8 @@ async function applyBlockmapPatch(params: {
       params.updateProgress(downloaded, total, '');
     }
   } finally {
-    closeSync(sourceFd);
-    closeSync(outFd);
+    if (sourceFd !== null) closeSync(sourceFd);
+    if (outFd !== null) closeSync(outFd);
   }
 
   await verifyReleaseArtifact(params.outputArtifact, params.expectedArtifact);
@@ -678,8 +686,10 @@ function killUpdaterProcesses(): Promise<void> {
  * @param callbacks - Optional callbacks for status and progress updates (used by splash screen)
  * @returns Resolves when the update check and any initiated update workflow complete (no return value).
  */
-export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
-  return new Promise<void>(async (resolve) => {
+export function checkIfInstallerUpdateAvailable(
+  callbacks?: UpdaterCallbacks
+): Promise<InstallerUpdateResult> {
+  return new Promise<InstallerUpdateResult>(async (resolve) => {
     const updateStatus = (text: string, subtext?: string) => {
       if (callbacks) {
         callbacks.onStatus(text, subtext);
@@ -701,7 +711,7 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
       } else {
         console.error('[updater] No internet connection available.');
       }
-      resolve();
+      resolve({ success: true, updated: false });
       return;
     }
 
@@ -709,7 +719,7 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
     if (basename(__dirname) !== 'update' && process.platform !== 'linux') {
       console.log('[updater] Running portably, skipping update check.');
       console.log(`[updater] Current directory: ${basename(__dirname)}`);
-      resolve();
+      resolve({ success: true, updated: false });
       return;
     }
 
@@ -719,7 +729,11 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
       );
       if (!existsSync('../OpenGameInstaller-Setup.AppImage')) {
         console.error('[updater] No setup found, exiting.');
-        resolve();
+        resolve({
+          success: false,
+          updated: false,
+          error: 'Setup AppImage not found',
+        });
         return;
       }
 
@@ -765,7 +779,7 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
       }
       if (!latestRelease) {
         console.error('[updater] No new version available.');
-        resolve();
+        resolve({ success: true, updated: false });
         return;
       }
       const latestVersion = latestRelease.tag_name;
@@ -775,7 +789,11 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
         console.error(
           '[updater] No setup version found for the current platform.'
         );
-        resolve();
+        resolve({
+          success: false,
+          updated: false,
+          error: 'No setup version found for the current platform',
+        });
         return;
       }
       console.log(
@@ -788,7 +806,11 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
         console.error(
           '[updater] No setup version found in the release description.'
         );
-        resolve();
+        resolve({
+          success: false,
+          updated: false,
+          error: 'No setup version found in the release description',
+        });
         return;
       }
       const latestSetupVersion = latestVersionResults[1];
@@ -833,6 +855,7 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
               process.exit(1);
             }
           }, 500);
+          resolve({ success: true, updated: true });
         } else if (process.platform === 'linux') {
           await setTimeoutPromise(3000);
           await downloadSetupAppImageWithDifferentialFallback({
@@ -887,14 +910,19 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
             await setTimeoutPromise(3000);
             process.exit(0);
           }, 500);
+          resolve({ success: true, updated: true });
         }
       } else {
         console.log(`[updater] No new version available.`);
-        resolve();
+        resolve({ success: true, updated: false });
       }
     } catch (ex) {
       console.error('[updater] Error while checking for updates: ', ex);
-      resolve();
+      resolve({
+        success: false,
+        updated: false,
+        error: ex instanceof Error ? ex.message : String(ex),
+      });
     }
   });
 }

--- a/application/src/electron/updater.ts
+++ b/application/src/electron/updater.ts
@@ -11,10 +11,17 @@ import {
   statSync,
   copyFileSync,
   writeFileSync,
+  openSync,
+  closeSync,
+  readSync,
+  writeSync,
+  createReadStream,
 } from 'original-fs';
 import { basename, dirname, join } from 'path';
 import { setTimeout as setTimeoutPromise } from 'timers/promises';
 import { spawn, exec } from 'child_process';
+import { createHash } from 'crypto';
+import * as zlib from 'zlib';
 import * as path from 'path';
 import { __dirname as persistentDataDir } from '@/electron/manager/manager.paths.js';
 import { getEffectiveOnlineState } from '@/electron/lib/online.js';
@@ -257,6 +264,320 @@ async function downloadFileWithProgress(
   });
 }
 
+const PATCH_PROGRESS_INTERVAL = 128;
+const RANGE_DOWNLOAD_CHUNK_SIZE = 16 * 1024 * 1024;
+const RANGE_DOWNLOAD_COALESCE_GAP = 512 * 1024;
+
+type ReleaseAsset = {
+  name: string;
+  browser_download_url: string;
+  size?: number;
+  digest?: string;
+};
+
+type GithubRelease = {
+  tag_name: string;
+  body?: string;
+  prerelease?: boolean;
+  assets: ReleaseAsset[];
+};
+
+function getSetupVersionFromRelease(release: GithubRelease): string | null {
+  const match = release.body?.match(/Setup Version: (.*)/);
+  return match?.[1]?.trim() ?? null;
+}
+
+function getSetupAsset(release: GithubRelease): ReleaseAsset | undefined {
+  const suffix =
+    process.platform === 'win32' ? '-Setup.exe' : '-Setup.AppImage';
+  return release.assets.find((asset) => asset.name.includes(suffix));
+}
+
+function getBlockmapAsset(
+  release: GithubRelease,
+  artifact: ReleaseAsset
+): ReleaseAsset | undefined {
+  return release.assets.find(
+    (asset) =>
+      asset.name.toLowerCase() === `${artifact.name.toLowerCase()}.blockmap`
+  );
+}
+
+function getBlockKey(checksum: string, size: number): string {
+  return `${checksum}:${size}`;
+}
+
+function parseDigest(
+  digest?: string
+): { algorithm: string; value: string } | null {
+  if (!digest) return null;
+  const [algorithm, value] = digest.split(':', 2);
+  const normalized = algorithm?.toLowerCase();
+  if (!value || !['sha256', 'sha384', 'sha512'].includes(normalized)) {
+    return null;
+  }
+  return { algorithm: normalized, value: value.toLowerCase() };
+}
+
+async function hashFile(filePath: string, algorithm: string): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const hash = createHash(algorithm);
+    const stream = createReadStream(filePath);
+    stream.on('error', reject);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+async function verifyReleaseArtifact(
+  artifactPath: string,
+  expectedArtifact: ReleaseAsset
+): Promise<void> {
+  const size = statSync(artifactPath).size;
+  if (
+    Number.isFinite(expectedArtifact.size) &&
+    expectedArtifact.size &&
+    size !== expectedArtifact.size
+  ) {
+    throw new Error(
+      `Artifact size mismatch: expected ${expectedArtifact.size}, got ${size}`
+    );
+  }
+
+  const parsedDigest = parseDigest(expectedArtifact.digest);
+  if (!parsedDigest) return;
+
+  const actualDigest = await hashFile(artifactPath, parsedDigest.algorithm);
+  if (actualDigest !== parsedDigest.value) {
+    throw new Error(`Artifact digest mismatch for ${parsedDigest.algorithm}`);
+  }
+}
+
+async function downloadRangeChunk(
+  url: string,
+  start: number,
+  end: number
+): Promise<Buffer> {
+  const response = await axios({
+    url,
+    method: 'GET',
+    responseType: 'arraybuffer',
+    headers: {
+      Range: `bytes=${start}-${end}`,
+      'Accept-Encoding': 'identity',
+    },
+    timeout: 60000,
+  });
+
+  const expectedSize = end - start + 1;
+  const actualSize = Buffer.byteLength(response.data);
+  if (response.status !== 206 || actualSize !== expectedSize) {
+    throw new Error(`Invalid range response for bytes=${start}-${end}`);
+  }
+
+  return Buffer.from(response.data);
+}
+
+function createRangeDownloadTasks(
+  misses: Array<{ offset: number; size: number }>
+) {
+  const coalescedRanges: Array<{ offset: number; size: number }> = [];
+  for (const miss of misses) {
+    const last = coalescedRanges[coalescedRanges.length - 1];
+    const missEnd = miss.offset + miss.size;
+    if (
+      last &&
+      miss.offset - (last.offset + last.size) <= RANGE_DOWNLOAD_COALESCE_GAP
+    ) {
+      last.size = missEnd - last.offset;
+    } else {
+      coalescedRanges.push({ ...miss });
+    }
+  }
+
+  const tasks: Array<{ start: number; end: number; size: number }> = [];
+  for (const range of coalescedRanges) {
+    let start = range.offset;
+    const end = range.offset + range.size - 1;
+    while (start <= end) {
+      const chunkEnd = Math.min(start + RANGE_DOWNLOAD_CHUNK_SIZE - 1, end);
+      tasks.push({ start, end: chunkEnd, size: chunkEnd - start + 1 });
+      start = chunkEnd + 1;
+    }
+  }
+  return tasks;
+}
+
+async function applyBlockmapPatch(params: {
+  sourceArtifact: string;
+  oldBlockmapPath: string;
+  outputArtifact: string;
+  newBlockmapPath: string;
+  targetUrl: string;
+  expectedArtifact: ReleaseAsset;
+  updateStatus: (text: string, subtext?: string) => void;
+  updateProgress: (current: number, total: number, speed: string) => void;
+}): Promise<void> {
+  const oldMap = JSON.parse(
+    zlib.gunzipSync(readFileSync(params.oldBlockmapPath)).toString('utf8')
+  );
+  const newMap = JSON.parse(
+    zlib.gunzipSync(readFileSync(params.newBlockmapPath)).toString('utf8')
+  );
+  const oldFile = oldMap.files?.[0];
+  const newFile = newMap.files?.[0];
+  if (!oldFile || !newFile) throw new Error('Invalid blockmap payload');
+
+  const checksumToBlocks = new Map<
+    string,
+    Array<{ offset: number; size: number }>
+  >();
+  let oldOffset = oldFile.offset || 0;
+  for (let i = 0; i < oldFile.checksums.length; i++) {
+    const key = getBlockKey(oldFile.checksums[i], oldFile.sizes[i]);
+    const blocks = checksumToBlocks.get(key) ?? [];
+    blocks.push({ offset: oldOffset, size: oldFile.sizes[i] });
+    checksumToBlocks.set(key, blocks);
+    oldOffset += oldFile.sizes[i];
+  }
+
+  const sourceFd = openSync(params.sourceArtifact, 'r');
+  const outFd = openSync(params.outputArtifact, 'w');
+  try {
+    let writeOffset = newFile.offset || 0;
+    const misses: Array<{ offset: number; size: number }> = [];
+
+    if (writeOffset > 0) {
+      const header = await downloadRangeChunk(
+        params.targetUrl,
+        0,
+        writeOffset - 1
+      );
+      writeSync(outFd, header, 0, header.length, 0);
+    }
+
+    for (let i = 0; i < newFile.checksums.length; i++) {
+      const size = newFile.sizes[i];
+      const blocks = checksumToBlocks.get(
+        getBlockKey(newFile.checksums[i], size)
+      );
+      const matched = blocks?.pop();
+      if (matched) {
+        const buffer = Buffer.alloc(size);
+        const bytesRead = readSync(sourceFd, buffer, 0, size, matched.offset);
+        if (bytesRead !== size)
+          throw new Error('Short read from source artifact');
+        writeSync(outFd, buffer, 0, size, writeOffset);
+      } else {
+        misses.push({ offset: writeOffset, size });
+      }
+      writeOffset += size;
+      if (
+        i === newFile.checksums.length - 1 ||
+        (i + 1) % PATCH_PROGRESS_INTERVAL === 0
+      ) {
+        params.updateStatus('Building setup patch');
+        params.updateProgress(i + 1, newFile.checksums.length, '');
+      }
+    }
+
+    const tasks = createRangeDownloadTasks(misses);
+    let downloaded = 0;
+    const total = tasks.reduce((sum, task) => sum + task.size, 0);
+    for (const task of tasks) {
+      const chunk = await downloadRangeChunk(
+        params.targetUrl,
+        task.start,
+        task.end
+      );
+      writeSync(outFd, chunk, 0, chunk.length, task.start);
+      downloaded += chunk.length;
+      params.updateStatus('Downloading setup patch data');
+      params.updateProgress(downloaded, total, '');
+    }
+  } finally {
+    closeSync(sourceFd);
+    closeSync(outFd);
+  }
+
+  await verifyReleaseArtifact(params.outputArtifact, params.expectedArtifact);
+}
+
+async function downloadSetupAppImageWithDifferentialFallback(params: {
+  releases: GithubRelease[];
+  latestRelease: GithubRelease;
+  latestAsset: ReleaseAsset;
+  localVersion: string;
+  destination: string;
+  updateStatus: (text: string, subtext?: string) => void;
+  updateProgress: (current: number, total: number, speed: string) => void;
+}): Promise<void> {
+  const currentSetupPath = '../OpenGameInstaller-Setup.AppImage';
+  const newBlockmapAsset = getBlockmapAsset(
+    params.latestRelease,
+    params.latestAsset
+  );
+  const previousRelease = params.releases.find(
+    (release) => getSetupVersionFromRelease(release) === params.localVersion
+  );
+  const previousAsset = previousRelease
+    ? getSetupAsset(previousRelease)
+    : undefined;
+  const oldBlockmapAsset =
+    previousRelease && previousAsset
+      ? getBlockmapAsset(previousRelease, previousAsset)
+      : undefined;
+
+  if (existsSync(currentSetupPath) && newBlockmapAsset && oldBlockmapAsset) {
+    const tempDir = app.getPath('temp');
+    const oldBlockmapPath = join(tempDir, 'ogi-old-setup.blockmap');
+    const newBlockmapPath = join(tempDir, 'ogi-new-setup.blockmap');
+    try {
+      params.updateStatus('Downloading setup blockmaps...');
+      await downloadFileWithProgress(
+        oldBlockmapAsset.browser_download_url,
+        oldBlockmapPath,
+        params.updateStatus,
+        params.updateProgress
+      );
+      await downloadFileWithProgress(
+        newBlockmapAsset.browser_download_url,
+        newBlockmapPath,
+        params.updateStatus,
+        params.updateProgress
+      );
+      await applyBlockmapPatch({
+        sourceArtifact: currentSetupPath,
+        oldBlockmapPath,
+        outputArtifact: params.destination,
+        newBlockmapPath,
+        targetUrl: params.latestAsset.browser_download_url,
+        expectedArtifact: params.latestAsset,
+        updateStatus: params.updateStatus,
+        updateProgress: params.updateProgress,
+      });
+      console.log('[updater] Setup AppImage differential update succeeded');
+      return;
+    } catch (error) {
+      console.warn(
+        '[updater] Setup AppImage differential update failed, falling back to full download:',
+        error
+      );
+      rmSync(params.destination, { force: true });
+    } finally {
+      rmSync(oldBlockmapPath, { force: true });
+      rmSync(newBlockmapPath, { force: true });
+    }
+  }
+
+  await downloadFileWithProgress(
+    params.latestAsset.browser_download_url,
+    params.destination,
+    params.updateStatus,
+    params.updateProgress
+  );
+}
+
 async function backupStateForSetupReplacement(
   updateStatus: (text: string, subtext?: string) => void,
   updateProgress: (current: number, total: number, speed: string) => void
@@ -447,18 +768,10 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
         resolve();
         return;
       }
-      let latestSetupVersionUrl: string | undefined = undefined;
       const latestVersion = latestRelease.tag_name;
-      if (process.platform === 'win32') {
-        latestSetupVersionUrl = latestRelease.assets.find(
-          (asset: { name: string }) => asset.name.includes('-Setup.exe')
-        )?.browser_download_url;
-      } else if (process.platform === 'linux') {
-        latestSetupVersionUrl = latestRelease.assets.find(
-          (asset: { name: string }) => asset.name.includes('-Setup.AppImage')
-        )?.browser_download_url;
-      }
-      if (!latestSetupVersionUrl) {
+      const latestSetupAsset = getSetupAsset(latestRelease);
+      const latestSetupVersionUrl = latestSetupAsset?.browser_download_url;
+      if (!latestSetupVersionUrl || !latestSetupAsset) {
         console.error(
           '[updater] No setup version found for the current platform.'
         );
@@ -522,12 +835,15 @@ export function checkIfInstallerUpdateAvailable(callbacks?: UpdaterCallbacks) {
           }, 500);
         } else if (process.platform === 'linux') {
           await setTimeoutPromise(3000);
-          await downloadFileWithProgress(
-            latestSetupVersionUrl,
-            '../temp-setup-OGI.AppImage',
+          await downloadSetupAppImageWithDifferentialFallback({
+            releases: releases.data,
+            latestRelease,
+            latestAsset: latestSetupAsset,
+            localVersion,
+            destination: '../temp-setup-OGI.AppImage',
             updateStatus,
-            updateProgress
-          );
+            updateProgress,
+          });
           console.log(`[updater] Setup downloaded successfully.`);
           console.log(`[updater] Backing up files in update.`);
           await backupStateForSetupReplacement(updateStatus, updateProgress);


### PR DESCRIPTION
## Summary
- Add an extensible system update manager for startup updates
- Route Setup/AppImage and UMU update checks through the centralized manager
- Add Linux Setup AppImage blockmap differential patching with full-download fallback
- Return structured installer update results and fix blockmap patch file descriptor cleanup

## Validation
- bun run --filter 'opengameinstaller-gui' typecheck
- CodeRabbit review findings addressed