### PR TITLE
fix: hide PlayPage update icon for ignored updates

### DIFF
--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -535,6 +535,21 @@
           </button>
         {/if}
 
+        {#if updateInfo && !hasActiveUpdateDownload && isUpdateDismissed}
+          <button
+            aria-label="Open update options"
+            title="Open update options"
+            class="flex items-center justify-center rounded-lg border-none bg-success px-3 py-3 text-overlay-text transition-colors duration-200 hover:bg-success-hover"
+            onclick={() => (showUpdateModal = true)}
+          >
+            <UpdateIcon
+              fill="var(--color-overlay-text)"
+              width="20px"
+              height="20px"
+            />
+          </button>
+        {/if}
+
         <button
           class="flex items-center justify-center gap-2 rounded-lg border-none bg-accent-light px-4 py-3 text-accent-dark transition-colors duration-200 hover:bg-accent-light/80"
           onclick={openGameConfiguration}

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -535,21 +535,6 @@
           </button>
         {/if}
 
-        {#if updateInfo && !hasActiveUpdateDownload && isUpdateDismissed}
-          <button
-            aria-label="Open update options"
-            title="Open update options"
-            class="flex items-center justify-center rounded-lg border-none bg-success px-3 py-3 text-overlay-text transition-colors duration-200 hover:bg-success-hover"
-            onclick={() => (showUpdateModal = true)}
-          >
-            <UpdateIcon
-              fill="var(--color-overlay-text)"
-              width="20px"
-              height="20px"
-            />
-          </button>
-        {/if}
-
         <button
           class="flex items-center justify-center gap-2 rounded-lg border-none bg-accent-light px-4 py-3 text-accent-dark transition-colors duration-200 hover:bg-accent-light/80"
           onclick={openGameConfiguration}

--- a/application/src/frontend/views/LibraryView.svelte
+++ b/application/src/frontend/views/LibraryView.svelte
@@ -95,6 +95,15 @@
     );
   }
 
+  function hasVisibleAppUpdate(app: LibraryInfo): boolean {
+    const update = updatesManager.getAppUpdate(app.appID);
+    if (!update?.updateAvailable || !update.updateVersion) return false;
+    return !updatesManager.isAppUpdateDismissed(
+      app.appID,
+      update.updateVersion
+    );
+  }
+
   async function openPlayPage(app: LibraryInfo) {
     const freshLibraryInfo = await window.electronAPI.app.getLibraryInfo(
       app.appID
@@ -192,11 +201,11 @@
                     style={getLibraryEntryDelay(index)}
                     onclick={() => void openPlayPage(app)}
                   >
-                    {#if updatesManager.getAppUpdate(app.appID)?.updateAvailable || needsUmuMigration(app)}
+                    {#if hasVisibleAppUpdate(app) || needsUmuMigration(app)}
                       <div
                         class="absolute top-2 right-2 z-2 flex flex-col items-end gap-1"
                       >
-                        {#if updatesManager.getAppUpdate(app.appID)?.updateAvailable}
+                        {#if hasVisibleAppUpdate(app)}
                           <div
                             class="shadow-md h-6 flex items-center bg-yellow-500 rounded-lg flex-row justify-end gap-1 px-2"
                           >
@@ -334,11 +343,11 @@
                     )}
                     onclick={() => void openPlayPage(app)}
                   >
-                    {#if updatesManager.getAppUpdate(app.appID)?.updateAvailable || needsUmuMigration(app)}
+                    {#if hasVisibleAppUpdate(app) || needsUmuMigration(app)}
                       <div
                         class="absolute top-2 right-2 z-2 flex flex-col items-end gap-1"
                       >
-                        {#if updatesManager.getAppUpdate(app.appID)?.updateAvailable}
+                        {#if hasVisibleAppUpdate(app)}
                           <div
                             class="shadow-md h-6 flex items-center bg-yellow-500 rounded-lg flex-row justify-end gap-1 px-2"
                           >


### PR DESCRIPTION
## Summary

- Removes the secondary update icon on PlayPage when an update has been ignored/dismissed, so only actionable updates stand out.
- Dismiss clearing on a newly detected version was already handled in `addAppUpdate` (stale dismiss entries are dropped when `updateVersion` changes).

Closes #155

## Test plan

- [ ] Ignore an update on PlayPage — no update icon or CTA should appear (Play still shows).
- [ ] When addon reports a new `updateVersion`, update CTA and icon should return.
- [x] `bun run typecheck` in `application/` passes locally.

Made with [Cursor](https://cursor.com)