### PR TITLE
Fix: remove stray console.log leaking job.headers in ddl parallel download

### DIFF
--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -758,7 +758,6 @@ class Download {
         : 0;
       const acceptRanges = headResponse.headers['accept-ranges'];
       const supportsRange = acceptRanges === 'bytes';
-      console.log(job.headers);
 
       const parallelLimit = mergeParallelLimits(
         parseParallelLimitHeader(job.headers),


### PR DESCRIPTION
Closes #186