### PR TITLE
fix: check for app updates after addon server reload

### DIFF
--- a/application/src/frontend/managers/AppUpdateManager.svelte
+++ b/application/src/frontend/managers/AppUpdateManager.svelte
@@ -4,6 +4,7 @@
     addonServer,
     fetchAddonsWithConfigure,
     findAddonsSupportingStorefront,
+    reconnectClientSdk,
   } from '@/frontend/utils';
   import { tryCatch } from '@/frontend/lib/core/tryCatch';
   import { updatesManager } from '@/frontend/states.svelte';
@@ -11,9 +12,21 @@
   let updateCheckRunId = 0;
 
   document.addEventListener('addon-runtime-ready', () => {
-    fetchAddonsWithConfigure();
-    checkForAppUpdates();
+    void onAddonRuntimeReady();
   });
+
+  async function onAddonRuntimeReady() {
+    try {
+      await reconnectClientSdk();
+      await fetchAddonsWithConfigure();
+      await checkForAppUpdates();
+    } catch (error) {
+      console.error(
+        'Failed to refresh addon runtime for update checks:',
+        error
+      );
+    }
+  }
 
   async function checkForAppUpdates() {
     let library;

--- a/updater/public/index.html
+++ b/updater/public/index.html
@@ -47,10 +47,13 @@
 </html>
 <script>
   document.addEventListener('text', (event) => {
+    const picker = document.querySelector('#channel-picker');
+    if (picker.style.display !== 'none') {
+      return;
+    }
     const { text, progress, subtext, max } = event.detail;
     const progressHTML = document.querySelector('progress');
     const subTextHTML = document.querySelector('p');
-    const picker = document.querySelector('#channel-picker');
     picker.style.display = 'none';
     document.querySelector('h1').textContent = text;
     if (progress !== undefined && progress !== null && max) {
@@ -109,6 +112,7 @@
   async function loadBranches() {
     const select = document.querySelector('#branch-select');
     setBranchUiVisible(true);
+    select.disabled = true;
     select.innerHTML = '<option value="">Loading branches...</option>';
     try {
       const result = await window.ogiUpdater.getBranches();
@@ -127,6 +131,8 @@
     } catch (error) {
       select.innerHTML = '<option value="main">main</option>';
       select.value = 'main';
+    } finally {
+      select.disabled = false;
     }
   }
 

--- a/updater/src/main.ts
+++ b/updater/src/main.ts
@@ -234,21 +234,49 @@ type BleedingEdgeSyncResult = {
   pullWasNoop: boolean;
 };
 
-function runCommand(command, args, options = {}): Promise<CommandResult> {
+type RunCommandOptions = {
+  cwd?: string;
+  /** Skip UI status updates (e.g. git metadata for branch/commit picker). */
+  quiet?: boolean;
+};
+
+function runCommand(
+  command,
+  args,
+  options: RunCommandOptions = {}
+): Promise<CommandResult> {
+  const { quiet = false, ...spawnOptions } = options;
   return new Promise((resolve, reject) => {
     logUpdater(`Running command: ${command} ${args.join(' ')}`);
-    const child = spawn(command, args, { ...options, shell: process.platform === 'win32' });
+    const child = spawn(command, args, {
+      ...spawnOptions,
+      shell: process.platform === 'win32',
+    });
     let stdout = '';
     let stderr = '';
     child.stdout?.on('data', (data) => {
       const text = data.toString();
       stdout += text;
-      sendUpdaterStatus('Building Bleeding Edge', undefined, undefined, text.trim().slice(-80));
+      if (!quiet) {
+        sendUpdaterStatus(
+          'Building Bleeding Edge',
+          undefined,
+          undefined,
+          text.trim().slice(-80)
+        );
+      }
     });
     child.stderr?.on('data', (data) => {
       const text = data.toString();
       stderr += text;
-      sendUpdaterStatus('Building Bleeding Edge', undefined, undefined, text.trim().slice(-80));
+      if (!quiet) {
+        sendUpdaterStatus(
+          'Building Bleeding Edge',
+          undefined,
+          undefined,
+          text.trim().slice(-80)
+        );
+      }
     });
     child.on('error', reject);
     child.on('close', (code) => code === 0 ? resolve({ stdout, stderr }) : reject(new Error(`${command} exited with code ${code}`)));
@@ -393,7 +421,10 @@ async function getBranchesViaGit(): Promise<string[]> {
   const repoDir = getBleedingEdgeRepoDir();
   if (fs.existsSync(path.join(repoDir, '.git'))) {
     try {
-      await runCommand('git', ['fetch', '--prune', 'origin'], { cwd: repoDir });
+      await runCommand('git', ['fetch', '--prune', 'origin'], {
+        cwd: repoDir,
+        quiet: true,
+      });
       const { stdout } = await runCommand(
         'git',
         [
@@ -402,7 +433,7 @@ async function getBranchesViaGit(): Promise<string[]> {
           '--format=%(refname:short)\t%(committerdate:iso8601)',
           '--sort=-committerdate',
         ],
-        { cwd: repoDir }
+        { cwd: repoDir, quiet: true }
       );
       const datedBranches: { name: string; date: string }[] = [];
       for (const line of stdout.split('\n')) {
@@ -429,7 +460,9 @@ async function getBranchesViaGit(): Promise<string[]> {
     }
   }
 
-  const { stdout } = await runCommand('git', ['ls-remote', '--heads', OGI_REPO_URL]);
+  const { stdout } = await runCommand('git', ['ls-remote', '--heads', OGI_REPO_URL], {
+    quiet: true,
+  });
   const names = new Set<string>();
   for (const line of stdout.split('\n')) {
     const trimmed = line.trim();
@@ -488,11 +521,12 @@ async function getRecentCommitsViaGit(
   if (fs.existsSync(path.join(repoDir, '.git'))) {
     await runCommand('git', ['fetch', 'origin', targetBranch, '--depth', '12'], {
       cwd: repoDir,
+      quiet: true,
     });
     const { stdout } = await runCommand(
       'git',
       ['log', `origin/${targetBranch}`, '-12', `--format=${logFormat}`],
-      { cwd: repoDir }
+      { cwd: repoDir, quiet: true }
     );
     const commits = parseGitLogCommits(stdout);
     if (commits.length) {
@@ -506,20 +540,24 @@ async function getRecentCommitsViaGit(
   );
   fs.rmSync(tmpDir, { recursive: true, force: true });
   try {
-    await runCommand('git', [
-      'clone',
-      '--depth',
-      '12',
-      '--branch',
-      targetBranch,
-      '--single-branch',
-      OGI_REPO_URL,
-      tmpDir,
-    ]);
+    await runCommand(
+      'git',
+      [
+        'clone',
+        '--depth',
+        '12',
+        '--branch',
+        targetBranch,
+        '--single-branch',
+        OGI_REPO_URL,
+        tmpDir,
+      ],
+      { quiet: true }
+    );
     const { stdout } = await runCommand(
       'git',
       ['log', 'HEAD', '-12', `--format=${logFormat}`],
-      { cwd: tmpDir }
+      { cwd: tmpDir, quiet: true }
     );
     return parseGitLogCommits(stdout);
   } finally {


### PR DESCRIPTION
## Summary

- On `addon-runtime-ready`, reconnect the client SDK and await configured addons before running per-app `check-for-updates` RPCs.
- Fixes a race where update checks ran against a stale WebSocket while UI callers only reconnected after `restartAddonServer()` returned.

Closes #141

## Test plan

- [ ] Start app with addons and library entries
- [ ] Client Options → Restart Addon Server
- [ ] Confirm console shows `checking for app updates` and library update badges refresh
- [ ] Repeat after install/update addons paths that restart the server without an explicit UI reconnect


Made with [Cursor](https://cursor.com)