### PR TITLE
fix(application): handle addon server restarts and parallel limits

### DIFF
--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -98,7 +98,10 @@ export async function startAddons(): Promise<void> {
   console.log('All addons started');
 }
 
-const MAX_ATTEMPTS_HEALTH_CHECK = 500;
+const HEALTH_CHECK_INTERVAL_MS = 500;
+const MAX_ATTEMPTS_HEALTH_CHECK = 60;
+const HEALTH_CHECK_TIMEOUT_MS =
+  MAX_ATTEMPTS_HEALTH_CHECK * HEALTH_CHECK_INTERVAL_MS;
 export async function restartAddonServer(): Promise<void> {
   // stop the server
   console.log('Stopping server...');
@@ -121,12 +124,12 @@ export async function restartAddonServer(): Promise<void> {
   };
   let attempts = 0;
   while (!(await checkHealth()) && attempts < MAX_ATTEMPTS_HEALTH_CHECK) {
-    await new Promise((res) => setTimeout(res, 500));
+    await new Promise((res) => setTimeout(res, HEALTH_CHECK_INTERVAL_MS));
     attempts++;
   }
   if (attempts === MAX_ATTEMPTS_HEALTH_CHECK) {
     throw new Error(
-      'Failed to start addon server: health check failed after maximum attempts'
+      `Failed to start addon server: health check failed after ${attempts} attempts (${HEALTH_CHECK_TIMEOUT_MS / 1000}s)`
     );
   }
   console.log(`Addon Server is running on http://localhost:${port}`);

--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -5,7 +5,6 @@ import { exec, spawn } from 'child_process';
 import { Addon } from '@/electron/manager/manager.addon.js';
 import { __dirname } from '@/electron/manager/manager.paths.js';
 import {
-  addonServer,
   port,
   startAddonServer,
   stopAddonServer,

--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -8,6 +8,7 @@ import {
   addonServer,
   port,
   startAddonServer,
+  stopAddonServer,
 } from '@/electron/server/addon-server.js';
 import { sendIPCMessage, sendNotification } from '@/electron/main.js';
 import axios from 'axios';
@@ -27,7 +28,10 @@ function isGitRepository(addonPath: string): boolean {
 
   const stat = fs.statSync(gitPath);
   if (stat.isDirectory()) {
-    return fs.existsSync(join(gitPath, 'HEAD')) && fs.existsSync(join(gitPath, 'config'));
+    return (
+      fs.existsSync(join(gitPath, 'HEAD')) &&
+      fs.existsSync(join(gitPath, 'config'))
+    );
   }
 
   if (stat.isFile()) {
@@ -95,17 +99,37 @@ export async function startAddons(): Promise<void> {
   console.log('All addons started');
 }
 
+const MAX_ATTEMPTS_HEALTH_CHECK = 500;
 export async function restartAddonServer(): Promise<void> {
   // stop the server
   console.log('Stopping server...');
-  addonServer.stop();
+  stopAddonServer();
   // stop all of the addons
   for (const instance of [...Addon.running.values()]) {
     console.log(`Stopping addon ${instance.config.path}`);
     instance.stop();
   }
   // start the server and wait for it to be listening before starting addons
+
   await startAddonServer();
+  const checkHealth = async () => {
+    try {
+      await axios.get(`http://localhost:${port}/health`, { timeout: 500 });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  let attempts = 0;
+  while (!(await checkHealth()) && attempts < MAX_ATTEMPTS_HEALTH_CHECK) {
+    await new Promise((res) => setTimeout(res, 500));
+    attempts++;
+  }
+  if (attempts === MAX_ATTEMPTS_HEALTH_CHECK) {
+    throw new Error(
+      'Failed to start addon server: health check failed after maximum attempts'
+    );
+  }
   console.log(`Addon Server is running on http://localhost:${port}`);
   console.log(`Server is being executed by electron!`);
   await startAddons();

--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -102,7 +102,7 @@ const MAX_ATTEMPTS_HEALTH_CHECK = 500;
 export async function restartAddonServer(): Promise<void> {
   // stop the server
   console.log('Stopping server...');
-  stopAddonServer();
+  await stopAddonServer();
   // stop all of the addons
   for (const instance of [...Addon.running.values()]) {
     console.log(`Stopping addon ${instance.config.path}`);

--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -223,6 +223,7 @@ class Download {
   private chunks: ChunkState[] = [];
   private parallelTotalSize: number = 0;
   private parallelLimit?: number;
+  private effectiveChunkCount?: number;
   private currentJobPath: string = ''; // Track current job path for chunk file cleanup
 
   // Multi-part parallel download state
@@ -534,6 +535,13 @@ class Download {
       );
     const activeParts = () =>
       this.parts.filter((p) => p.status === 'downloading');
+    const activeRequestCount = () =>
+      activeParts().reduce((count, part) => {
+        if (!part.useChunks || part.chunks.length === 0) {
+          return count + 1;
+        }
+        return count + part.chunks.filter((chunk) => !chunk.completed).length;
+      }, 0);
     const completedParts = () =>
       this.parts.filter((p) => p.status === 'completed');
 
@@ -556,7 +564,7 @@ class Download {
       );
       const availableSlots = Math.max(
         0,
-        (effectivePartLimit ?? PARALLEL_CHUNK_COUNT) - activeParts().length
+        (effectivePartLimit ?? PARALLEL_CHUNK_COUNT) - activeRequestCount()
       );
       const partsToStart = this.parts
         .filter((p) => p.status === 'pending')
@@ -625,6 +633,9 @@ class Download {
       part.parallelLimit,
       parallelInfo.parallelLimit
     );
+    part.effectiveChunkCount =
+      mergeParallelLimits(PARALLEL_CHUNK_COUNT, part.parallelLimit) ??
+      PARALLEL_CHUNK_COUNT;
 
     // Update total bytes for progress calculation
     this.updateMultiPartTotalBytes();
@@ -785,15 +796,8 @@ class Download {
     const job = part.job;
     part.chunks = [];
 
-    // Get parallel limit from the part's parallel info
-    const parallelInfo = await this.shouldUseParallelDownloadForPart(job);
-    part.parallelLimit = mergeParallelLimits(
-      part.parallelLimit,
-      parallelInfo.parallelLimit
-    );
     const effectiveChunkCount =
-      mergeParallelLimits(PARALLEL_CHUNK_COUNT, part.parallelLimit) ??
-      PARALLEL_CHUNK_COUNT;
+      part.effectiveChunkCount ?? PARALLEL_CHUNK_COUNT;
 
     // Store effective chunk count in part state for later use
     part.effectiveChunkCount = effectiveChunkCount;
@@ -1864,15 +1868,10 @@ class Download {
     this.currentJobPath = job.path;
     this.chunks = [];
 
-    // Get parallel limit from the parallel info
-    const parallelInfo = await this.shouldUseParallelDownload(job);
-    this.parallelLimit = mergeParallelLimits(
-      this.parallelLimit,
-      parallelInfo.parallelLimit
-    );
     const effectiveChunkCount =
       mergeParallelLimits(PARALLEL_CHUNK_COUNT, this.parallelLimit) ??
       PARALLEL_CHUNK_COUNT;
+    this.effectiveChunkCount = effectiveChunkCount;
 
     // Calculate chunk sizes
     const chunkSize = Math.ceil(fileSize / effectiveChunkCount);
@@ -1934,7 +1933,7 @@ class Download {
 
     console.log(
       `[direct] Starting parallel download with ${effectiveChunkCount} chunks ` +
-        `(limit: ${parallelInfo.parallelLimit ?? 'none'}), ` +
+        `(limit: ${this.parallelLimit ?? 'none'}), ` +
         `chunk size: ${(chunkSize / (1024 * 1024)).toFixed(2)}MB`
     );
 
@@ -2140,15 +2139,9 @@ class Download {
   private async mergeChunkFiles(job: DownloadJob): Promise<void> {
     console.log('[direct] Merging chunk files into final file...');
 
-    // Get effective chunk count for this job
-    const parallelInfo = await this.shouldUseParallelDownload(job);
-    this.parallelLimit = mergeParallelLimits(
-      this.parallelLimit,
-      parallelInfo.parallelLimit
-    );
     const effectiveChunkCount =
-      mergeParallelLimits(PARALLEL_CHUNK_COUNT, this.parallelLimit) ??
-      PARALLEL_CHUNK_COUNT;
+      this.effectiveChunkCount ??
+      (this.chunks.length > 0 ? this.chunks.length : PARALLEL_CHUNK_COUNT);
 
     // Create the final file write stream
     const finalStream = fs.createWriteStream(job.path, { flags: 'w' });

--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -2314,7 +2314,7 @@ async function checkParallelChunkCount() {
   await refreshCached('general');
   let val = Number(await getStoredValue('general', 'parallelChunkCount'));
   // Ensure minimum of 1, default to 8 if invalid
-  const chunkCount = Math.max(1, Number.isFinite(val) ? val : 8);
+  const chunkCount = Math.max(0, Number.isFinite(val) ? val : 8);
   console.log('[direct] parallel chunk count:', chunkCount);
 
   // Coerce to safe positive integer, ensuring minimum of 1

--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -543,7 +543,7 @@ class Download {
       }
 
       // Start new parts if we have capacity. Respect OGI-Parallel-Limit as a
-      // total connection cap for multipart downloads, not just a per-part chunk cap.
+      // total connection cap for concurrent parts.
       const knownParallelLimits = this.parts.map((part) =>
         mergeParallelLimits(
           part.parallelLimit,
@@ -555,7 +555,7 @@ class Download {
         ...knownParallelLimits
       );
       const availableSlots = Math.max(
-        1,
+        0,
         (effectivePartLimit ?? PARALLEL_CHUNK_COUNT) - activeParts().length
       );
       const partsToStart = this.parts
@@ -2314,7 +2314,7 @@ async function checkParallelChunkCount() {
   await refreshCached('general');
   let val = Number(await getStoredValue('general', 'parallelChunkCount'));
   // Ensure minimum of 1, default to 8 if invalid
-  const chunkCount = Math.max(0, Number.isFinite(val) ? val : 8);
+  const chunkCount = Math.max(1, Number.isFinite(val) ? val : 8);
   console.log('[direct] parallel chunk count:', chunkCount);
 
   // Coerce to safe positive integer, ensuring minimum of 1

--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -566,9 +566,12 @@ class Download {
         0,
         (effectivePartLimit ?? PARALLEL_CHUNK_COUNT) - activeRequestCount()
       );
-      const partsToStart = this.parts
-        .filter((p) => p.status === 'pending')
-        .slice(0, availableSlots);
+      // Start one part at a time so chunk fan-out cannot briefly exceed the
+      // parallel limit while multiple parts are still in HEAD/setup.
+      const partsToStart =
+        availableSlots > 0
+          ? this.parts.filter((p) => p.status === 'pending').slice(0, 1)
+          : [];
 
       if (partsToStart.length > 0) {
         console.log(

--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -114,6 +114,7 @@ interface PartState {
   useChunks: boolean;
   chunks: ChunkState[];
   chunkJobPath: string;
+  parallelLimit?: number; // Parsed OGI-Parallel-Limit for this part, if known
   effectiveChunkCount?: number; // Effective chunk count considering parallel limit
 }
 
@@ -142,6 +143,38 @@ const downloads = new Map<string, Download>();
 function average(values: number[]): number {
   if (values.length === 0) return 0;
   return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function getHeaderValue(
+  headers: Record<string, unknown> | undefined,
+  headerName: string
+): string | undefined {
+  if (!headers) return undefined;
+  const lowerHeaderName = headerName.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== lowerHeaderName) continue;
+    if (Array.isArray(value)) return String(value[0]);
+    if (value !== undefined && value !== null) return String(value);
+  }
+  return undefined;
+}
+
+function parseParallelLimitHeader(
+  headers: Record<string, unknown> | undefined
+): number | undefined {
+  const rawLimit = getHeaderValue(headers, 'OGI-Parallel-Limit');
+  if (!rawLimit) return undefined;
+  const limit = parseInt(rawLimit, 10);
+  return Number.isFinite(limit) && limit > 0 ? limit : undefined;
+}
+
+function mergeParallelLimits(
+  ...limits: Array<number | undefined>
+): number | undefined {
+  const validLimits = limits.filter(
+    (limit): limit is number => typeof limit === 'number' && limit > 0
+  );
+  return validLimits.length > 0 ? Math.min(...validLimits) : undefined;
 }
 
 function calculateBaselineSpeed(samples: number[]): number {
@@ -189,6 +222,7 @@ class Download {
   private useParallel: boolean = false;
   private chunks: ChunkState[] = [];
   private parallelTotalSize: number = 0;
+  private parallelLimit?: number;
   private currentJobPath: string = ''; // Track current job path for chunk file cleanup
 
   // Multi-part parallel download state
@@ -413,6 +447,7 @@ class Download {
 
       // Check if part file exists for resume
       let totalBytes = 0;
+      let knownPartParallelLimit = parseParallelLimitHeader(job.headers);
       if (fs.existsSync(job.path)) {
         downloadedBytes = fs.statSync(job.path).size;
         console.log(
@@ -423,15 +458,22 @@ class Download {
         try {
           const parallelInfo = await this.shouldUseParallelDownloadForPart(job);
           totalBytes = parallelInfo.fileSize;
+          knownPartParallelLimit = mergeParallelLimits(
+            knownPartParallelLimit,
+            parallelInfo.parallelLimit
+          );
 
           if (parallelInfo.fileSize > 0) {
             // For chunked downloads, check if merged file exists and is correct size
             if (parallelInfo.useParallel) {
               // Check if all chunk files exist and merged file is correct size
               // Use stored effectiveChunkCount if available, otherwise calculate
-              const effectiveChunkCount = parallelInfo.parallelLimit
-                ? Math.min(PARALLEL_CHUNK_COUNT, parallelInfo.parallelLimit)
-                : PARALLEL_CHUNK_COUNT;
+              const effectiveChunkCount =
+                mergeParallelLimits(
+                  PARALLEL_CHUNK_COUNT,
+                  parseParallelLimitHeader(job.headers),
+                  parallelInfo.parallelLimit
+                ) ?? PARALLEL_CHUNK_COUNT;
               const allChunksExist = Array.from(
                 { length: effectiveChunkCount },
                 (_, idx) => {
@@ -470,6 +512,7 @@ class Download {
         useChunks: false,
         chunks: [],
         chunkJobPath: '',
+        parallelLimit: knownPartParallelLimit,
         effectiveChunkCount: undefined,
       });
 
@@ -499,10 +542,21 @@ class Download {
         throw new Error('Download not active');
       }
 
-      // Start new parts if we have capacity
+      // Start new parts if we have capacity. Respect OGI-Parallel-Limit as a
+      // total connection cap for multipart downloads, not just a per-part chunk cap.
+      const knownParallelLimits = this.parts.map((part) =>
+        mergeParallelLimits(
+          part.parallelLimit,
+          parseParallelLimitHeader(part.job.headers)
+        )
+      );
+      const effectivePartLimit = mergeParallelLimits(
+        PARALLEL_CHUNK_COUNT,
+        ...knownParallelLimits
+      );
       const availableSlots = Math.max(
         1,
-        PARALLEL_CHUNK_COUNT - activeParts().length
+        (effectivePartLimit ?? PARALLEL_CHUNK_COUNT) - activeParts().length
       );
       const partsToStart = this.parts
         .filter((p) => p.status === 'pending')
@@ -567,6 +621,10 @@ class Download {
     // Check if this part should use chunk parallelization
     const parallelInfo = await this.shouldUseParallelDownloadForPart(job);
     part.totalBytes = parallelInfo.fileSize;
+    part.parallelLimit = mergeParallelLimits(
+      part.parallelLimit,
+      parallelInfo.parallelLimit
+    );
 
     // Update total bytes for progress calculation
     this.updateMultiPartTotalBytes();
@@ -688,19 +746,15 @@ class Download {
       const supportsRange = acceptRanges === 'bytes';
       console.log(job.headers);
 
-      // Parse OGI-Parallel-Limit header from response (case-insensitive)
-      const parallelLimitHeader =
-        headResponse.headers['ogi-parallel-limit'] ||
-        headResponse.headers['OGI-Parallel-Limit'];
-      const parallelLimit = parallelLimitHeader
-        ? parseInt(parallelLimitHeader as string, 10)
-        : undefined;
+      const parallelLimit = mergeParallelLimits(
+        parseParallelLimitHeader(job.headers),
+        parseParallelLimitHeader(headResponse.headers)
+      );
 
       const useParallel =
         supportsRange &&
         contentLength > PARALLEL_DOWNLOAD_THRESHOLD &&
-        !(job.headers && job.headers['OGI-Parallel-Limit'] === '1') && // If the link served has a parallel limit of 1, don't use it
-        !(parallelLimit === 1); // Also check response header
+        !(parallelLimit === 1);
 
       return {
         useParallel,
@@ -733,9 +787,13 @@ class Download {
 
     // Get parallel limit from the part's parallel info
     const parallelInfo = await this.shouldUseParallelDownloadForPart(job);
-    const effectiveChunkCount = parallelInfo.parallelLimit
-      ? Math.min(PARALLEL_CHUNK_COUNT, parallelInfo.parallelLimit)
-      : PARALLEL_CHUNK_COUNT;
+    part.parallelLimit = mergeParallelLimits(
+      part.parallelLimit,
+      parallelInfo.parallelLimit
+    );
+    const effectiveChunkCount =
+      mergeParallelLimits(PARALLEL_CHUNK_COUNT, part.parallelLimit) ??
+      PARALLEL_CHUNK_COUNT;
 
     // Store effective chunk count in part state for later use
     part.effectiveChunkCount = effectiveChunkCount;
@@ -1754,20 +1812,20 @@ class Download {
       const acceptRanges = headResponse.headers['accept-ranges'];
       const supportsRange = acceptRanges === 'bytes';
 
-      // Parse OGI-Parallel-Limit header from response (case-insensitive)
-      const parallelLimitHeader =
-        headResponse.headers['ogi-parallel-limit'] ||
-        headResponse.headers['OGI-Parallel-Limit'];
-      const parallelLimit = parallelLimitHeader
-        ? parseInt(parallelLimitHeader as string, 10)
-        : undefined;
+      const parallelLimit = mergeParallelLimits(
+        parseParallelLimitHeader(job.headers),
+        parseParallelLimitHeader(headResponse.headers)
+      );
+      this.parallelLimit = mergeParallelLimits(
+        this.parallelLimit,
+        parallelLimit
+      );
 
       const useParallel =
         supportsRange &&
         contentLength > PARALLEL_DOWNLOAD_THRESHOLD &&
         this.totalParts === 1 && // Only use parallel for single-file downloads
-        !(job.headers && job.headers['OGI-Parallel-Limit'] === '1') && // If the link served has a parallel limit of 1, don't use it
-        !(parallelLimit === 1); // Also check response header
+        !(parallelLimit === 1);
 
       console.log(
         `[direct] Parallel check: size=${(contentLength / (1024 * 1024 * 1024)).toFixed(2)}GB, ` +
@@ -1808,9 +1866,13 @@ class Download {
 
     // Get parallel limit from the parallel info
     const parallelInfo = await this.shouldUseParallelDownload(job);
-    const effectiveChunkCount = parallelInfo.parallelLimit
-      ? Math.min(PARALLEL_CHUNK_COUNT, parallelInfo.parallelLimit)
-      : PARALLEL_CHUNK_COUNT;
+    this.parallelLimit = mergeParallelLimits(
+      this.parallelLimit,
+      parallelInfo.parallelLimit
+    );
+    const effectiveChunkCount =
+      mergeParallelLimits(PARALLEL_CHUNK_COUNT, this.parallelLimit) ??
+      PARALLEL_CHUNK_COUNT;
 
     // Calculate chunk sizes
     const chunkSize = Math.ceil(fileSize / effectiveChunkCount);
@@ -2080,9 +2142,13 @@ class Download {
 
     // Get effective chunk count for this job
     const parallelInfo = await this.shouldUseParallelDownload(job);
-    const effectiveChunkCount = parallelInfo.parallelLimit
-      ? Math.min(PARALLEL_CHUNK_COUNT, parallelInfo.parallelLimit)
-      : PARALLEL_CHUNK_COUNT;
+    this.parallelLimit = mergeParallelLimits(
+      this.parallelLimit,
+      parallelInfo.parallelLimit
+    );
+    const effectiveChunkCount =
+      mergeParallelLimits(PARALLEL_CHUNK_COUNT, this.parallelLimit) ??
+      PARALLEL_CHUNK_COUNT;
 
     // Create the final file write stream
     const finalStream = fs.createWriteStream(job.path, { flags: 'w' });

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -858,7 +858,7 @@ app.on('window-all-closed', async function () {
 
     if (isAddonServerListening) {
       console.log('Stopping addon server...');
-      stopAddonServer();
+      await stopAddonServer();
     }
   } catch (error) {
     console.error('Error during cleanup:', error);

--- a/application/src/electron/server/addon-server.ts
+++ b/application/src/electron/server/addon-server.ts
@@ -67,11 +67,14 @@ function startAddonServer() {
   return addonServerStarting;
 }
 
-function stopAddonServer() {
+async function stopAddonServer(): Promise<void> {
+  if (addonServerStarting) {
+    await addonServerStarting;
+  }
   if (!isAddonServerListening) {
     return;
   }
-  addonServer.stop();
+  await addonServer.stop();
   isAddonServerListening = false;
 }
 

--- a/application/src/electron/server/addon-server.ts
+++ b/application/src/electron/server/addon-server.ts
@@ -19,18 +19,22 @@ if (existsSync(join(__dirname, 'config/option/developer.json'))) {
   }
 }
 
-const addonServer = new AddonServer({
-  port,
-  securityCheck: isSecurityCheckEnabled,
-});
-
-addonServer.on('disconnect', (reason) => {
-  addonServer.emit('notification', {
-    type: 'error',
-    message: reason,
-    id: 'addon-disconnect-' + Math.random().toString(36).substring(7),
+function createAddonServer() {
+  const server = new AddonServer({
+    port,
+    securityCheck: isSecurityCheckEnabled,
   });
-});
+  server.on('disconnect', (reason) => {
+    server.emit('notification', {
+      type: 'error',
+      message: reason,
+      id: 'addon-disconnect-' + Math.random().toString(36).substring(7),
+    });
+  });
+  return server;
+}
+
+let addonServer = createAddonServer();
 
 let addonServerStarting: Promise<void> | null = null;
 let isAddonServerListening = false;
@@ -42,6 +46,8 @@ function startAddonServer() {
   if (addonServerStarting) {
     return addonServerStarting;
   }
+
+  addonServer = createAddonServer();
 
   addonServerStarting = new Promise<void>((resolve, reject) => {
     const onStart = () => {

--- a/packages/addon-server/lib/server.ts
+++ b/packages/addon-server/lib/server.ts
@@ -202,7 +202,8 @@ export class AddonServer {
     req: http.IncomingMessage,
     res: http.ServerResponse
   ): void {
-    if (req.url === '/health') {
+    const pathname = req.url?.split('?')[0]?.replace(/\/+$/, '') ?? '';
+    if (pathname === '/health') {
       res.statusCode = 200;
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify({ status: 'ok' }));

--- a/packages/addon-server/lib/server.ts
+++ b/packages/addon-server/lib/server.ts
@@ -133,6 +133,7 @@ export class AddonServer {
       this.server.removeListener('upgrade', this.upgradeListener);
       this.upgradeListener = undefined;
     }
+    this.server.removeListener('request', this.healthHandler);
     this.connections.forEach((connection) => {
       connection.ws.close();
     });
@@ -181,6 +182,17 @@ export class AddonServer {
     })();
   }
 
+  private healthHandler(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): void {
+    if (req.url === '/health') {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ status: 'ok' }));
+    }
+  }
+
   public async start(): Promise<void> {
     if (this.upgradeListener) {
       this.server.removeListener('upgrade', this.upgradeListener);
@@ -195,13 +207,7 @@ export class AddonServer {
     };
     this.server.on('upgrade', this.upgradeListener);
     // add a health endpoint
-    this.server.on('request', (req, res) => {
-      if (req.url === '/health') {
-        res.statusCode = 200;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ status: 'ok' }));
-      }
-    });
+    this.server.on('request', this.healthHandler);
 
     this.server.listen(this.config.port, () => {
       this.eventEmitter.emit('start');

--- a/packages/addon-server/lib/server.ts
+++ b/packages/addon-server/lib/server.ts
@@ -36,6 +36,10 @@ export class AddonServer {
     socket: import('node:stream').Duplex,
     head: Buffer
   ) => void;
+  private healthListener?: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ) => void;
 
   private deferredTasksManager: DeferredTasksManager =
     new DeferredTasksManager();
@@ -133,7 +137,10 @@ export class AddonServer {
       this.server.removeListener('upgrade', this.upgradeListener);
       this.upgradeListener = undefined;
     }
-    this.server.removeListener('request', this.healthHandler);
+    if (this.healthListener) {
+      this.server.removeListener('request', this.healthListener);
+      this.healthListener = undefined;
+    }
     this.connections.forEach((connection) => {
       connection.ws.close();
     });
@@ -198,6 +205,10 @@ export class AddonServer {
       this.server.removeListener('upgrade', this.upgradeListener);
       this.upgradeListener = undefined;
     }
+    if (this.healthListener) {
+      this.server.removeListener('request', this.healthListener);
+      this.healthListener = undefined;
+    }
     this.wss?.close();
     this.wss = new WebSocketServer({ noServer: true });
     this.upgradeListener = (req, socket, head) => {
@@ -206,8 +217,14 @@ export class AddonServer {
       });
     };
     this.server.on('upgrade', this.upgradeListener);
-    // add a health endpoint
-    this.server.on('request', this.healthHandler);
+    this.healthListener = (req, res) => {
+      if (req.url === '/health') {
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ status: 'ok' }));
+      }
+    };
+    this.server.on('request', this.healthListener);
 
     this.server.listen(this.config.port, () => {
       this.eventEmitter.emit('start');

--- a/packages/addon-server/lib/server.ts
+++ b/packages/addon-server/lib/server.ts
@@ -132,7 +132,7 @@ export class AddonServer {
     return this.config.secret;
   }
 
-  public stop(): void {
+  public stop(): Promise<void> {
     if (this.upgradeListener) {
       this.server.removeListener('upgrade', this.upgradeListener);
       this.upgradeListener = undefined;
@@ -150,12 +150,21 @@ export class AddonServer {
     this.sdkConnections.forEach((connection) => {
       connection.close();
     });
-    this.wss?.close();
+    const closeWebSocketServer = this.wss
+      ? new Promise<void>((resolve, reject) => {
+          this.wss!.close((error) => (error ? reject(error) : resolve()));
+        })
+      : Promise.resolve();
     this.wss = undefined;
-    this.server.close();
+    const closeHttpServer = new Promise<void>((resolve, reject) => {
+      this.server.close((error) => (error ? reject(error) : resolve()));
+    });
     this.connections.clear();
     this.sdkConnections.clear();
     this.clients.clear();
+    return Promise.all([closeWebSocketServer, closeHttpServer]).then(
+      () => undefined
+    );
   }
 
   private handleWebSocketConnection(
@@ -217,13 +226,7 @@ export class AddonServer {
       });
     };
     this.server.on('upgrade', this.upgradeListener);
-    this.healthListener = (req, res) => {
-      if (req.url === '/health') {
-        res.statusCode = 200;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ status: 'ok' }));
-      }
-    };
+    this.healthListener = this.healthHandler.bind(this);
     this.server.on('request', this.healthListener);
 
     this.server.listen(this.config.port, () => {

--- a/packages/addon-server/lib/server.ts
+++ b/packages/addon-server/lib/server.ts
@@ -194,6 +194,14 @@ export class AddonServer {
       });
     };
     this.server.on('upgrade', this.upgradeListener);
+    // add a health endpoint
+    this.server.on('request', (req, res) => {
+      if (req.url === '/health') {
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ status: 'ok' }));
+      }
+    });
 
     this.server.listen(this.config.port, () => {
       this.eventEmitter.emit('start');


### PR DESCRIPTION
fixes issues with the downloader not including parallel limits and addon server restarts blocking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint for the addon server to confirm when it is ready.
  * Improved download handling to better respect server and request parallelism limits.

* **Bug Fixes**
  * Made addon server restarts more reliable with retry-based readiness checks.
  * Improved download concurrency behavior for both single-part and multi-part downloads, including resumed downloads.

* **Refactor**
  * Updated server startup and shutdown handling to be more consistent and resilient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->