### PR TITLE
fix(addon-server): return string from getSecret instead of Effect

### DIFF
--- a/application/src/electron/manager/manager.addon.ts
+++ b/application/src/electron/manager/manager.addon.ts
@@ -39,11 +39,7 @@ export class Addon extends ExecutorAddon {
       ).pipe(
         Effect.mapError((cause) => new AddonLoadError({ addonName, cause }))
       );
-      const secret = yield* addonServer
-        .getSecret()
-        .pipe(
-          Effect.mapError((cause) => new AddonLoadError({ addonName, cause }))
-        );
+      const secret = addonServer.getSecret();
       return new Addon({
         port,
         secret,

--- a/application/src/frontend/lib/core/ipc.ts
+++ b/application/src/frontend/lib/core/ipc.ts
@@ -9,38 +9,30 @@ export async function connectClientSdk(): Promise<Connection> {
   const developerConfig = getConfigClientOption('developer') as {
     clientSdkUrl?: string;
   } | null;
-  const server = await Effect.runPromise(
-    Connection.make({
-      url: developerConfig?.clientSdkUrl ?? 'ws://127.0.0.1:7654',
-    })
-  );
+  const server = await Connection.make({
+    url: developerConfig?.clientSdkUrl ?? 'ws://127.0.0.1:7654',
+  });
   initialize(server);
   return server;
 }
 
 export let addonServer = await connectClientSdk();
 
-export function queryConnectedAddons<T = AddonInfo>(): Promise<T[]> {
-  return Effect.runPromise(
-    Effect.gen(function* () {
-      const response = yield* addonServer.request('query-connected-addons', {
-        type: 'addons',
-      });
-      if (response.statusError) {
-        return yield* Effect.fail(
-          new AddonError({ message: response.statusError })
-        );
-      }
-      return response.args.addons as T[];
-    })
-  );
+export async function queryConnectedAddons<T = AddonInfo>(): Promise<T[]> {
+  const response = await addonServer.request('query-connected-addons', {
+    type: 'addons',
+  });
+  if (response.statusError) {
+    throw new AddonError({ message: response.statusError });
+  }
+  return response.args.addons as T[];
 }
 
 let reconnectInFlight: Promise<void> | null = null;
 export async function reconnectClientSdk(): Promise<void> {
   if (reconnectInFlight) return reconnectInFlight;
   reconnectInFlight = (async () => {
-    await Effect.runPromise(addonServer.close());
+    await addonServer.close();
     addonServer = await connectClientSdk();
   })().finally(() => {
     reconnectInFlight = null;

--- a/application/src/frontend/lib/tasks/deferred.ts
+++ b/application/src/frontend/lib/tasks/deferred.ts
@@ -1,5 +1,4 @@
 import type { DeferredTaskSnapshot } from '@ogi-sdk/client-kit';
-import { Effect } from 'effect';
 import { addonServer } from '@/frontend/lib/core/ipc';
 import {
   type DeferredTask,
@@ -9,7 +8,7 @@ import {
 
 export async function loadDeferredTasks(tasksToRemove: string[] = []) {
   try {
-    const tasks = await Effect.runPromise(addonServer.getDeferredTasks());
+    const tasks = await addonServer.getDeferredTasks();
     deferredTasks.set(
       tasks
         .filter(

--- a/packages/addon-server/lib/server.ts
+++ b/packages/addon-server/lib/server.ts
@@ -1,4 +1,4 @@
-import { AddonError, NetworkError } from '@ogi/errors';
+import { NetworkError } from '@ogi/errors';
 import type {
   AddonNotificationMessage,
   AddonServerHostEventListeners,
@@ -120,12 +120,8 @@ export class AddonServer {
     return this;
   }
 
-  public getSecret(): Effect.Effect<string, AddonError> {
-    return this.config.secret
-      ? Effect.succeed(this.config.secret)
-      : Effect.fail(
-          new AddonError({ message: 'Addon server secret is not configured' })
-        );
+  public getSecret(): string {
+    return this.config.secret ?? '';
   }
 
   public stop(): Effect.Effect<void, NetworkError> {

--- a/packages/client-kit/lib/connection.ts
+++ b/packages/client-kit/lib/connection.ts
@@ -119,19 +119,35 @@ export class Connection {
             }),
         });
         const eventPubSub = yield* PubSub.unbounded<ConnectionEvent>();
-        const transport = yield* EventResponseSocket.make<
-          AddonServerToClientSDKIncomingMessage,
-          AddonClientSDKToServerIncomingMessage
-        >(socket, {
-          onInvalidMessage: () =>
-            Effect.sync(() => {
-              console.error('Failed to parse websocket message');
-              socket.close(1008, 'Invalid JSON message');
-            }),
-        });
-        const connection = new Connection(socket, transport, eventPubSub);
-        yield* connection.connect();
-        return connection;
+        return yield* Effect.gen(function* () {
+          const transport = yield* EventResponseSocket.make<
+            AddonServerToClientSDKIncomingMessage,
+            AddonClientSDKToServerIncomingMessage
+          >(socket, {
+            onInvalidMessage: () =>
+              Effect.sync(() => {
+                console.error('Failed to parse websocket message');
+                socket.close(1008, 'Invalid JSON message');
+              }),
+          });
+          const connection = new Connection(socket, transport, eventPubSub);
+          yield* connection.connect();
+          return connection;
+        }).pipe(
+          Effect.catchAll((error) =>
+            Effect.gen(function* () {
+              yield* PubSub.shutdown(eventPubSub);
+              yield* Effect.sync(() => {
+                try {
+                  socket.close();
+                } catch {
+                  // Preserve the original connection error if closing fails.
+                }
+              });
+              return yield* Effect.fail(error);
+            })
+          )
+        );
       })
     );
   }
@@ -349,7 +365,16 @@ export class Connection {
     const interval = options.interval ?? 50;
     return Effect.gen(this, function* () {
       while (true) {
-        const task = yield* this.getDeferredTaskEffect<T>(taskID);
+        const task = yield* this.getDeferredTaskEffect<T>(taskID).pipe(
+          Effect.catchAll((error) =>
+            Effect.gen(function* () {
+              if (options.onFailed) {
+                yield* asEffect(options.onFailed(error.message));
+              }
+              return yield* Effect.fail(error);
+            })
+          )
+        );
         if (!task) {
           const message = 'Task not found';
           if (options.onFailed) yield* asEffect(options.onFailed(message));

--- a/packages/client-kit/lib/connection.ts
+++ b/packages/client-kit/lib/connection.ts
@@ -119,8 +119,14 @@ export class Connection {
             }),
         });
         const eventPubSub = yield* PubSub.unbounded<ConnectionEvent>();
+        let transport:
+          | EventResponseSocket<
+              AddonServerToClientSDKIncomingMessage,
+              AddonClientSDKToServerIncomingMessage
+            >
+          | undefined;
         return yield* Effect.gen(function* () {
-          const transport = yield* EventResponseSocket.make<
+          transport = yield* EventResponseSocket.make<
             AddonServerToClientSDKIncomingMessage,
             AddonClientSDKToServerIncomingMessage
           >(socket, {
@@ -136,6 +142,11 @@ export class Connection {
         }).pipe(
           Effect.catchAll((error) =>
             Effect.gen(function* () {
+              if (transport) {
+                yield* transport
+                  .shutdown('Connection failed')
+                  .pipe(Effect.ignore);
+              }
               yield* PubSub.shutdown(eventPubSub);
               yield* Effect.sync(() => {
                 try {

--- a/packages/client-kit/lib/connection.ts
+++ b/packages/client-kit/lib/connection.ts
@@ -80,7 +80,7 @@ type GenericRequestName = Exclude<SDKRequestName, 'forward'>;
 
 export type ConnectionError = NetworkError | ValidationError;
 
-/** Effect-based client SDK connection. */
+/** Client SDK connection. */
 export class Connection {
   private readonly connectedAddonInfo = new Map<string, ConnectedAddonInfo>();
 
@@ -94,43 +94,45 @@ export class Connection {
   ) {}
 
   /** Creates a connected SDK client and installs its message stream consumers. */
-  public static make(
-    options: ConnectionOptions
-  ): Effect.Effect<Connection, ConnectionError> {
-    return Effect.gen(function* () {
-      const WebSocketImplementation =
-        options.webSocket ??
-        (globalThis as { WebSocket?: WebSocketConstructor }).WebSocket;
-      if (!WebSocketImplementation) {
-        return yield* Effect.fail(
-          new NetworkError({ message: 'No WebSocket implementation available' })
-        );
-      }
+  public static make(options: ConnectionOptions): Promise<Connection> {
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const WebSocketImplementation =
+          options.webSocket ??
+          (globalThis as { WebSocket?: WebSocketConstructor }).WebSocket;
+        if (!WebSocketImplementation) {
+          return yield* Effect.fail(
+            new NetworkError({
+              message: 'No WebSocket implementation available',
+            })
+          );
+        }
 
-      const url = yield* Connection.getSDKUrl(options.url);
-      const socket = yield* Effect.try({
-        try: () => new WebSocketImplementation(url),
-        catch: (cause) =>
-          new NetworkError({
-            message: `Unable to create WebSocket: ${String(cause)}`,
-            url,
-          }),
-      });
-      const eventPubSub = yield* PubSub.unbounded<ConnectionEvent>();
-      const transport = yield* EventResponseSocket.make<
-        AddonServerToClientSDKIncomingMessage,
-        AddonClientSDKToServerIncomingMessage
-      >(socket, {
-        onInvalidMessage: () =>
-          Effect.sync(() => {
-            console.error('Failed to parse websocket message');
-            socket.close(1008, 'Invalid JSON message');
-          }),
-      });
-      const connection = new Connection(socket, transport, eventPubSub);
-      yield* connection.connect();
-      return connection;
-    });
+        const url = yield* Connection.getSDKUrl(options.url);
+        const socket = yield* Effect.try({
+          try: () => new WebSocketImplementation(url),
+          catch: (cause) =>
+            new NetworkError({
+              message: `Unable to create WebSocket: ${String(cause)}`,
+              url,
+            }),
+        });
+        const eventPubSub = yield* PubSub.unbounded<ConnectionEvent>();
+        const transport = yield* EventResponseSocket.make<
+          AddonServerToClientSDKIncomingMessage,
+          AddonClientSDKToServerIncomingMessage
+        >(socket, {
+          onInvalidMessage: () =>
+            Effect.sync(() => {
+              console.error('Failed to parse websocket message');
+              socket.close(1008, 'Invalid JSON message');
+            }),
+        });
+        const connection = new Connection(socket, transport, eventPubSub);
+        yield* connection.connect();
+        return connection;
+      })
+    );
   }
 
   /**
@@ -144,7 +146,7 @@ export class Connection {
     return createAddonProxy(
       addonId,
       (targetAddonId, event, ...args) =>
-        Effect.runPromise(this.sendToAddon(targetAddonId, event, ...args)),
+        this.sendToAddon(targetAddonId, event, ...args),
       this.createDeferToAddon(deferredOptions),
       (id) => this.connectedAddonInfo.get(id)
     );
@@ -154,122 +156,41 @@ export class Connection {
     addonId: string,
     event: Event,
     ...args: AddonServerToClientEventArgs[Event]
-  ): Effect.Effect<AddonForwardResponseMessage<Event>, ConnectionError> {
-    return this.transport
-      .send(
-        {
-          event: 'forward',
-          args: { addonId, event, args },
-        } as AddonClientSDKToServerWebsocketMessage<'forward', Event>,
-        { expectResponse: true, responseEvent: 'forward-response' }
-      )
-      .pipe(
-        Effect.map((response) => response as AddonForwardResponseMessage<Event>)
-      );
+  ): Promise<AddonForwardResponseMessage<Event>> {
+    return Effect.runPromise(this.sendToAddonEffect(addonId, event, ...args));
   }
 
   public request<Name extends GenericRequestName>(
     name: Name,
     args: SDKRequest<Name>
-  ): Effect.Effect<SDKResponseMessage<Name>, ConnectionError> {
-    return Effect.gen(this, function* () {
-      const response = (yield* this.transport.send(
-        {
-          event: name,
-          args,
-        } as AddonClientSDKToServerIncomingMessage,
-        { expectResponse: true, responseEvent: 'response' }
-      )) as SDKResponseMessage<Name>;
-
-      if (name === 'query-connected-addons' && !response.statusError) {
-        const addons = (
-          response as SDKResponseMessage<'query-connected-addons'>
-        ).args.addons;
-        for (const addon of addons) {
-          this.connectedAddonInfo.set(addon.id, addon);
-        }
-      }
-      return response;
-    });
+  ): Promise<SDKResponseMessage<Name>> {
+    return Effect.runPromise(this.requestEffect(name, args));
   }
 
   public deferToAddon<Event extends AddonServerToClientEventName>(
     addonId: string,
     event: Event,
     ...args: AddonServerToClientEventArgs[Event]
-  ): Effect.Effect<string, ConnectionError> {
-    return Effect.gen(this, function* () {
-      const response = yield* this.request('defer-forward', {
-        addonId,
-        event,
-        args,
-      });
-      if (response.statusError) {
-        return yield* Effect.fail(
-          new NetworkError({ message: response.statusError })
-        );
-      }
-      return response.args.taskID;
-    });
+  ): Promise<string> {
+    return Effect.runPromise(this.deferToAddonEffect(addonId, event, ...args));
   }
 
   public getDeferredTask<T = unknown>(
     taskID: string
-  ): Effect.Effect<DeferredTaskSnapshot<T> | undefined, ConnectionError> {
-    return Effect.gen(this, function* () {
-      const response = yield* this.request('get-deferred-task', { taskID });
-      if (response.statusError) {
-        return yield* Effect.fail(
-          new NetworkError({ message: response.statusError })
-        );
-      }
-      return response.args.task as DeferredTaskSnapshot<T> | undefined;
-    });
+  ): Promise<DeferredTaskSnapshot<T> | undefined> {
+    return Effect.runPromise(this.getDeferredTaskEffect<T>(taskID));
   }
 
-  public getDeferredTasks(): Effect.Effect<
-    DeferredTaskSnapshot[],
-    ConnectionError
-  > {
-    return Effect.gen(this, function* () {
-      const response = yield* this.request('get-deferred-tasks', {});
-      if (response.statusError) {
-        return yield* Effect.fail(
-          new NetworkError({ message: response.statusError })
-        );
-      }
-      return response.args.tasks as DeferredTaskSnapshot[];
-    });
+  public getDeferredTasks(): Promise<DeferredTaskSnapshot[]> {
+    return Effect.runPromise(this.getDeferredTasksEffect());
   }
 
-  /** Polls a deferred task without timers or Promise constructors. */
+  /** Polls a deferred task until it resolves. */
   public waitForDeferredTask<T = unknown>(
     taskID: string,
     options: DeferredTaskOptions<T> = {}
-  ): Effect.Effect<T | undefined, ConnectionError> {
-    const interval = options.interval ?? 50;
-    return Effect.gen(this, function* () {
-      while (true) {
-        const task = yield* this.getDeferredTask<T>(taskID);
-        if (!task) {
-          const message = 'Task not found';
-          if (options.onFailed) yield* asEffect(options.onFailed(message));
-          return yield* Effect.fail(new NetworkError({ message }));
-        }
-
-        if (options.onProgress) {
-          yield* asEffect(options.onProgress(task.progress, task));
-        }
-        if (options.onLogs) yield* asEffect(options.onLogs(task.logs, task));
-
-        if (task.failed) {
-          if (options.onFailed) yield* asEffect(options.onFailed(task.failed));
-          return yield* Effect.fail(new NetworkError({ message: task.failed }));
-        }
-        if (task.resolved) return task.data;
-        yield* Effect.sleep(interval);
-      }
-    });
+  ): Promise<T | undefined> {
+    return Effect.runPromise(this.waitForDeferredTaskEffect(taskID, options));
   }
 
   public deferToAddonAndWait<
@@ -280,11 +201,13 @@ export class Connection {
     event: Event,
     args: AddonServerToClientEventArgs[Event],
     options: DeferredTaskOptions<T> = {}
-  ): Effect.Effect<T | undefined, ConnectionError> {
-    return Effect.gen(this, function* () {
-      const taskID = yield* this.deferToAddon(addonId, event, ...args);
-      return yield* this.waitForDeferredTask<T>(taskID, options);
-    });
+  ): Promise<T | undefined> {
+    return Effect.runPromise(
+      Effect.gen(this, function* () {
+        const taskID = yield* this.deferToAddonEffect(addonId, event, ...args);
+        return yield* this.waitForDeferredTaskEffect<T>(taskID, options);
+      })
+    );
   }
 
   /** Stream of one SDK event with its event-specific argument type. */
@@ -311,15 +234,140 @@ export class Connection {
     );
   }
 
-  public close(): Effect.Effect<void, NetworkError> {
+  public close(): Promise<void> {
+    return Effect.runPromise(
+      Effect.gen(this, function* () {
+        yield* PubSub.shutdown(this.eventPubSub);
+        yield* this.transport.shutdown('Connection closed');
+      })
+    );
+  }
+
+  public dispose(): Promise<void> {
+    return this.close();
+  }
+
+  private sendToAddonEffect<Event extends AddonServerToClientEventName>(
+    addonId: string,
+    event: Event,
+    ...args: AddonServerToClientEventArgs[Event]
+  ): Effect.Effect<AddonForwardResponseMessage<Event>, ConnectionError> {
+    return this.transport
+      .send(
+        {
+          event: 'forward',
+          args: { addonId, event, args },
+        } as AddonClientSDKToServerWebsocketMessage<'forward', Event>,
+        { expectResponse: true, responseEvent: 'forward-response' }
+      )
+      .pipe(
+        Effect.map((response) => response as AddonForwardResponseMessage<Event>)
+      );
+  }
+
+  private requestEffect<Name extends GenericRequestName>(
+    name: Name,
+    args: SDKRequest<Name>
+  ): Effect.Effect<SDKResponseMessage<Name>, ConnectionError> {
     return Effect.gen(this, function* () {
-      yield* PubSub.shutdown(this.eventPubSub);
-      yield* this.transport.shutdown('Connection closed');
+      const response = (yield* this.transport.send(
+        {
+          event: name,
+          args,
+        } as AddonClientSDKToServerIncomingMessage,
+        { expectResponse: true, responseEvent: 'response' }
+      )) as SDKResponseMessage<Name>;
+
+      if (name === 'query-connected-addons' && !response.statusError) {
+        const addons = (
+          response as SDKResponseMessage<'query-connected-addons'>
+        ).args.addons;
+        for (const addon of addons) {
+          this.connectedAddonInfo.set(addon.id, addon);
+        }
+      }
+      return response;
     });
   }
 
-  public dispose(): Effect.Effect<void, NetworkError> {
-    return this.close();
+  private deferToAddonEffect<Event extends AddonServerToClientEventName>(
+    addonId: string,
+    event: Event,
+    ...args: AddonServerToClientEventArgs[Event]
+  ): Effect.Effect<string, ConnectionError> {
+    return Effect.gen(this, function* () {
+      const response = yield* this.requestEffect('defer-forward', {
+        addonId,
+        event,
+        args,
+      });
+      if (response.statusError) {
+        return yield* Effect.fail(
+          new NetworkError({ message: response.statusError })
+        );
+      }
+      return response.args.taskID;
+    });
+  }
+
+  private getDeferredTaskEffect<T = unknown>(
+    taskID: string
+  ): Effect.Effect<DeferredTaskSnapshot<T> | undefined, ConnectionError> {
+    return Effect.gen(this, function* () {
+      const response = yield* this.requestEffect('get-deferred-task', {
+        taskID,
+      });
+      if (response.statusError) {
+        return yield* Effect.fail(
+          new NetworkError({ message: response.statusError })
+        );
+      }
+      return response.args.task as DeferredTaskSnapshot<T> | undefined;
+    });
+  }
+
+  private getDeferredTasksEffect(): Effect.Effect<
+    DeferredTaskSnapshot[],
+    ConnectionError
+  > {
+    return Effect.gen(this, function* () {
+      const response = yield* this.requestEffect('get-deferred-tasks', {});
+      if (response.statusError) {
+        return yield* Effect.fail(
+          new NetworkError({ message: response.statusError })
+        );
+      }
+      return response.args.tasks as DeferredTaskSnapshot[];
+    });
+  }
+
+  private waitForDeferredTaskEffect<T = unknown>(
+    taskID: string,
+    options: DeferredTaskOptions<T> = {}
+  ): Effect.Effect<T | undefined, ConnectionError> {
+    const interval = options.interval ?? 50;
+    return Effect.gen(this, function* () {
+      while (true) {
+        const task = yield* this.getDeferredTaskEffect<T>(taskID);
+        if (!task) {
+          const message = 'Task not found';
+          if (options.onFailed) yield* asEffect(options.onFailed(message));
+          return yield* Effect.fail(new NetworkError({ message }));
+        }
+
+        if (options.onProgress) {
+          yield* asEffect(options.onProgress(task.progress, task));
+        }
+        if (options.onLogs) yield* asEffect(options.onLogs(task.logs, task));
+
+        if (task.failed) {
+          if (options.onFailed) yield* asEffect(options.onFailed(task.failed));
+          return yield* Effect.fail(new NetworkError({ message: task.failed }));
+        }
+        if (task.resolved) return task.data;
+        yield* Effect.sleep(interval);
+      }
+    });
   }
 
   private connect(): Effect.Effect<void, NetworkError> {
@@ -425,7 +473,7 @@ export class Connection {
     ): Promise<AddonForwardResponse<Event>['args']> =>
       Effect.runPromise(
         Effect.gen(this, function* () {
-          const taskID = yield* this.deferToAddon(
+          const taskID = yield* this.deferToAddonEffect(
             targetAddonId,
             event,
             ...args
@@ -433,7 +481,7 @@ export class Connection {
           if (deferredOptions.onTaskStarted) {
             yield* asEffect(deferredOptions.onTaskStarted(taskID));
           }
-          const result = yield* this.waitForDeferredTask<
+          const result = yield* this.waitForDeferredTaskEffect<
             AddonForwardResponse<Event>['args']
           >(
             taskID,

--- a/packages/client-kit/lib/connection.ts
+++ b/packages/client-kit/lib/connection.ts
@@ -15,6 +15,7 @@ import type {
   WebSocketLike,
 } from '@ogi-sdk/connect';
 import { EventResponseSocket } from '@ogi-sdk/connect';
+import type { Cause } from 'effect';
 import { Effect, Fiber, PubSub, Stream } from 'effect';
 import type {
   AddonForwardResponseMessage,
@@ -41,28 +42,28 @@ export type DeferredTaskSnapshot<T = unknown> = {
   readonly resolved: boolean;
 };
 
-type MaybeEffect = Effect.Effect<void> | void;
-const asEffect = (value: MaybeEffect): Effect.Effect<void> =>
-  Effect.isEffect(value) ? value : Effect.void;
+type MaybePromise = void | Promise<void>;
+const asEffect = (value: MaybePromise) =>
+  value === undefined ? Effect.void : Effect.tryPromise(() => value);
 
 export type DeferredTaskOptions<T = unknown> = {
   readonly interval?: number;
-  readonly onTaskStarted?: (taskID: string) => MaybeEffect;
+  readonly onTaskStarted?: (taskID: string) => MaybePromise;
   readonly onProgress?: (
     progress: number,
     task: DeferredTaskSnapshot<T>
-  ) => MaybeEffect;
+  ) => MaybePromise;
   readonly onLogs?: (
     logs: string[],
     task: DeferredTaskSnapshot<T>
-  ) => MaybeEffect;
-  readonly onFailed?: (error: string) => MaybeEffect;
+  ) => MaybePromise;
+  readonly onFailed?: (error: string) => MaybePromise;
 };
 
 type InputAskedArgs = AddonServerToClientSDKEventArgs['input-asked'] & {
   readonly reply: (
     result: Record<string, string | number | boolean>
-  ) => Effect.Effect<void, ConnectionError>;
+  ) => Promise<void>;
 };
 
 type SDKEventArgs<Event extends AddonServerToClientSDKEvent> =
@@ -344,7 +345,7 @@ export class Connection {
   private waitForDeferredTaskEffect<T = unknown>(
     taskID: string,
     options: DeferredTaskOptions<T> = {}
-  ): Effect.Effect<T | undefined, ConnectionError> {
+  ): Effect.Effect<T | undefined, ConnectionError | Cause.UnknownException> {
     const interval = options.interval ?? 50;
     return Effect.gen(this, function* () {
       while (true) {
@@ -387,16 +388,18 @@ export class Connection {
           args: {
             ...message.args,
             reply: (result: Record<string, string | number | boolean>) =>
-              this.transport
-                .send(
-                  {
-                    event: 'input-response',
-                    id,
-                    args: result,
-                  } as AddonClientSDKToServerIncomingMessage,
-                  { expectResponse: false }
-                )
-                .pipe(Effect.asVoid),
+              Effect.runPromise(
+                this.transport
+                  .send(
+                    {
+                      event: 'input-response',
+                      id,
+                      args: result,
+                    } as AddonClientSDKToServerIncomingMessage,
+                    { expectResponse: false }
+                  )
+                  .pipe(Effect.asVoid)
+              ),
           } satisfies InputAskedArgs,
         }).pipe(Effect.asVoid);
       });


### PR DESCRIPTION
## Summary
- return the initialized addon server secret as a plain string
- update the addon manager caller to stop yielding the secret as an Effect
- ensure URL concatenation receives the UUID instead of `[object Object]`

## Validation
- `tsc --noEmit -p packages/addon-server/tsconfig.json`
- `tsc -p application/src/electron/tsconfig.json --noEmit`
- `biome check packages/addon-server/lib/server.ts application/src/electron/manager/manager.addon.ts --files-ignore-unknown=true`

Closes #193