### PR TITLE
fix: run addon setup after qBittorrent torrent completes

### DIFF
--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -1299,7 +1299,9 @@ class Download {
 
   private complete() {
     console.log('[direct] Download completed');
-    this.status = 'completed';
+    // Keep status as 'downloading' (not 'completed') so the frontend does not
+    // enter the addon setup phase before ddl:download-complete fires.
+    // The frontend sets 'completed' when setup actually starts.
 
     // Clean up any remaining resources
     if (this.useParallelParts) {

--- a/application/src/electron/handlers/handler.torrent.ts
+++ b/application/src/electron/handlers/handler.torrent.ts
@@ -338,6 +338,7 @@ class TorrentDownload {
     if (
       this.status === 'cancelled' ||
       this.status === 'completed' ||
+      this.status === 'seeding' ||
       this.status === 'failed'
     ) {
       return;
@@ -367,16 +368,19 @@ class TorrentDownload {
   private complete() {
     if (
       this.status === 'completed' ||
+      this.status === 'seeding' ||
       this.status === 'cancelled' ||
       this.status === 'failed'
     ) {
       return;
     }
-    this.status = 'completed';
+    // Use 'seeding' (not 'completed') so the frontend does not treat the torrent
+    // as entering the addon setup phase before torrent:download-complete fires.
+    this.status = 'seeding';
     this.sendProgress({ progress: 1, downloadSpeed: 0 });
     this.sendIpc('torrent:download-complete', { id: this.id });
     sendNotification({
-      message: 'Download completed',
+      message: 'Download completed, now seeding.',
       id: this.id,
       type: 'success',
     });
@@ -390,7 +394,8 @@ class TorrentDownload {
     if (
       this.status === 'failed' ||
       this.status === 'cancelled' ||
-      this.status === 'completed'
+      this.status === 'completed' ||
+      this.status === 'seeding'
     ) {
       return;
     }

--- a/application/src/frontend/lib/downloads/lifecycle.ts
+++ b/application/src/frontend/lib/downloads/lifecycle.ts
@@ -127,15 +127,28 @@ export function updateDownloadStatus(
 
         // Initialize setup logs when status changes to 'completed' (setup phase)
         if (updates.status === 'completed' && download.status !== 'completed') {
-          setupLogs.update((logs) => ({
-            ...logs,
-            [downloadID]: {
-              downloadId: downloadID,
-              logs: [],
-              progress: 0,
-              isActive: true,
-            },
-          }));
+          setupLogs.update((logs) => {
+            const existing = logs[downloadID];
+            // Preserve logs from debrid extraction or other pre-setup work
+            if (existing?.logs?.length) {
+              return {
+                ...logs,
+                [downloadID]: {
+                  ...existing,
+                  isActive: true,
+                },
+              };
+            }
+            return {
+              ...logs,
+              [downloadID]: {
+                downloadId: downloadID,
+                logs: [],
+                progress: 0,
+                isActive: true,
+              },
+            };
+          });
         }
 
         return updatedDownload;

--- a/application/src/frontend/managers/DownloadManager.svelte
+++ b/application/src/frontend/managers/DownloadManager.svelte
@@ -3,7 +3,9 @@
     createNotification,
     currentDownloads,
     setupLogs,
+    type DownloadStatusAndInfo,
   } from '@/frontend/store';
+  import { get } from 'svelte/store';
   import {
     updateDownloadStatus,
     getDownloadItem,
@@ -41,12 +43,40 @@
     );
   }
 
+  function shouldSkipDownloadCompleteProcessing(
+    downloadID: string,
+    item: DownloadStatusAndInfo
+  ): boolean {
+    if (item.status === 'merging' || item.status === 'setup-complete') {
+      return true;
+    }
+
+    const setupLog = get(setupLogs)[downloadID];
+
+    // Post-setup torrents stay in 'seeding' with inactive setup logs.
+    if (item.status === 'seeding' && setupLog && !setupLog.isActive) {
+      return true;
+    }
+
+    // 'completed' means setup is running; skip only if logs prove setup started.
+    if (item.status === 'completed' && setupLog?.logs?.length) {
+      return true;
+    }
+
+    return false;
+  }
+
   async function processDownloadComplete(
     downloadID: string,
     isTorrent: boolean = false
   ) {
     const downloadedItem = getDownloadItem(downloadID);
-    if (!downloadedItem || downloadedItem.status === 'completed') return;
+    if (
+      !downloadedItem ||
+      shouldSkipDownloadCompleteProcessing(downloadID, downloadedItem)
+    ) {
+      return;
+    }
 
     updateDownloadStatus(downloadID, { status: 'merging' });
 

--- a/application/src/frontend/managers/DownloadManager.svelte
+++ b/application/src/frontend/managers/DownloadManager.svelte
@@ -58,8 +58,13 @@
       return true;
     }
 
-    // 'completed' means setup is running; skip only if logs prove setup started.
-    if (item.status === 'completed' && setupLog?.logs?.length) {
+    // Skip duplicate complete events after setup finished (inactive logs).
+    // Debrid extraction also writes logs while isActive; do not skip those.
+    if (
+      item.status === 'completed' &&
+      setupLog?.logs?.length &&
+      !setupLog.isActive
+    ) {
       return true;
     }
 


### PR DESCRIPTION
## Summary

- Fixes #149 — torrent downloads no longer hang on "Initializing setup process…" with an empty setup console.
- qBittorrent now reports `seeding` (matching WebTorrent) when a torrent finishes, instead of `completed`, which the frontend treats as the addon setup phase.
- Hardens `processDownloadComplete` so setup still runs if status was prematurely marked `completed` before the download-complete handler fired.

## Root cause

qBittorrent sent a final progress update with `status: 'completed'` before `torrent:download-complete`. That initialized the setup UI but caused `processDownloadComplete` to return early, so `runSetupApp` never ran.

## Test plan

- [ ] Complete a torrent download with qBittorrent enabled and confirm setup logs appear and progress past "Initializing setup process…"
- [ ] Complete a torrent download with WebTorrent and confirm behavior is unchanged
- [ ] Verify a finished torrent with completed setup stays in `seeding` and does not re-run setup on duplicate events


Made with [Cursor](https://cursor.com)