### PR TITLE
fix: clear torrent download queue on finish and cancel

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -72,7 +72,6 @@
     "@tsconfig/svelte": "^5.0.6",
     "@types/d3": "^7.4.3",
     "@types/node": "^22.15.0",
-    "@types/parse-torrent": "^5.8.8",
     "@types/sanitize-html": "^2.16.0",
     "@types/semver": "^7.7.1",
     "@types/shell-quote": "^1.7.5",

--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -343,14 +343,17 @@ class Download {
     });
 
     if (result === 'cancelled') {
+      this.removeCancelHandler();
       return;
     }
-
-    ipcMain.removeHandler(`queue:${this.id}:cancel`);
 
     console.log('[direct] Starting download...');
 
     this.run();
+  }
+
+  private removeCancelHandler() {
+    ipcMain.removeHandler(`queue:${this.id}:cancel`);
   }
 
   private async run() {
@@ -1286,6 +1289,7 @@ class Download {
     }
 
     this.cleanupAllFiles().then(() => {
+      this.removeCancelHandler();
       this.sendIpc('ddl:download-cancelled', { id: this.id });
       this.taskFinisher();
       console.log('[direct] Download Cancelled', this.id);
@@ -1324,6 +1328,7 @@ class Download {
       id: this.id,
       type: 'success',
     });
+    this.removeCancelHandler();
     this.taskFinisher();
     downloads.delete(this.id);
   }
@@ -1366,6 +1371,7 @@ class Download {
         id: this.id,
         type: 'error',
       });
+      this.removeCancelHandler();
       this.taskFinisher();
       downloads.delete(this.id);
     });

--- a/application/src/electron/handlers/handler.torrent.ts
+++ b/application/src/electron/handlers/handler.torrent.ts
@@ -12,9 +12,16 @@ import { QBittorrent } from '@ctrl/qbittorrent';
 import { torrent as wtConnect } from '@/electron/manager/manager.webtorrent.js';
 import { __dirname } from '@/electron/manager/manager.paths.js';
 import { DOWNLOAD_QUEUE } from '@/electron/manager/manager.queue.js';
-import ParseTorrent from 'parse-torrent';
+import parseTorrent from 'parse-torrent';
 
 let qbitClient: QBittorrent | undefined = undefined;
+
+async function getTorrentInfoHash(
+  input: string | Buffer | Uint8Array
+): Promise<string> {
+  const parsed = await parseTorrent(input);
+  return parsed.infoHash;
+}
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -209,16 +216,14 @@ class TorrentDownload {
 
       if (this.job.type === 'torrent') {
         const torrentData = await this.downloadTorrentFile(this.job.link);
-        const parsed = await (ParseTorrent as any)(torrentData);
-        this.expectedInfoHash = parsed.infoHash;
+        this.expectedInfoHash = await getTorrentInfoHash(torrentData);
         // turn torrent data into a Uint8Array<ArrayBuffer>
         const torrentDataUint8Array = new Uint8Array(torrentData);
         await qbitClient.addTorrent(torrentDataUint8Array, {
           savepath: this.job.path,
         });
       } else {
-        const parsed = await (ParseTorrent as any)(this.job.link);
-        this.expectedInfoHash = parsed.infoHash;
+        this.expectedInfoHash = await getTorrentInfoHash(this.job.link);
         await qbitClient.addMagnet(this.job.link, {
           savepath: this.job.path,
         });
@@ -585,8 +590,7 @@ export default function handler(mainWindow: BrowserWindow) {
   ipcMain.handle(
     'torrent:get-hash',
     async (_, item: string | Buffer | Uint8Array) => {
-      const parsed = await (ParseTorrent as any)(item);
-      return parsed.infoHash;
+      return getTorrentInfoHash(item);
     }
   );
 }

--- a/application/src/electron/handlers/handler.torrent.ts
+++ b/application/src/electron/handlers/handler.torrent.ts
@@ -138,14 +138,17 @@ class TorrentDownload {
     });
 
     if (result === 'cancelled') {
+      this.removeCancelHandler();
       this.releaseQueueSlot();
       return;
     }
 
-    ipcMain.removeHandler(`queue:${this.id}:cancel`);
-
     console.log('[torrent] Starting download...');
     this.run();
+  }
+
+  private removeCancelHandler() {
+    ipcMain.removeHandler(`queue:${this.id}:cancel`);
   }
 
   private async run() {
@@ -193,8 +196,18 @@ class TorrentDownload {
         this.ratio = ratio;
       },
       () => {
+        if (
+          this.status === 'cancelled' ||
+          this.status === 'failed' ||
+          this.status === 'completed'
+        ) {
+          return;
+        }
         this.releaseQueueSlot();
         setTimeout(() => {
+          if (this.status === 'cancelled' || this.status === 'failed') {
+            return;
+          }
           this.status = 'seeding';
           this.progress = 1;
           this.sendProgress({ progress: 1, downloadSpeed: 0, ratio: 0 });
@@ -343,6 +356,7 @@ class TorrentDownload {
     }
 
     this.cleanup();
+    this.removeCancelHandler();
 
     this.sendIpc('torrent:download-cancelled', { id: this.id });
     console.log('[torrent] Download Cancelled', this.id);
@@ -367,6 +381,7 @@ class TorrentDownload {
       type: 'success',
     });
     this.cleanup();
+    this.removeCancelHandler();
     this.releaseQueueSlot();
     downloads.delete(this.id);
   }
@@ -391,6 +406,7 @@ class TorrentDownload {
     });
     console.error(`[torrent] Download ${this.id} failed:`, error);
     this.cleanup();
+    this.removeCancelHandler();
     this.releaseQueueSlot();
     downloads.delete(this.id);
   }

--- a/application/src/electron/handlers/handler.torrent.ts
+++ b/application/src/electron/handlers/handler.torrent.ts
@@ -77,6 +77,7 @@ class TorrentDownload {
   private mainWindow: BrowserWindow;
   private job: TorrentJob;
   private taskFinisher: () => void = () => {};
+  private queueReleased = false;
   private torrentClientType: 'webtorrent' | 'qbittorrent' | 'unselected' =
     'unselected';
 
@@ -90,8 +91,12 @@ class TorrentDownload {
 
   // qBittorrent specific
   private qbitTorrentHash?: string;
+  private expectedInfoHash?: string;
+  private qbitNotFoundTicks = 0;
   private qbitCheckInterval?: NodeJS.Timeout;
   private qbitProgressInterval?: NodeJS.Timeout;
+
+  private static readonly QBIT_LOOKUP_TIMEOUT_TICKS = 60;
 
   private progressInterval?: NodeJS.Timeout;
 
@@ -125,11 +130,12 @@ class TorrentDownload {
       this.sendProgress({ queuePosition });
     });
 
-    ipcMain.removeHandler(`queue:${this.id}:cancel`);
-
     if (result === 'cancelled') {
+      this.releaseQueueSlot();
       return;
     }
+
+    ipcMain.removeHandler(`queue:${this.id}:cancel`);
 
     console.log('[torrent] Starting download...');
     this.run();
@@ -180,6 +186,7 @@ class TorrentDownload {
         this.ratio = ratio;
       },
       () => {
+        this.releaseQueueSlot();
         setTimeout(() => {
           this.status = 'seeding';
           this.progress = 1;
@@ -190,9 +197,7 @@ class TorrentDownload {
             id: this.id,
             type: 'success',
           });
-          this.taskFinisher();
           this.wtInstance?.seed();
-          // Don't call task finisher until seeding is stopped (e.g., by cancellation)
         }, 1000);
       }
     );
@@ -204,12 +209,16 @@ class TorrentDownload {
 
       if (this.job.type === 'torrent') {
         const torrentData = await this.downloadTorrentFile(this.job.link);
+        const parsed = await (ParseTorrent as any)(torrentData);
+        this.expectedInfoHash = parsed.infoHash;
         // turn torrent data into a Uint8Array<ArrayBuffer>
         const torrentDataUint8Array = new Uint8Array(torrentData);
         await qbitClient.addTorrent(torrentDataUint8Array, {
           savepath: this.job.path,
         });
       } else {
+        const parsed = await (ParseTorrent as any)(this.job.link);
+        this.expectedInfoHash = parsed.infoHash;
         await qbitClient.addMagnet(this.job.link, {
           savepath: this.job.path,
         });
@@ -308,7 +317,13 @@ class TorrentDownload {
   }
 
   public cancel() {
-    if (this.status === 'cancelled' || this.status === 'completed') return;
+    if (
+      this.status === 'cancelled' ||
+      this.status === 'completed' ||
+      this.status === 'failed'
+    ) {
+      return;
+    }
     this.status = 'cancelled';
 
     if (this.torrentClientType === 'webtorrent') {
@@ -326,11 +341,18 @@ class TorrentDownload {
 
     this.sendIpc('torrent:download-cancelled', { id: this.id });
     console.log('[torrent] Download Cancelled', this.id);
-    this.taskFinisher();
+    this.releaseQueueSlot();
     downloads.delete(this.id);
   }
 
   private complete() {
+    if (
+      this.status === 'completed' ||
+      this.status === 'cancelled' ||
+      this.status === 'failed'
+    ) {
+      return;
+    }
     this.status = 'completed';
     this.sendProgress({ progress: 1, downloadSpeed: 0 });
     this.sendIpc('torrent:download-complete', { id: this.id });
@@ -340,12 +362,18 @@ class TorrentDownload {
       type: 'success',
     });
     this.cleanup();
-    this.taskFinisher();
+    this.releaseQueueSlot();
     downloads.delete(this.id);
   }
 
   private fail(error: Error) {
-    if (this.status === 'failed' || this.status === 'cancelled' || this.status === 'completed') return;
+    if (
+      this.status === 'failed' ||
+      this.status === 'cancelled' ||
+      this.status === 'completed'
+    ) {
+      return;
+    }
     this.status = 'failed';
     this.sendIpc('torrent:download-error', {
       id: this.id,
@@ -358,18 +386,30 @@ class TorrentDownload {
     });
     console.error(`[torrent] Download ${this.id} failed:`, error);
     this.cleanup();
-    this.taskFinisher();
+    this.releaseQueueSlot();
     downloads.delete(this.id);
+  }
+
+  private releaseQueueSlot() {
+    if (this.queueReleased) return;
+    this.queueReleased = true;
+    this.taskFinisher();
   }
 
   private startProgressTracker() {
     this.progressInterval = setInterval(() => {
-      if (this.status === 'downloading' || this.status === 'seeding') {
+      if (this.status === 'downloading') {
         this.sendProgress({
           progress: this.progress,
           downloadSpeed: this.downloadSpeed,
           ratio: this.ratio,
           queuePosition: 1,
+        });
+      } else if (this.status === 'seeding') {
+        this.sendProgress({
+          progress: this.progress,
+          downloadSpeed: this.downloadSpeed,
+          ratio: this.ratio,
         });
       }
     }, 500);
@@ -384,13 +424,24 @@ class TorrentDownload {
         let torrent;
 
         if (!this.qbitTorrentHash) {
-          torrent = torrents.find(
-            (t) =>
-              t.savePath === this.job.path.replace(/\//g, '\\') ||
-              t.savePath === this.job.path
-          );
+          torrent = torrents.find((t) => {
+            if (
+              this.expectedInfoHash &&
+              (t.id === this.expectedInfoHash ||
+                (t as { hash?: string }).hash === this.expectedInfoHash)
+            ) {
+              return true;
+            }
+            const normalizedJobPath = this.job.path.replace(/[/\\]+$/, '');
+            const normalizedSavePath = t.savePath.replace(/[/\\]+$/, '');
+            return (
+              normalizedSavePath === normalizedJobPath.replace(/\//g, '\\') ||
+              normalizedSavePath === normalizedJobPath
+            );
+          });
           if (torrent) {
             this.qbitTorrentHash = torrent.id;
+            this.qbitNotFoundTicks = 0;
             console.log(
               `[torrent-handler] Found torrent hash: ${this.qbitTorrentHash}`
             );
@@ -399,17 +450,31 @@ class TorrentDownload {
           torrent = torrents.find((t) => t.id === this.qbitTorrentHash);
         }
 
-        if (torrent) {
-          this.downloadSpeed = torrent.downloadSpeed;
-          this.progress = torrent.progress;
-          this.totalSize = torrent.totalSize;
-          this.ratio = torrent.totalDownloaded
-            ? torrent.totalUploaded / torrent.totalDownloaded
-            : 0;
-
-          if (torrent.isCompleted) {
-            this.complete();
+        if (!torrent) {
+          this.qbitNotFoundTicks++;
+          if (
+            this.qbitNotFoundTicks >= TorrentDownload.QBIT_LOOKUP_TIMEOUT_TICKS
+          ) {
+            this.fail(
+              new Error(
+                'Timed out waiting for qBittorrent to register the torrent.'
+              )
+            );
           }
+          return;
+        }
+
+        this.qbitNotFoundTicks = 0;
+
+        this.downloadSpeed = torrent.downloadSpeed;
+        this.progress = torrent.progress;
+        this.totalSize = torrent.totalSize;
+        this.ratio = torrent.totalDownloaded
+          ? torrent.totalUploaded / torrent.totalDownloaded
+          : 0;
+
+        if (torrent.isCompleted || torrent.progress >= 1) {
+          this.complete();
         }
       } catch (error) {
         console.error('[torrent] Error getting qBittorrent data:', error);
@@ -423,6 +488,7 @@ class TorrentDownload {
           progress: this.progress,
           downloadSpeed: this.downloadSpeed,
           ratio: this.ratio,
+          queuePosition: 1,
         });
       }
     }, 500);

--- a/application/src/electron/manager/manager.queue.ts
+++ b/application/src/electron/manager/manager.queue.ts
@@ -44,6 +44,10 @@ export class Queue<T = any> {
         }),
       cancelHandler: (cancel: (handle: () => void) => void) => {
         cancel(() => {
+          if (this.processing.has(id)) {
+            this.finish(id);
+            return;
+          }
           this.queueListeners.get(id)?.(0, true);
           this.remove(id);
         });

--- a/application/src/frontend/lib/downloads/pause-resume.ts
+++ b/application/src/frontend/lib/downloads/pause-resume.ts
@@ -326,6 +326,7 @@ export function cancelPausedDownload(downloadId: string) {
     if (!pausedState) {
       // Handle persisted paused downloads after app restart (no in-memory state)
       const item = getDownloadItem(downloadId);
+      window.electronAPI.queue.cancel(downloadId);
       deleteDownloadedItems(downloadId);
       deletePersistedDownload(downloadId);
       currentDownloads.update((downloads) => {
@@ -347,7 +348,7 @@ export function cancelPausedDownload(downloadId: string) {
       return downloads.filter((d) => d.id !== downloadId);
     });
 
-    window.electronAPI.ddl.abortDownload(downloadId);
+    window.electronAPI.queue.cancel(downloadId);
     deleteDownloadedItems(downloadId);
     deletePersistedDownload(downloadId);
 

--- a/application/src/frontend/managers/DownloadManager.svelte
+++ b/application/src/frontend/managers/DownloadManager.svelte
@@ -397,20 +397,31 @@
       part,
       totalParts,
       ratio,
+      status,
     } = event.detail;
     if (queuePosition > 1) {
       console.log('Queue Position Update: ', downloadID, queuePosition);
     }
 
-    updateDownloadStatus(downloadID, {
+    const updates: Record<string, unknown> = {
       progress,
       downloadSpeed,
       downloadSize: fileSize,
-      queuePosition,
       part,
       totalParts,
       ratio,
-    });
+    };
+
+    if (status) {
+      updates.status = status;
+    }
+    if (queuePosition !== undefined) {
+      updates.queuePosition = queuePosition;
+    } else if (status && status !== 'downloading' && status !== 'queued') {
+      updates.queuePosition = undefined;
+    }
+
+    updateDownloadStatus(downloadID, updates);
   }
 
   function handleDownloadCancelled(event: Event) {
@@ -485,6 +496,7 @@
     updateDownloadStatus(event.detail.id, {
       status: 'error',
       error: event.detail.error,
+      queuePosition: undefined,
     });
 
     if (event.detail.error) {

--- a/application/typings/parse-torrent.d.ts
+++ b/application/typings/parse-torrent.d.ts
@@ -1,0 +1,12 @@
+declare module 'parse-torrent' {
+  export interface ParsedTorrent {
+    infoHash: string;
+    name?: string;
+    announce?: string | string[];
+    urlList?: string[];
+  }
+
+  export default function parseTorrent(
+    torrentId: string | Buffer | Uint8Array | ParsedTorrent
+  ): Promise<ParsedTorrent>;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "application": {
       "name": "opengameinstaller-gui",
-      "version": "3.0.12",
+      "version": "4.0.0",
       "dependencies": {
         "@ctrl/qbittorrent": "^9.11.0",
         "@ogi-sdk/addon-server": "workspace:*",
@@ -43,7 +43,6 @@
         "@tsconfig/svelte": "^5.0.6",
         "@types/d3": "^7.4.3",
         "@types/node": "^22.15.0",
-        "@types/parse-torrent": "^5.8.8",
         "@types/sanitize-html": "^2.16.0",
         "@types/semver": "^7.7.1",
         "@types/shell-quote": "^1.7.5",
@@ -70,11 +69,11 @@
     },
     "packages/addon-server": {
       "name": "@ogi-sdk/addon-server",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
-        "@ogi-sdk/connect": "^1.0.1",
+        "@ogi-sdk/connect": "^1.0.2",
         "elysia": "^1.4.28",
-        "ogi-addon": "^4.0.1",
+        "ogi-addon": "^4.1.0",
         "websocket": "^1.0.35",
         "ws": "^8.20.0",
       },
@@ -104,10 +103,10 @@
     },
     "packages/client-kit": {
       "name": "@ogi-sdk/client-kit",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
-        "@ogi-sdk/connect": "^1.0.1",
-        "ogi-addon": "^4.0.1",
+        "@ogi-sdk/connect": "^1.0.2",
+        "ogi-addon": "^4.1.0",
         "ws": "^8.20.0",
       },
       "devDependencies": {
@@ -121,7 +120,7 @@
     },
     "packages/connection": {
       "name": "@ogi-sdk/connect",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "devDependencies": {
         "@types/bun": "latest",
         "tsdown": "^0.21.10",
@@ -155,9 +154,9 @@
     },
     "packages/ogi-addon": {
       "name": "ogi-addon",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "dependencies": {
-        "@ogi-sdk/connect": "^1.0.1",
+        "@ogi-sdk/connect": "^1.0.2",
         "fuse.js": "^7.1.0",
         "zod": "^3.23.8",
       },
@@ -171,7 +170,7 @@
     },
     "packages/real-debrid": {
       "name": "real-debrid-js",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "axios": "^1.7.2",
         "zod": "^3.23.8",
@@ -196,7 +195,7 @@
     },
     "updater": {
       "name": "ogi-updater",
-      "version": "1.4.3",
+      "version": "2.0.0",
       "dependencies": {
         "axios": "^1.13.4",
         "yauzl": "^3.2.0",


### PR DESCRIPTION
## Summary
- Add an idempotent `releaseQueueSlot()` helper so webtorrent/qbittorrent jobs always release the global download queue exactly once on finish, cancel, or failure
- Release the queue immediately when a WebTorrent download completes (instead of waiting on the seeding timeout), stop sending `queuePosition` during seeding, and improve qBittorrent torrent lookup by info hash with a timeout fallback
- Clear stale `queuePosition` in the frontend when torrent downloads error or leave the active queue

Fixes #145

## Test plan
- [x] `bun run typecheck` in `application/`
- [ ] Queue 2+ torrents with webtorrent — first finishing should start the second
- [ ] Cancel a queued torrent via Download view
- [ ] Repeat with qbittorrent client configured
- [ ] Confirm logs show `[Queue] Finishing download:` / `[Queue] Finished. Next in queue:`


Made with [Cursor](https://cursor.com)