### PR TITLE
fix: wait for addon configure before config-update after restart

### DIFF
--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -13,6 +13,7 @@ import { sendIPCMessage, sendNotification } from '@/electron/main.js';
 import axios from 'axios';
 import { AddonConnection } from '@ogi-sdk/addon-server';
 import { deleteInstalledAddon } from '@/electron/server/addon-lifecycle.js';
+import { waitForAddonsConfigured } from '@/electron/manager/manager.addon-readiness.js';
 
 export async function startAddons(): Promise<void> {
   // start all of the addons
@@ -77,6 +78,10 @@ export async function restartAddonServer(): Promise<void> {
   console.log(`Addon Server is running on http://localhost:${port}`);
   console.log(`Server is being executed by electron!`);
   await startAddons();
+  const configuredAddons = await waitForAddonsConfigured();
+  for (const connection of configuredAddons) {
+    await sendIPCMessage('addon-connected', connection.addonInfo!.id);
+  }
   await sendIPCMessage('addon-runtime-ready');
 
   sendNotification({

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -32,6 +32,7 @@ import {
 import AddonManagerHandler, {
   startAddons,
 } from '@/electron/handlers/handler.addon.js';
+import { waitForAddonsConfigured } from '@/electron/manager/manager.addon-readiness.js';
 import OOBEHandler from '@/electron/handlers/handler.oobe.js';
 import {
   runStartupTasks,
@@ -461,6 +462,10 @@ async function onMainAppReady() {
     await checkForAddonUpdates(mainWindow);
   }
   await sendIPCMessage('all-addons-started');
+  const configuredAddons = await waitForAddonsConfigured();
+  for (const connection of configuredAddons) {
+    await sendIPCMessage('addon-connected', connection.addonInfo!.id);
+  }
   await sendIPCMessage('addon-runtime-ready');
 
   // Register process-wide listeners only once

--- a/application/src/electron/manager/manager.addon-readiness.ts
+++ b/application/src/electron/manager/manager.addon-readiness.ts
@@ -1,0 +1,45 @@
+import type { AddonConnection } from '@ogi-sdk/addon-server';
+import { addonServer } from '@/electron/server/addon-server.js';
+import { Addon } from '@/electron/manager/manager.addon.js';
+
+function addonFolderName(addonPath: string): string {
+  return addonPath.replace(/\/$/, '').split(/[/\\]/).pop() ?? addonPath;
+}
+
+function configuredRunningConnections(): AddonConnection[] {
+  const configured: AddonConnection[] = [];
+  for (const addonPath of Addon.running.keys()) {
+    const client = addonServer.getClient(addonFolderName(addonPath));
+    if (client?.addonInfo && client.configTemplate !== undefined) {
+      configured.push(client);
+    }
+  }
+  return configured;
+}
+
+export async function waitForAddonsConfigured(
+  options: { timeoutMs?: number; pollIntervalMs?: number } = {}
+): Promise<AddonConnection[]> {
+  const { timeoutMs = 30_000, pollIntervalMs = 100 } = options;
+  const expectedCount = Addon.running.size;
+
+  if (expectedCount === 0) {
+    return [];
+  }
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const ready = configuredRunningConnections();
+    if (ready.length >= expectedCount) {
+      return ready;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  const ready = configuredRunningConnections();
+  console.warn(
+    `[addon-readiness] Timed out waiting for addons to send configure (${ready.length}/${expectedCount} ready)`
+  );
+  return ready;
+}

--- a/application/src/electron/preload.mts
+++ b/application/src/electron/preload.mts
@@ -568,13 +568,6 @@ ipcRenderer.on(
 );
 
 ipcRenderer.on(
-  'addon-connected',
-  wrap((_, arg) => {
-    document.dispatchEvent(new CustomEvent('addon-connected', { detail: arg }));
-  })
-);
-
-ipcRenderer.on(
   'all-addons-started',
   wrap(() => {
     console.log('ALL ADDONS STARTED');

--- a/application/src/frontend/App.svelte
+++ b/application/src/frontend/App.svelte
@@ -132,32 +132,29 @@
     console.log('App mounted, initializing stores');
     showNotificationSideView.set(false);
     loading = true;
-    setTimeout(() => {
-      fetchAddonsWithConfigure();
-      const installedOption = getConfigClientOption('installed') as {
-        installed: boolean;
-      };
-      console.log('installedOption', installedOption);
-      if (!installedOption || !installedOption.installed) {
-        console.log('OOBE not finished');
-        console.log(installedOption);
-        finishedOOBE = false;
-      }
-      loading = false;
+    const installedOption = getConfigClientOption('installed') as {
+      installed: boolean;
+    };
+    console.log('installedOption', installedOption);
+    if (!installedOption || !installedOption.installed) {
+      console.log('OOBE not finished');
+      console.log(installedOption);
+      finishedOOBE = false;
+    }
+    loading = false;
 
-      // get recently launched apps
-      updateRecents();
+    // get recently launched apps
+    updateRecents();
 
-      // Initialize search-related data
-      initializeSearch();
-      initDownloadPersistence();
-      const persistedUpdateState = loadPersistedUpdateState();
-      appUpdates.requiredReadds = persistedUpdateState.requiredReadds;
-      appUpdates.dismissedUpdates = persistedUpdateState.dismissedUpdates;
-      // send client-ready-for-events
-      window.electronAPI.app.clientReadyForEvents();
-      console.log('client-ready-for-events sent');
-    }, 200);
+    // Initialize search-related data
+    initializeSearch();
+    initDownloadPersistence();
+    const persistedUpdateState = loadPersistedUpdateState();
+    appUpdates.requiredReadds = persistedUpdateState.requiredReadds;
+    appUpdates.dismissedUpdates = persistedUpdateState.dismissedUpdates;
+    // send client-ready-for-events
+    window.electronAPI.app.clientReadyForEvents();
+    console.log('client-ready-for-events sent');
   });
 
   // Initialize when DOM is ready

--- a/application/src/frontend/lib/config/client.ts
+++ b/application/src/frontend/lib/config/client.ts
@@ -77,8 +77,26 @@ export function getConfigClientOption<T>(id: string): T | null {
   );
   return JSON.parse(config) as T;
 }
+async function waitForConfiguredAddons(
+  maxWaitMs = 15_000,
+  pollMs = 100
+): Promise<ConfigTemplateAndInfo[]> {
+  const deadline = Date.now() + maxWaitMs;
+  while (Date.now() < deadline) {
+    const addons = await queryConnectedAddons<ConfigTemplateAndInfo>();
+    if (addons.length === 0) {
+      return addons;
+    }
+    if (addons.every((addon) => addon.configTemplate !== undefined)) {
+      return addons;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return queryConnectedAddons<ConfigTemplateAndInfo>();
+}
+
 export async function fetchAddonsWithConfigure() {
-  const addons = await queryConnectedAddons<ConfigTemplateAndInfo>();
+  const addons = await waitForConfiguredAddons();
 
   await Promise.all(
     addons.map(async (addon) => {
@@ -87,6 +105,13 @@ export async function fetchAddonsWithConfigure() {
 
       const configPath = addonConfigPath(safeId);
       let config: Record<string, number | boolean | string>;
+
+      if (!addon.configTemplate) {
+        console.warn(
+          `Skipping config update for ${safeId}: configure template not ready`
+        );
+        return;
+      }
 
       if (!window.electronAPI.fs.exists(configPath)) {
         config = buildDefaultConfig(addon.configTemplate);

--- a/application/src/frontend/views/CommunityAddonsList.svelte
+++ b/application/src/frontend/views/CommunityAddonsList.svelte
@@ -41,10 +41,8 @@
     await window.electronAPI.installAddons(
       JSON.parse(JSON.stringify(currentAddons.addons))
     );
-    setTimeout(async () => {
-      await window.electronAPI.restartAddonServer();
-      await reconnectClientSdk();
-    }, 2500);
+    await window.electronAPI.restartAddonServer();
+    await reconnectClientSdk();
   }
 
   async function deleteAddon(addon: CommunityAddon) {


### PR DESCRIPTION
## Summary

- After addon server restart, the main process now waits until each running addon has sent its `configure` template before emitting `addon-runtime-ready`.
- `fetchAddonsWithConfigure()` polls until connected addons expose `configTemplate`, skipping updates when templates are not ready yet.
- `addon-connected` IPC is emitted per ready addon (and the duplicate preload listener was removed).
- Removed startup/restart timing hacks (`setTimeout` 200ms in App mount, 2500ms after community addon install).

Fixes #137

## Test plan

- [ ] Settings → General → Restart Addon Server — General action buttons and search work immediately
- [ ] Install an addon from Community tab — addon receives config without manual delay/restart
- [ ] Check addon logs for "Config update received" right after restart
- [ ] `bun run --cwd application typecheck` passes


Made with [Cursor](https://cursor.com)