### PR TITLE
fix: improve updater release selection

### DIFF
--- a/application/src/electron/startup.ts
+++ b/application/src/electron/startup.ts
@@ -734,7 +734,10 @@ function isGitRepository(repoPath: string): boolean {
 
   const stat = fs.statSync(gitPath);
   if (stat.isDirectory()) {
-    return fs.existsSync(join(gitPath, 'HEAD')) && fs.existsSync(join(gitPath, 'config'));
+    return (
+      fs.existsSync(join(gitPath, 'HEAD')) &&
+      fs.existsSync(join(gitPath, 'config'))
+    );
   }
 
   if (stat.isFile()) {
@@ -755,7 +758,9 @@ function isGitRepository(repoPath: string): boolean {
 
 async function checkForGitUpdates(repoPath: string): Promise<boolean> {
   if (!isGitRepository(repoPath)) {
-    console.log(`Skipping git update check for ${repoPath}: not a valid git repository`);
+    console.log(
+      `Skipping git update check for ${repoPath}: not a valid git repository`
+    );
     return false;
   }
 

--- a/application/src/electron/updater.ts
+++ b/application/src/electron/updater.ts
@@ -280,6 +280,7 @@ type GithubRelease = {
   tag_name: string;
   body?: string;
   prerelease?: boolean;
+  created_at: string;
   assets: ReleaseAsset[];
 };
 
@@ -761,31 +762,37 @@ export function checkIfInstallerUpdateAvailable(
         `https://api.github.com/repos/${gitRepo}/releases`,
         { timeout: 10000 } // 10 second timeout for update check
       );
-      let latestRelease: any | undefined = undefined;
-      for (const rel of releases.data) {
-        if (!rel.body) continue;
+      let latestRelease: GithubRelease | undefined = undefined;
+      const candidates = (releases.data as GithubRelease[]).filter(
+        (rel) => rel.body && /Setup Version: /.test(rel.body)
+      );
+      const stableCandidate = candidates.find((rel) => !rel.prerelease);
+      const prereleaseCandidate = candidates.find((rel) => rel.prerelease);
 
-        const latestVersionResults = rel.body.match(/Setup Version: (.*)/);
-        if (!latestVersionResults || latestVersionResults.length < 2) {
-          continue;
-        }
-        const latestSetupVersion = latestVersionResults[1];
-        console.log(latestSetupVersion, localVersion);
-        if (latestSetupVersion === localVersion) {
-          break;
-        }
-        if (
-          rel.prerelease &&
-          bleedingEdge &&
-          latestSetupVersion !== localVersion
-        ) {
-          latestRelease = rel;
-          break;
-        } else if (!rel.prerelease && latestSetupVersion !== localVersion) {
-          latestRelease = rel;
-          break;
+      const wanted = bleedingEdge
+        ? (prereleaseCandidate ?? stableCandidate)
+        : stableCandidate;
+      // check if the stable candidate time released is greater than the pre release candidate
+      if (
+        stableCandidate &&
+        prereleaseCandidate &&
+        new Date(stableCandidate.created_at) >
+          new Date(prereleaseCandidate.created_at)
+      ) {
+        latestRelease = stableCandidate;
+      } else {
+        latestRelease = wanted;
+      }
+
+      if (wanted) {
+        const wantedVersion = wanted
+          .body!.match(/Setup Version: (.*)/)![1]
+          .trim();
+        if (wantedVersion !== localVersion) {
+          latestRelease = wanted;
         }
       }
+
       if (!latestRelease) {
         console.error('[updater] No new version available.');
         resolve({ success: true, updated: false });
@@ -810,7 +817,7 @@ export function checkIfInstallerUpdateAvailable(
       );
       // get the latest version of the setup from the description of the release
       const latestVersionResults =
-        latestRelease.body.match(/Setup Version: (.*)/);
+        latestRelease.body!.match(/Setup Version: (.*)/);
       if (!latestVersionResults || latestVersionResults.length < 2) {
         console.error(
           '[updater] No setup version found in the release description.'

--- a/application/src/electron/updater.ts
+++ b/application/src/electron/updater.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { app } from 'electron';
+import semver from 'semver';
 import {
   chmodSync,
   createWriteStream,
@@ -757,6 +758,7 @@ export function checkIfInstallerUpdateAvailable(
     const bleedingEdge = existsSync(`${__dirname}/../bleeding-edge.txt`);
     // check for updates
     try {
+      const local = semver.coerce(localVersion.trim())?.version!;
       const gitRepo = 'nat3z/OpenGameInstaller';
       const releases = await axios.get(
         `https://api.github.com/repos/${gitRepo}/releases`,
@@ -789,7 +791,8 @@ export function checkIfInstallerUpdateAvailable(
         const wantedVersion = latestRelease
           .body!.match(/Setup Version: (.*)/)![1]
           .trim();
-        if (wantedVersion === localVersion) {
+        const version = semver.coerce(wantedVersion)?.version!;
+        if (!semver.gt(version, local)) {
           latestRelease = undefined;
         }
       }

--- a/application/src/electron/updater.ts
+++ b/application/src/electron/updater.ts
@@ -784,12 +784,13 @@ export function checkIfInstallerUpdateAvailable(
         latestRelease = wanted;
       }
 
-      if (wanted) {
-        const wantedVersion = wanted
+      // disable the release if we already have this version
+      if (latestRelease) {
+        const wantedVersion = latestRelease
           .body!.match(/Setup Version: (.*)/)![1]
           .trim();
-        if (wantedVersion !== localVersion) {
-          latestRelease = wanted;
+        if (wantedVersion === localVersion) {
+          latestRelease = undefined;
         }
       }
 


### PR DESCRIPTION
closes #176 so that pre-releases are prioritized (if newer) on the setup updater.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update detection so the app more reliably selects the correct GitHub release, especially when both stable and pre-release builds are available.
  * Fixed update version matching to better compare release timestamps and installed version information.
  * Kept repository-check and update-check logging behavior unchanged while improving internal formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->