### PR TITLE
fix: wrapped launch ERR_FAILED from malformed file:// query string

### DIFF
--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -203,7 +203,7 @@ async function handleLaunchHooks(
       : `file://${join(app.getAppPath(), 'out', 'renderer', 'index.html')}`;
 
     // Add flags to indicate this is a hook-only launch
-    const launchUrl = `${baseUrl}&launchGameId=${gameId}&hookType=${hookType}&noLaunch=true`;
+    const launchUrl = `${baseUrl}?launchGameId=${gameId}&hookType=${hookType}&noLaunch=true`;
 
     await mainWindow.loadURL(launchUrl);
 
@@ -243,7 +243,7 @@ async function launchGameById(gameId: number, wrapperCommand?: string | null) {
     const wrapperQuery = wrapperCommand
       ? `&wrapperCommand=${encodeURIComponent(wrapperCommand)}`
       : '';
-    const launchUrl = `${baseUrl}&launchGameId=${gameId}${wrapperQuery}`;
+    const launchUrl = `${baseUrl}?launchGameId=${gameId}${wrapperQuery}`;
 
     await mainWindow.loadURL(launchUrl);
 


### PR DESCRIPTION
## Summary
- Fix wrapped Steam launches failing with `ERR_FAILED` when loading the renderer
- Use `?` instead of `&` for the first query parameter in `launchGameById` and `handleLaunchHooks` URLs
- Ensures `launchGameId` and `wrapperCommand` are parsed correctly by the Svelte frontend

Fixes #153

## Test plan
- [x] `bun run typecheck` in `application/`
- [ ] Launch OGI via Steam shortcut with a wrapper command; confirm renderer loads and `GameLaunchOverlay` runs pre-hooks → wrapper → post-hooks without `ERR_FAILED`


Made with [Cursor](https://cursor.com)