### PR TITLE
fix(security): fix path traversal bypass and wrong variable in error log

### DIFF
--- a/application/src/electron/handlers/handler.app.ts
+++ b/application/src/electron/handlers/handler.app.ts
@@ -252,14 +252,14 @@ export default function handler(mainWindow: Electron.BrowserWindow) {
     try {
       realPath = fs.realpathSync(requestPath);
     } catch (err) {
-      console.error('Failed to resolve real path:', path, err);
+      console.error('Failed to resolve real path:', requestPath, err);
       return null;
     }
 
     // Normalize paths for comparison
     const normalizedRealPath = realPath.replace(/\\/g, '/');
     const isAllowed = allowedDirs.some((allowedDir) => {
-      const normalizedAllowed = allowedDir.replace(/\\/g, '/');
+      const normalizedAllowed = `${allowedDir.replace(/\\/g, '/').replace(/\/+$/, '')}/`;
       return normalizedRealPath.startsWith(normalizedAllowed);
     });
 


### PR DESCRIPTION
## Summary
- require an allowed-directory path separator before matching local image paths
- log the requested image path when realpath resolution fails

## Validation
- `bun run lint` *(fails on pre-existing formatting/import issues in unrelated files)*
- targeted Biome check passes for `application/src/electron/handlers/handler.app.ts`

Closes #202 and Closes #203