### PR TITLE
feat: prevent sleep during app download and setup

### DIFF
--- a/application/src/electron/handlers/handler.power-save.ts
+++ b/application/src/electron/handlers/handler.power-save.ts
@@ -1,0 +1,8 @@
+import { ipcMain } from 'electron';
+import { setPowerSaveBlockActive } from '@/electron/lib/power-save.js';
+
+export function registerPowerSaveHandlers() {
+  ipcMain.handle('power-save:set-active', (_, active: boolean) => {
+    setPowerSaveBlockActive(active);
+  });
+}

--- a/application/src/electron/lib/power-save.ts
+++ b/application/src/electron/lib/power-save.ts
@@ -1,0 +1,21 @@
+import { powerSaveBlocker } from 'electron';
+
+let blockerId: number | null = null;
+
+export function setPowerSaveBlockActive(active: boolean) {
+  if (active) {
+    if (blockerId === null || !powerSaveBlocker.isStarted(blockerId)) {
+      blockerId = powerSaveBlocker.start('prevent-app-suspension');
+    }
+    return;
+  }
+
+  if (blockerId !== null && powerSaveBlocker.isStarted(blockerId)) {
+    powerSaveBlocker.stop(blockerId);
+  }
+  blockerId = null;
+}
+
+export function releasePowerSaveBlock() {
+  setPowerSaveBlockActive(false);
+}

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -39,12 +39,14 @@ import {
   closeSplashWindow,
 } from '@/electron/startup-runner.js';
 import { registerUmuHandlers } from '@/electron/handlers/handler.umu.js';
+import { registerPowerSaveHandlers } from '@/electron/handlers/handler.power-save.js';
 import {
   executeWrapperCommandForApp,
   launchGameFromLibrary,
   type ExecuteWrapperResult,
 } from '@/electron/handlers/handler.library.js';
 import { loadLibraryInfo } from '@/electron/handlers/helpers.app/library.js';
+import { releasePowerSaveBlock } from '@/electron/lib/power-save.js';
 // import steamworks from 'steamworks.js';
 
 /**
@@ -408,6 +410,7 @@ function registerMainHandlers(win: BrowserWindow) {
   AddonManagerHandler(win);
   OOBEHandler();
   registerUmuHandlers();
+  registerPowerSaveHandlers();
 }
 
 function registerClientReadyListener() {
@@ -873,6 +876,8 @@ app.on('window-all-closed', async function () {
 
   // Perform cleanup before quitting
   try {
+    releasePowerSaveBlock();
+
     // stop torrenting
     console.log('Stopping torrent client...');
     await stopClient();

--- a/application/src/electron/preload.mts
+++ b/application/src/electron/preload.mts
@@ -347,6 +347,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getTorrentHash: wrap((torrent: string | Buffer | Uint8Array) =>
     ipcRenderer.invoke('torrent:get-hash', torrent)
   ),
+  powerSave: {
+    setActive: wrap((active: boolean) =>
+      ipcRenderer.invoke('power-save:set-active', active)
+    ),
+  },
 });
 
 ipcRenderer.on(

--- a/application/src/frontend/App.svelte
+++ b/application/src/frontend/App.svelte
@@ -53,7 +53,7 @@
   import Debug from '@/frontend/managers/Debug.svelte';
   import DiscoverView from '@/frontend/views/DiscoverView.svelte';
   import RootPasswordGranter from '@/frontend/managers/RootPasswordGranter.svelte';
-  import { initDownloadPersistence } from '@/frontend/utils';
+  import { initDownloadPersistence, initSleepLock } from '@/frontend/utils';
   import AppUpdateManager from '@/frontend/managers/AppUpdateManager.svelte';
   import ChangelogManager from '@/frontend/managers/ChangelogManager.svelte';
   import {
@@ -149,6 +149,7 @@
     // Initialize search-related data
     initializeSearch();
     initDownloadPersistence();
+    initSleepLock();
     const persistedUpdateState = loadPersistedUpdateState();
     appUpdates.requiredReadds = persistedUpdateState.requiredReadds;
     appUpdates.dismissedUpdates = persistedUpdateState.dismissedUpdates;

--- a/application/src/frontend/global.d.ts
+++ b/application/src/frontend/global.d.ts
@@ -264,6 +264,9 @@ interface Window {
     cleanAddons: () => Promise<void>;
     downloadTorrentInto: (link: string) => Promise<Uint8Array>;
     getTorrentHash: (torrent: string | Buffer | Uint8Array) => Promise<string>;
+    powerSave: {
+      setActive: (active: boolean) => Promise<void>;
+    };
   };
   gamepadNavigator: $GamepadNavigator;
 }

--- a/application/src/frontend/lib/downloads/sleep-lock.ts
+++ b/application/src/frontend/lib/downloads/sleep-lock.ts
@@ -1,0 +1,68 @@
+import {
+  currentDownloads,
+  setupLogs,
+  type DownloadStatusAndInfo,
+  type SetupLog,
+} from '@/frontend/store';
+import { get } from 'svelte/store';
+
+const BLOCKING_DOWNLOAD_STATUSES = new Set<DownloadStatusAndInfo['status']>([
+  'downloading',
+  'merging',
+  'completed',
+  'rd-downloading',
+  'redistr-downloading',
+  'requesting',
+  'installing-redistributables',
+]);
+
+function shouldBlockSleep(
+  downloads: DownloadStatusAndInfo[],
+  logs: Record<string, SetupLog>
+): boolean {
+  for (const download of downloads) {
+    if (BLOCKING_DOWNLOAD_STATUSES.has(download.status)) {
+      return true;
+    }
+  }
+
+  for (const log of Object.values(logs)) {
+    if (log.isActive) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+let sleepBlockActive = false;
+
+function syncSleepBlock(
+  downloads: DownloadStatusAndInfo[],
+  logs: Record<string, SetupLog>
+) {
+  const shouldBlock = shouldBlockSleep(downloads, logs);
+  if (shouldBlock === sleepBlockActive) return;
+
+  sleepBlockActive = shouldBlock;
+  window.electronAPI.powerSave.setActive(shouldBlock).catch((error) => {
+    console.error('Failed to update sleep lock:', error);
+  });
+}
+
+export function initSleepLock() {
+  let latestDownloads = get(currentDownloads);
+  let latestSetupLogs = get(setupLogs);
+
+  currentDownloads.subscribe((downloads) => {
+    latestDownloads = downloads;
+    syncSleepBlock(latestDownloads, latestSetupLogs);
+  });
+
+  setupLogs.subscribe((logs) => {
+    latestSetupLogs = logs;
+    syncSleepBlock(latestDownloads, latestSetupLogs);
+  });
+
+  syncSleepBlock(latestDownloads, latestSetupLogs);
+}

--- a/application/src/frontend/utils.ts
+++ b/application/src/frontend/utils.ts
@@ -7,6 +7,7 @@ export * from '@/frontend/lib/downloads/lifecycle';
 export * from '@/frontend/lib/downloads/pause-resume';
 export * from '@/frontend/lib/downloads/restart';
 export * from '@/frontend/lib/downloads/persistence';
+export * from '@/frontend/lib/downloads/sleep-lock';
 export * from '@/frontend/lib/recovery/failedSetups';
 export * from '@/frontend/lib/tasks/deferred';
 export * from '@/frontend/lib/tasks/runner';


### PR DESCRIPTION
## Summary

- Prevents system sleep/suspension on Linux and Windows while any app is downloading or being set up, using Electron's `powerSaveBlocker`.
- Renderer watches `currentDownloads` and active setup logs, toggling the lock when work starts and releasing it when all jobs are paused, finished, or errored.
- Sleep block is released on app quit.

Closes #160

## Test plan

- [x] `bun run typecheck` in `application/`
- [ ] Start a download on Linux/Windows, leave idle past the sleep timeout, confirm the system stays awake
- [ ] Pause or finish the download and confirm sleep is allowed again
- [ ] Restart the app with a paused in-progress download and confirm sleep is not blocked until resume


Made with [Cursor](https://cursor.com)