### PR TITLE
fix(downloader): respect server parallel limits and clean retries

### DIFF
--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -215,7 +215,7 @@ function calculateBaselineSpeed(samples: number[]): number {
   return average(positiveSamples.slice(0, baselineSampleCount));
 }
 
-class Download {
+export class Download {
   public id: string;
   private _status: DownloadStatus = 'queued';
 
@@ -270,6 +270,22 @@ class Download {
 
     downloads.set(this.id, this);
     registerDownloadHandshake(this.id);
+  }
+
+  private observeParallelLimit(
+    headers: Record<string, unknown> | undefined,
+    part?: PartState
+  ): void {
+    const observedLimit = parseParallelLimitHeader(headers);
+    if (observedLimit === undefined) return;
+
+    this.parallelLimit = mergeParallelLimits(this.parallelLimit, observedLimit);
+    if (part) {
+      part.parallelLimit = mergeParallelLimits(
+        part.parallelLimit,
+        observedLimit
+      );
+    }
   }
 
   private reportHandshake(
@@ -632,9 +648,12 @@ class Download {
       this.startMultiPartProgressTracker();
 
       // Process parts in batches
-      const pendingParts = () =>
+      const unfinishedParts = () =>
         this.parts.filter(
-          (p) => p.status === 'pending' || p.status === 'downloading'
+          (p) =>
+            p.status === 'pending' ||
+            p.status === 'downloading' ||
+            p.status === 'merging'
         );
       const activeParts = () =>
         this.parts.filter((p) => p.status === 'downloading');
@@ -648,7 +667,7 @@ class Download {
       const completedParts = () =>
         this.parts.filter((p) => p.status === 'completed');
 
-      while (pendingParts().length > 0 || activeParts().length > 0) {
+      while (unfinishedParts().length > 0) {
         if (this.status !== 'downloading') {
           return yield* Effect.fail(
             new DownloadNotActive({ downloadId: this.id })
@@ -665,6 +684,7 @@ class Download {
         );
         const effectivePartLimit = mergeParallelLimits(
           PARALLEL_CHUNK_COUNT,
+          this.parallelLimit,
           ...knownParallelLimits
         );
         const availableSlots = Math.max(
@@ -785,6 +805,7 @@ class Download {
               new DownloadNotActive({ downloadId: this.id })
             );
           }
+          part.status = 'downloading';
           const attempt = yield* Effect.either(
             this.executeParallelDownloadForPart(part, parallelInfo.fileSize)
           );
@@ -798,6 +819,20 @@ class Download {
             `[direct] Part ${part.index + 1} chunk download attempt ${i} failed:`,
             lastError
           );
+          const failedChunkCount = part.effectiveChunkCount;
+          const nextChunkCount =
+            mergeParallelLimits(PARALLEL_CHUNK_COUNT, part.parallelLimit) ??
+            PARALLEL_CHUNK_COUNT;
+          // A failed attempt may have learned a stricter response limit. Its
+          // partial files use the old byte partition and cannot be resumed
+          // safely with the new count. Clear the whole failed layout even when
+          // the count is unchanged so corrupt chunks cannot poison every retry.
+          yield* this.deleteChunkFiles(
+            part.job.path,
+            Math.max(failedChunkCount ?? 0, nextChunkCount)
+          );
+          part.chunks = [];
+          part.effectiveChunkCount = nextChunkCount;
           if (lastError instanceof TooManyRequests) {
             console.log(
               `[direct] Part ${part.index + 1}: 429 detected, disabling chunk parallelization and retrying as standard download`
@@ -906,10 +941,49 @@ class Download {
         ? parseInt(String(headResponse.headers['content-length']), 10)
         : 0;
       const supportsRange = headResponse.headers['accept-ranges'] === 'bytes';
-      const parallelLimit = mergeParallelLimits(
+      let parallelLimit = mergeParallelLimits(
         parseParallelLimitHeader(job.headers),
         parseParallelLimitHeader(headResponse.headers)
       );
+
+      // Some hosts only send OGI-Parallel-Limit on GET responses. Probe one
+      // byte before chunk fan-out so that a GET-only cap is known before OGI
+      // opens all ranged connections.
+      if (
+        supportsRange &&
+        contentLength > PARALLEL_DOWNLOAD_THRESHOLD &&
+        parallelLimit !== 1
+      ) {
+        const probeResult = yield* Effect.either(
+          Effect.tryPromise({
+            try: () =>
+              axios.get<Readable>(job.link, {
+                responseType: 'stream',
+                headers: {
+                  ...job.headers,
+                  'User-Agent': 'OpenGameInstaller Downloader/1.0.0',
+                  'Accept-Encoding': 'identity',
+                  Range: 'bytes=0-0',
+                },
+                httpAgent: keepAliveAgent,
+                httpsAgent: keepAliveAgent,
+                timeout: 10000,
+              }),
+            catch: (cause) =>
+              new DownloadError({
+                message: `Parallel limit probe failed: ${formatError(cause)}`,
+                cause,
+              }),
+          })
+        );
+        if (probeResult._tag === 'Right') {
+          parallelLimit = mergeParallelLimits(
+            parallelLimit,
+            parseParallelLimitHeader(probeResult.right.headers)
+          );
+          probeResult.right.data.destroy();
+        }
+      }
 
       return {
         useParallel:
@@ -967,6 +1041,10 @@ class Download {
         let chunkCurrentBytes = 0;
         if (fs.existsSync(chunkPath)) {
           chunkCurrentBytes = fs.statSync(chunkPath).size;
+          if (chunkCurrentBytes > expectedChunkSize) {
+            fs.rmSync(chunkPath, { force: true });
+            chunkCurrentBytes = 0;
+          }
         }
 
         part.chunks.push({
@@ -975,7 +1053,7 @@ class Download {
           endByte,
           currentBytes: chunkCurrentBytes,
           abortController: new AbortController(),
-          completed: chunkCurrentBytes >= expectedChunkSize,
+          completed: chunkCurrentBytes === expectedChunkSize,
         });
       }
 
@@ -1073,6 +1151,12 @@ class Download {
       const responseResult = yield* Effect.either(request);
       if (responseResult._tag === 'Left') {
         const cause = responseResult.left.cause;
+        if (cause instanceof AxiosError) {
+          this.observeParallelLimit(
+            cause.response?.headers as Record<string, unknown> | undefined,
+            part
+          );
+        }
         if (cause instanceof AxiosError && cause.response?.status === 416) {
           chunk.completed = true;
           return;
@@ -1083,6 +1167,7 @@ class Download {
         return yield* Effect.fail(responseResult.left);
       }
       chunk.response = responseResult.right;
+      this.observeParallelLimit(chunk.response.headers, part);
 
       if (chunk.response.status === 429) {
         return yield* Effect.fail(new TooManyRequests({}));
@@ -1165,7 +1250,17 @@ class Download {
           );
           onProgress?.();
         });
-      });
+      }).pipe(
+        Effect.onInterrupt(() =>
+          Effect.sync(() => {
+            stream.throttle?.destroy();
+            chunk.response?.data.destroy();
+            chunk.fileStream?.destroy();
+            chunk.fileStream = undefined;
+            chunk.response = undefined;
+          })
+        )
+      );
     });
   }
 
@@ -1176,6 +1271,35 @@ class Download {
     part: PartState
   ): Effect.Effect<void, FileSystemError> {
     return Effect.gen(this, function* () {
+      const effectiveChunkCount =
+        part.effectiveChunkCount ?? PARALLEL_CHUNK_COUNT;
+      yield* Effect.try({
+        try: () => {
+          if (part.chunks.length !== effectiveChunkCount) {
+            throw new Error(
+              `Expected ${effectiveChunkCount} chunks, found ${part.chunks.length}`
+            );
+          }
+          for (let i = 0; i < effectiveChunkCount; i++) {
+            const chunk = part.chunks[i];
+            const chunkPath = this.getChunkPath(part.job.path, i);
+            const expectedSize = chunk.endByte - chunk.startByte + 1;
+            const actualSize = fs.statSync(chunkPath).size;
+            if (actualSize !== expectedSize) {
+              throw new Error(
+                `Chunk ${i} has ${actualSize} bytes; expected ${expectedSize}`
+              );
+            }
+          }
+        },
+        catch: (cause) =>
+          new FileSystemError({
+            message: `Cannot merge invalid chunks: ${formatError(cause)}`,
+            path: part.job.path,
+            cause,
+          }),
+      });
+
       const finalStream = yield* Effect.try({
         try: () => fs.createWriteStream(part.job.path, { flags: 'w' }),
         catch: (cause) =>
@@ -1185,9 +1309,6 @@ class Download {
             cause,
           }),
       });
-      const effectiveChunkCount =
-        part.effectiveChunkCount ?? PARALLEL_CHUNK_COUNT;
-
       yield* Effect.async<void, FileSystemError>((resume) => {
         let resolved = false;
         let currentChunkIndex = 0;
@@ -1205,6 +1326,7 @@ class Download {
           );
         };
         const writeNextChunk = () => {
+          if (resolved) return;
           if (currentChunkIndex >= effectiveChunkCount) {
             finalStream.end(() => {
               if (resolved) return;
@@ -1219,13 +1341,21 @@ class Download {
             return;
           }
           const chunkStream = fs.createReadStream(chunkPath);
+          let ended = false;
           chunkStream.on('error', (cause) => {
             finalStream.destroy();
             fail(cause, chunkPath);
           });
           chunkStream.on('end', () => {
+            ended = true;
             currentChunkIndex++;
             writeNextChunk();
+          });
+          chunkStream.on('close', () => {
+            if (!ended && !resolved) {
+              finalStream.destroy();
+              fail('Chunk stream closed before reaching the end', chunkPath);
+            }
           });
           chunkStream.pipe(finalStream, { end: false });
         };
@@ -1310,6 +1440,14 @@ class Download {
       );
       if (responseResult._tag === 'Left') {
         const cause = responseResult.left.cause;
+        part.fileStream?.destroy();
+        part.fileStream = undefined;
+        if (cause instanceof AxiosError) {
+          this.observeParallelLimit(
+            cause.response?.headers as Record<string, unknown> | undefined,
+            part
+          );
+        }
         if (cause instanceof AxiosError && cause.response?.status === 416) {
           part.downloadedBytes = 0;
           yield* Effect.tryPromise({
@@ -1329,6 +1467,7 @@ class Download {
         return yield* Effect.fail(responseResult.left);
       }
       part.response = responseResult.right;
+      this.observeParallelLimit(part.response.headers, part);
 
       if (startByte > 0 && part.response.status !== 206) {
         part.fileStream?.close();
@@ -1877,6 +2016,11 @@ class Download {
       );
       if (responseResult._tag === 'Left') {
         const cause = responseResult.left.cause;
+        if (cause instanceof AxiosError) {
+          this.observeParallelLimit(
+            cause.response?.headers as Record<string, unknown> | undefined
+          );
+        }
         if (cause instanceof AxiosError && cause.response?.status === 416) {
           this.startByte = 0;
           this.currentBytes = 0;
@@ -1897,12 +2041,14 @@ class Download {
           yield* this.cleanupAllFiles();
         }
         if (cause instanceof AxiosError && cause.response?.status === 429) {
+          this.cleanupPart();
           return yield* Effect.fail(new TooManyRequests({}));
         }
         this.cleanupPart();
         return yield* Effect.fail(responseResult.left);
       }
       this.response = responseResult.right;
+      this.observeParallelLimit(this.response.headers);
 
       if (this.startByte > 0 && this.response.status !== 206) {
         this.startByte = 0;
@@ -2161,6 +2307,10 @@ class Download {
         let chunkCurrentBytes = 0;
         if (fs.existsSync(chunkPath)) {
           chunkCurrentBytes = fs.statSync(chunkPath).size;
+          if (chunkCurrentBytes > expectedChunkSize) {
+            fs.rmSync(chunkPath, { force: true });
+            chunkCurrentBytes = 0;
+          }
           console.log(
             `[direct] Chunk ${i} file exists with ${chunkCurrentBytes} bytes`
           );
@@ -2172,7 +2322,7 @@ class Download {
           endByte,
           currentBytes: chunkCurrentBytes,
           abortController: new AbortController(),
-          completed: chunkCurrentBytes >= expectedChunkSize,
+          completed: chunkCurrentBytes === expectedChunkSize,
         });
       }
 

--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -779,7 +779,10 @@ export class Download {
         | undefined;
 
       // Check if this part should use chunk parallelization
-      const parallelInfo = yield* this.shouldUseParallelDownloadForPart(job);
+      const parallelInfo = yield* this.shouldUseParallelDownloadForPart(
+        job,
+        part.abortController.signal
+      );
       part.totalBytes = parallelInfo.fileSize;
       part.parallelLimit = mergeParallelLimits(
         part.parallelLimit,
@@ -912,7 +915,8 @@ export class Download {
    * Check if parallel download should be used for a part in multi-part download.
    */
   private shouldUseParallelDownloadForPart(
-    job: DownloadJob
+    job: DownloadJob,
+    signal?: AbortSignal
   ): Effect.Effect<ParallelDownloadInfo> {
     return Effect.gen(function* () {
       const keepAliveAgent = job.link.startsWith('https')
@@ -968,6 +972,7 @@ export class Download {
                 httpAgent: keepAliveAgent,
                 httpsAgent: keepAliveAgent,
                 timeout: 10000,
+                signal,
               }),
             catch: (cause) =>
               new DownloadError({
@@ -1312,9 +1317,12 @@ export class Download {
       yield* Effect.async<void, FileSystemError>((resume) => {
         let resolved = false;
         let currentChunkIndex = 0;
+        let activeChunkStream: fs.ReadStream | undefined;
         const fail = (cause: unknown, path = part.job.path) => {
           if (resolved) return;
           resolved = true;
+          activeChunkStream?.destroy();
+          activeChunkStream = undefined;
           resume(
             Effect.fail(
               new FileSystemError({
@@ -1341,6 +1349,7 @@ export class Download {
             return;
           }
           const chunkStream = fs.createReadStream(chunkPath);
+          activeChunkStream = chunkStream;
           let ended = false;
           chunkStream.on('error', (cause) => {
             finalStream.destroy();
@@ -1348,6 +1357,7 @@ export class Download {
           });
           chunkStream.on('end', () => {
             ended = true;
+            activeChunkStream = undefined;
             currentChunkIndex++;
             writeNextChunk();
           });
@@ -1856,6 +1866,7 @@ export class Download {
 
       // Check if we should use parallel download (only for single-part downloads)
       if (this.totalParts === 1) {
+        this.abortController = new AbortController();
         const parallelInfo = yield* this.shouldUseParallelDownload(job);
         if (parallelInfo.useParallel) {
           console.log('[direct] Using parallel download');
@@ -2256,7 +2267,10 @@ export class Download {
     job: DownloadJob
   ): Effect.Effect<ParallelDownloadInfo> {
     return Effect.gen(this, function* () {
-      const info = yield* this.shouldUseParallelDownloadForPart(job);
+      const info = yield* this.shouldUseParallelDownloadForPart(
+        job,
+        this.abortController?.signal
+      );
       this.parallelLimit = mergeParallelLimits(
         this.parallelLimit,
         info.parallelLimit

--- a/application/src/electron/handlers/handler.umu.ts
+++ b/application/src/electron/handlers/handler.umu.ts
@@ -24,7 +24,10 @@ import {
   getHomeDir,
   isLinux,
 } from '@/electron/handlers/helpers.app/platform.js';
-import { getUmuRedistributableEnvironment } from '@/electron/handlers/helpers.app/umu-environment.js';
+import {
+  getUmuLaunchEnvironment,
+  getUmuRedistributableEnvironment,
+} from '@/electron/handlers/helpers.app/umu-environment.js';
 import { sendNotification } from '@/electron/main.js';
 import { __dirname } from '@/electron/manager/manager.paths.js';
 import { downloadLatestUmu } from '@/electron/startup.js';
@@ -499,16 +502,13 @@ export async function launchWithUmu(
   const dllOverrideStr = buildDllOverrides(dllOverrides);
 
   // Build environment variables
-  const env: NodeJS.ProcessEnv = {
-    ...process.env,
-    ...launchEnv,
-    GAMEID: gameId,
-    WINEPREFIX: winePrefix,
-  };
-
-  if (protonPath) {
-    env.PROTONPATH = protonPath;
-  }
+  const env = getUmuLaunchEnvironment({
+    launchEnvironment: launchEnv,
+    gameId,
+    winePrefix,
+    cwd: libraryInfo.cwd,
+    protonPath,
+  });
 
   if (store) {
     env.STORE = store;

--- a/application/src/electron/handlers/handler.umu.ts
+++ b/application/src/electron/handlers/handler.umu.ts
@@ -24,6 +24,7 @@ import {
   getHomeDir,
   isLinux,
 } from '@/electron/handlers/helpers.app/platform.js';
+import { getUmuRedistributableEnvironment } from '@/electron/handlers/helpers.app/umu-environment.js';
 import { sendNotification } from '@/electron/main.js';
 import { __dirname } from '@/electron/manager/manager.paths.js';
 import { downloadLatestUmu } from '@/electron/startup.js';
@@ -717,16 +718,12 @@ export async function installRedistributablesWithUmu(
           resolve(result);
         };
 
-        const env: NodeJS.ProcessEnv = {
-          ...process.env,
-          GAMEID: gameId,
-          WINEPREFIX: winePrefix,
-          UMU_LOG: 'debug',
-        };
-
-        if (protonPath) {
-          env.PROTONPATH = protonPath;
-        }
+        const env = getUmuRedistributableEnvironment({
+          gameId,
+          winePrefix,
+          cwd: libraryInfo.cwd,
+          protonPath,
+        });
 
         let child: ReturnType<typeof spawn>;
 
@@ -736,10 +733,7 @@ export async function installRedistributablesWithUmu(
             umuRunExecutable,
             ['winetricks', '-q', '-f', redistributable.name],
             {
-              env: {
-                ...env,
-                PWD: libraryInfo.cwd,
-              },
+              env,
               stdio: ['ignore', 'pipe', 'pipe'],
             }
           );
@@ -771,10 +765,7 @@ export async function installRedistributablesWithUmu(
           const silentFlags = getSilentInstallFlags(redistFile);
 
           child = spawn(umuRunExecutable, [redistFile, ...silentFlags], {
-            env: {
-              ...env,
-              PWD: libraryInfo.cwd,
-            },
+            env,
             cwd: redistDir,
             stdio: ['ignore', 'pipe', 'pipe'],
           });
@@ -1115,6 +1106,11 @@ export async function installRedistributablesWithUmuForLegacy(
         };
 
         let child: ReturnType<typeof spawn>;
+        const env = getUmuRedistributableEnvironment({
+          gameId: `umu-${steamAppId}`,
+          winePrefix,
+          cwd: libraryInfo.cwd,
+        });
 
         if (redistributable.path === 'winetricks') {
           // Use winetricks verb via UMU
@@ -1122,13 +1118,7 @@ export async function installRedistributablesWithUmuForLegacy(
             umuRunExecutable,
             ['winetricks', '-q', '-f', redistributable.name],
             {
-              env: {
-                ...process.env,
-                UMU_LOG: 'debug',
-                GAMEID: `umu-${steamAppId}`,
-                WINEPREFIX: winePrefix,
-                PWD: libraryInfo.cwd,
-              },
+              env,
               stdio: ['ignore', 'pipe', 'pipe'],
             }
           );
@@ -1152,13 +1142,7 @@ export async function installRedistributablesWithUmuForLegacy(
           const silentFlags = getSilentInstallFlags(redistFile);
 
           child = spawn(umuRunExecutable, [redistFile, ...silentFlags], {
-            env: {
-              ...process.env,
-              UMU_LOG: 'debug',
-              GAMEID: `umu-${steamAppId}`,
-              WINEPREFIX: winePrefix,
-              PWD: libraryInfo.cwd,
-            },
+            env,
             cwd: redistDir,
             stdio: ['ignore', 'pipe', 'pipe'],
           });

--- a/application/src/electron/handlers/helpers.app/umu-environment.ts
+++ b/application/src/electron/handlers/helpers.app/umu-environment.ts
@@ -6,21 +6,29 @@ export type UmuRedistributableEnvironmentOptions = {
   protonPath?: string;
 };
 
-export function getUmuRedistributableEnvironment({
+export type UmuLaunchEnvironmentOptions =
+  UmuRedistributableEnvironmentOptions & {
+    launchEnvironment?: Record<string, string>;
+  };
+
+function getUmuEnvironment({
   baseEnvironment = process.env,
   gameId,
   winePrefix,
   cwd,
   protonPath,
-}: UmuRedistributableEnvironmentOptions): NodeJS.ProcessEnv {
+  additionalEnvironment = {},
+}: UmuRedistributableEnvironmentOptions & {
+  additionalEnvironment?: NodeJS.ProcessEnv;
+}): NodeJS.ProcessEnv {
   const environment: NodeJS.ProcessEnv = {
     ...baseEnvironment,
+    ...additionalEnvironment,
     GAMEID: gameId,
     WINEPREFIX: winePrefix,
     UMU_LOG: 'debug',
-    // Xalia is Proton-GE's .NET accessibility helper. Letting it start while
-    // Winetricks is replacing .NET can display a framework prompt and block an
-    // otherwise unattended redistributable installation.
+    // Xalia is Proton-GE's accessibility helper. Its own VC++/.NET dependency
+    // prompts can be mistaken for game prerequisites and block unattended work.
     PROTON_USE_XALIA: '0',
     PWD: cwd,
   };
@@ -30,4 +38,20 @@ export function getUmuRedistributableEnvironment({
   }
 
   return environment;
+}
+
+export function getUmuLaunchEnvironment({
+  launchEnvironment,
+  ...options
+}: UmuLaunchEnvironmentOptions): NodeJS.ProcessEnv {
+  return getUmuEnvironment({
+    ...options,
+    additionalEnvironment: launchEnvironment,
+  });
+}
+
+export function getUmuRedistributableEnvironment(
+  options: UmuRedistributableEnvironmentOptions
+): NodeJS.ProcessEnv {
+  return getUmuEnvironment(options);
 }

--- a/application/src/electron/handlers/helpers.app/umu-environment.ts
+++ b/application/src/electron/handlers/helpers.app/umu-environment.ts
@@ -1,0 +1,33 @@
+export type UmuRedistributableEnvironmentOptions = {
+  baseEnvironment?: NodeJS.ProcessEnv;
+  gameId: string;
+  winePrefix: string;
+  cwd: string;
+  protonPath?: string;
+};
+
+export function getUmuRedistributableEnvironment({
+  baseEnvironment = process.env,
+  gameId,
+  winePrefix,
+  cwd,
+  protonPath,
+}: UmuRedistributableEnvironmentOptions): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    ...baseEnvironment,
+    GAMEID: gameId,
+    WINEPREFIX: winePrefix,
+    UMU_LOG: 'debug',
+    // Xalia is Proton-GE's .NET accessibility helper. Letting it start while
+    // Winetricks is replacing .NET can display a framework prompt and block an
+    // otherwise unattended redistributable installation.
+    PROTON_USE_XALIA: '0',
+    PWD: cwd,
+  };
+
+  if (protonPath) {
+    environment.PROTONPATH = protonPath;
+  }
+
+  return environment;
+}

--- a/application/tests/handler.ddl.test.ts
+++ b/application/tests/handler.ddl.test.ts
@@ -1,0 +1,435 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test';
+import { Effect } from 'effect';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Readable } from 'stream';
+
+class MockAxiosError extends Error {
+  constructor(
+    public response?: {
+      status: number;
+      headers: Record<string, string>;
+    }
+  ) {
+    super('mock axios error');
+  }
+}
+
+class MockBrowserWindow {}
+
+const get = mock(() =>
+  Promise.resolve({
+    status: 200,
+    headers: {
+      'content-length': '7',
+      'ogi-parallel-limit': '1',
+    },
+    data: Readable.from([Buffer.from('payload')]),
+  })
+);
+const head = mock(() => Promise.reject(new Error('unused')));
+
+mock.module('axios', () => ({
+  default: { get, head },
+  AxiosError: MockAxiosError,
+}));
+mock.module('electron', () => ({
+  BrowserWindow: MockBrowserWindow,
+  ipcMain: {
+    handle: mock(() => {}),
+    handleOnce: mock(() => {}),
+    removeHandler: mock(() => {}),
+  },
+}));
+mock.module('@/electron/lib/online.js', () => ({
+  getEffectiveOnlineState: () => ({ effectiveOnline: true }),
+}));
+mock.module('@/electron/main.js', () => ({
+  sendNotification: mock(() => {}),
+}));
+mock.module('@/electron/manager/manager.config.js', () => ({
+  getStoredValue: () => Effect.succeed(8),
+  refreshCached: () => Effect.void,
+}));
+mock.module('@/electron/manager/manager.queue.js', () => ({
+  DOWNLOAD_QUEUE: {
+    enqueue: () => ({
+      wait: () => Effect.succeed('ready'),
+      finish: () => {},
+      cancelHandler: () => {},
+    }),
+  },
+}));
+mock.module('@/lib/download-handshake.js', () => ({
+  clearDownloadHandshake: mock(() => {}),
+  registerDownloadHandshake: mock(() => {}),
+  updateDownloadHandshake: mock(() => {}),
+  waitForDownloadHandshake: mock(() =>
+    Promise.resolve({ status: 'downloading' })
+  ),
+}));
+
+let Download: typeof import('../src/electron/handlers/handler.ddl.js').Download;
+const testDirectories: string[] = [];
+
+beforeAll(async () => {
+  ({ Download } = await import('../src/electron/handlers/handler.ddl.js'));
+});
+
+beforeEach(() => {
+  get.mockClear();
+  head.mockClear();
+  get.mockImplementation(() =>
+    Promise.resolve({
+      status: 200,
+      headers: {
+        'content-length': '7',
+        'ogi-parallel-limit': '1',
+      },
+      data: Readable.from([Buffer.from('payload')]),
+    })
+  );
+  head.mockImplementation(() => Promise.reject(new Error('unused')));
+});
+
+afterEach(() => {
+  for (const directory of testDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('OGI-Parallel-Limit response handling', () => {
+  test('discovers a GET-only limit before starting chunk fan-out', async () => {
+    head.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        headers: {
+          'content-length': String(101 * 1024 * 1024),
+          'accept-ranges': 'bytes',
+        },
+      })
+    );
+    get.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 206,
+        headers: { 'ogi-parallel-limit': '1' },
+        data: Readable.from([Buffer.from('x')]),
+      })
+    );
+    const job = {
+      link: 'https://example.test/file',
+      path: join(tmpdir(), 'unused-download.bin'),
+    };
+    const download = new Download(
+      {
+        isDestroyed: () => false,
+        webContents: { send: () => {} },
+      } as never,
+      [job]
+    );
+
+    const info = await Effect.runPromise(
+      (
+        download as unknown as {
+          shouldUseParallelDownloadForPart(
+            currentJob: typeof job
+          ): Effect.Effect<{
+            useParallel: boolean;
+            parallelLimit?: number;
+          }>;
+        }
+      ).shouldUseParallelDownloadForPart(job)
+    );
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(info.parallelLimit).toBe(1);
+    expect(info.useParallel).toBe(false);
+  });
+
+  test('retains a limit returned by the live download response', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'ogi-parallel-limit-'));
+    testDirectories.push(directory);
+    const path = join(directory, 'download.bin');
+    const job = { link: 'https://example.test/file', path };
+    const download = new Download(
+      {
+        isDestroyed: () => false,
+        webContents: { send: () => {} },
+      } as never,
+      [job]
+    );
+    download.status = 'downloading';
+
+    await Effect.runPromise(
+      (
+        download as unknown as {
+          _executeDownloadPart(currentJob: typeof job): Effect.Effect<void>;
+        }
+      )._executeDownloadPart(job)
+    );
+
+    expect(readFileSync(path, 'utf8')).toBe('payload');
+    expect(
+      (download as unknown as { parallelLimit?: number }).parallelLimit
+    ).toBe(1);
+  });
+
+  test('retains a changed limit from a failed response and releases the file', async () => {
+    get.mockImplementationOnce(() =>
+      Promise.reject(
+        new MockAxiosError({
+          status: 429,
+          headers: { 'ogi-parallel-limit': '2' },
+        })
+      )
+    );
+    const directory = mkdtempSync(join(tmpdir(), 'ogi-failed-limit-'));
+    testDirectories.push(directory);
+    const path = join(directory, 'download.bin');
+    const job = { link: 'https://example.test/file', path };
+    const download = new Download(
+      {
+        isDestroyed: () => false,
+        webContents: { send: () => {} },
+      } as never,
+      [job]
+    );
+    download.status = 'downloading';
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        (
+          download as unknown as {
+            _executeDownloadPart(
+              currentJob: typeof job
+            ): Effect.Effect<void, unknown>;
+          }
+        )._executeDownloadPart(job)
+      )
+    );
+
+    expect(result._tag).toBe('Left');
+    expect(
+      (download as unknown as { parallelLimit?: number }).parallelLimit
+    ).toBe(2);
+    expect(
+      (download as unknown as { fileStream?: unknown }).fileStream
+    ).toBeUndefined();
+  });
+
+  test('repartitions cleanly when a failed attempt learns a stricter limit', async () => {
+    head.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        headers: {
+          'content-length': String(101 * 1024 * 1024),
+          'accept-ranges': 'bytes',
+          'ogi-parallel-limit': '4',
+        },
+      })
+    );
+    get.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 206,
+        headers: { 'ogi-parallel-limit': '4' },
+        data: Readable.from([Buffer.from('x')]),
+      })
+    );
+    const directory = mkdtempSync(join(tmpdir(), 'ogi-repartition-'));
+    testDirectories.push(directory);
+    const path = join(directory, 'download.bin');
+    const job = { link: 'https://example.test/file', path };
+    const download = new Download(
+      {
+        isDestroyed: () => false,
+        webContents: { send: () => {} },
+      } as never,
+      [job]
+    );
+    const part = {
+      index: 0,
+      job,
+      status: 'downloading' as
+        | 'pending'
+        | 'downloading'
+        | 'completed'
+        | 'failed'
+        | 'merging',
+      downloadedBytes: 0,
+      totalBytes: 0,
+      abortController: new AbortController(),
+      useChunks: false,
+      chunks: [],
+      chunkJobPath: '',
+      parallelLimit: undefined as number | undefined,
+      effectiveChunkCount: undefined as number | undefined,
+    };
+    let attempt = 0;
+    let staleChunksFound = true;
+    const internals = download as unknown as {
+      executeParallelDownloadForPart(
+        currentPart: typeof part
+      ): Effect.Effect<void, { message: string }>;
+      downloadPartWithState(
+        currentPart: typeof part,
+        retries: number
+      ): Effect.Effect<void, { message: string }>;
+    };
+    internals.executeParallelDownloadForPart = (currentPart) =>
+      Effect.gen(function* () {
+        attempt++;
+        if (attempt === 1) {
+          for (let index = 0; index < 4; index++) {
+            writeFileSync(`${path}.chunk${index}`, 'old-layout');
+          }
+          currentPart.parallelLimit = 2;
+          return yield* Effect.fail({ message: 'simulated failure' });
+        }
+        staleChunksFound = Array.from({ length: 4 }, (_, index) =>
+          existsSync(`${path}.chunk${index}`)
+        ).some(Boolean);
+      });
+    download.status = 'downloading';
+
+    await Effect.runPromise(internals.downloadPartWithState(part, 2));
+
+    expect(attempt).toBe(2);
+    expect(part.effectiveChunkCount).toBe(2);
+    expect(staleChunksFound).toBe(false);
+    expect(part.status).toBe('completed');
+  });
+});
+
+describe('parallel chunk merging', () => {
+  test('waits for a part that is still merging before resolving', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'ogi-wait-merge-'));
+    testDirectories.push(directory);
+    const job = {
+      link: 'https://example.test/file',
+      path: join(directory, 'download.bin'),
+      headers: { 'OGI-Parallel-Limit': '1' },
+    };
+    const download = new Download(
+      {
+        isDestroyed: () => false,
+        webContents: { send: () => {} },
+      } as never,
+      [job]
+    );
+    const part = {
+      index: 0,
+      job,
+      status: 'pending' as
+        | 'pending'
+        | 'downloading'
+        | 'completed'
+        | 'failed'
+        | 'merging',
+      downloadedBytes: 0,
+      totalBytes: 0,
+      abortController: new AbortController(),
+      useChunks: false,
+      chunks: [],
+      chunkJobPath: '',
+      parallelLimit: 1,
+    };
+    const internals = download as unknown as {
+      parts: Array<typeof part>;
+      downloadPartWithState(currentPart: typeof part): Effect.Effect<void>;
+      runParallelParts(): Effect.Effect<void>;
+    };
+    internals.parts = [part];
+    internals.downloadPartWithState = (currentPart) =>
+      Effect.sync(() => {
+        currentPart.status = 'merging';
+      }).pipe(
+        Effect.zipRight(Effect.sleep('250 millis')),
+        Effect.tap(() =>
+          Effect.sync(() => {
+            currentPart.status = 'completed';
+          })
+        )
+      );
+    download.status = 'downloading';
+
+    const startedAt = Date.now();
+    await Effect.runPromise(internals.runParallelParts());
+
+    expect(part.status).toBe('completed');
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(200);
+  });
+
+  test('rejects a corrupted chunk instead of completing the merge', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'ogi-corrupt-merge-'));
+    testDirectories.push(directory);
+    const path = join(directory, 'download.bin');
+    writeFileSync(`${path}.chunk0`, 'too-long');
+    writeFileSync(`${path}.chunk1`, 'def');
+    const job = { link: 'https://example.test/file', path };
+    const download = new Download(
+      {
+        isDestroyed: () => false,
+        webContents: { send: () => {} },
+      } as never,
+      [job]
+    );
+    const part = {
+      index: 0,
+      job,
+      status: 'merging' as const,
+      downloadedBytes: 11,
+      totalBytes: 6,
+      abortController: new AbortController(),
+      useChunks: true,
+      chunks: [
+        {
+          index: 0,
+          startByte: 0,
+          endByte: 2,
+          currentBytes: 8,
+          abortController: new AbortController(),
+          completed: true,
+        },
+        {
+          index: 1,
+          startByte: 3,
+          endByte: 5,
+          currentBytes: 3,
+          abortController: new AbortController(),
+          completed: true,
+        },
+      ],
+      chunkJobPath: path,
+      effectiveChunkCount: 2,
+    };
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        (
+          download as unknown as {
+            mergeChunkFilesForPart(
+              currentPart: typeof part
+            ): Effect.Effect<void, unknown>;
+          }
+        ).mergeChunkFilesForPart(part)
+      )
+    );
+
+    expect(result._tag).toBe('Left');
+  });
+});

--- a/application/tests/handler.ddl.test.ts
+++ b/application/tests/handler.ddl.test.ts
@@ -32,7 +32,7 @@ class MockAxiosError extends Error {
 
 class MockBrowserWindow {}
 
-const get = mock(() =>
+const get = mock((_url?: string, _config?: { signal?: AbortSignal }) =>
   Promise.resolve({
     status: 200,
     headers: {
@@ -142,21 +142,24 @@ describe('OGI-Parallel-Limit response handling', () => {
       } as never,
       [job]
     );
+    const abortController = new AbortController();
 
     const info = await Effect.runPromise(
       (
         download as unknown as {
           shouldUseParallelDownloadForPart(
-            currentJob: typeof job
+            currentJob: typeof job,
+            signal?: AbortSignal
           ): Effect.Effect<{
             useParallel: boolean;
             parallelLimit?: number;
           }>;
         }
-      ).shouldUseParallelDownloadForPart(job)
+      ).shouldUseParallelDownloadForPart(job, abortController.signal)
     );
 
     expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0]?.[1]?.signal).toBe(abortController.signal);
     expect(info.parallelLimit).toBe(1);
     expect(info.useParallel).toBe(false);
   });
@@ -367,11 +370,9 @@ describe('parallel chunk merging', () => {
       );
     download.status = 'downloading';
 
-    const startedAt = Date.now();
     await Effect.runPromise(internals.runParallelParts());
 
     expect(part.status).toBe('completed');
-    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(200);
   });
 
   test('rejects a corrupted chunk instead of completing the merge', async () => {

--- a/application/tests/umu-environment.test.ts
+++ b/application/tests/umu-environment.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { getUmuRedistributableEnvironment } from '../src/electron/handlers/helpers.app/umu-environment';
+
+describe('UMU redistributable environment', () => {
+  test.each([
+    'dotnet40',
+    'dotnet48',
+  ])('prevents Xalia from interrupting the %s Winetricks install', () => {
+    const environment = getUmuRedistributableEnvironment({
+      baseEnvironment: { PROTON_USE_XALIA: '1', UNRELATED: 'preserved' },
+      gameId: 'umu-test',
+      winePrefix: '/tmp/test-prefix',
+      cwd: '/tmp/test-game',
+    });
+
+    expect(environment.PROTON_USE_XALIA).toBe('0');
+    expect(environment.UNRELATED).toBe('preserved');
+  });
+});

--- a/application/tests/umu-environment.test.ts
+++ b/application/tests/umu-environment.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, test } from 'bun:test';
-import { getUmuRedistributableEnvironment } from '../src/electron/handlers/helpers.app/umu-environment';
+import {
+  getUmuLaunchEnvironment,
+  getUmuRedistributableEnvironment,
+} from '../src/electron/handlers/helpers.app/umu-environment';
 
-describe('UMU redistributable environment', () => {
+describe('UMU environment', () => {
+  test('prevents Xalia from displaying dependency prompts at game launch', () => {
+    const environment = getUmuLaunchEnvironment({
+      baseEnvironment: { PROTON_USE_XALIA: '1', UNRELATED: 'preserved' },
+      launchEnvironment: { CUSTOM_LAUNCH_VALUE: 'preserved' },
+      gameId: 'umu-test',
+      winePrefix: '/tmp/test-prefix',
+      cwd: '/tmp/test-game',
+    });
+
+    expect(environment.PROTON_USE_XALIA).toBe('0');
+    expect(environment.UNRELATED).toBe('preserved');
+    expect(environment.CUSTOM_LAUNCH_VALUE).toBe('preserved');
+  });
+
   test.each([
     'dotnet40',
     'dotnet48',
+    'vcrun2022',
   ])('prevents Xalia from interrupting the %s Winetricks install', () => {
     const environment = getUmuRedistributableEnvironment({
       baseEnvironment: { PROTON_USE_XALIA: '1', UNRELATED: 'preserved' },

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ogi-monorepo",
@@ -160,6 +161,7 @@
         "effect": "^3.22.0",
       },
       "devDependencies": {
+        "tsdown": "^0.21.10",
         "typescript": "^5.9.3",
       },
     },

--- a/packages/errors/.gitignore
+++ b/packages/errors/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./build/index.mjs",
-        "types": "./build/index.d.mts"
+        "types": "./build/index.d.mts",
+        "default": "./build/index.mjs"
       },
       "require": {
-        "default": "./build/index.cjs",
-        "types": "./build/index.d.cts"
+        "types": "./build/index.d.cts",
+        "default": "./build/index.cjs"
       }
     }
   },

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -2,22 +2,34 @@
   "name": "@ogi/errors",
   "type": "module",
   "version": "1.0.0",
-  "module": "./src/index.ts",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "module": "./build/index.mjs",
+  "main": "./build/index.cjs",
+  "types": "./build/index.d.mts",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts"
+      "import": {
+        "default": "./build/index.mjs",
+        "types": "./build/index.d.mts"
+      },
+      "require": {
+        "default": "./build/index.cjs",
+        "types": "./build/index.d.cts"
+      }
     }
   },
+  "files": [
+    "build"
+  ],
   "dependencies": {
     "effect": "^3.22.0"
   },
   "scripts": {
+    "build": "tsdown --config tsdown.config.js",
+    "test": "bun run build && bun test package.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "tsdown": "^0.21.10",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/errors/package.test.ts
+++ b/packages/errors/package.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import { spawnSync } from 'child_process';
 
 describe('@ogi/errors package contract', () => {
-  test('loads through Node without runtime TypeScript stripping', () => {
-    const result = spawnSync(
+  test('loads ESM and CommonJS through Node without runtime TypeScript stripping', () => {
+    const esmResult = spawnSync(
       'node',
       ['--input-type=module', '--eval', "import('@ogi/errors')"],
       {
@@ -12,9 +12,19 @@ describe('@ogi/errors package contract', () => {
       }
     );
 
-    expect(result.stderr).not.toContain(
+    expect(esmResult.stderr).not.toContain(
       'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING'
     );
-    expect(result.status, result.stderr).toBe(0);
+    expect(esmResult.status, esmResult.stderr).toBe(0);
+
+    const cjsResult = spawnSync('node', ['--eval', "require('@ogi/errors')"], {
+      cwd: import.meta.dir,
+      encoding: 'utf8',
+    });
+
+    expect(cjsResult.stderr).not.toContain(
+      'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING'
+    );
+    expect(cjsResult.status, cjsResult.stderr).toBe(0);
   });
 });

--- a/packages/errors/package.test.ts
+++ b/packages/errors/package.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+
+describe('@ogi/errors package contract', () => {
+  test('loads through Node without runtime TypeScript stripping', () => {
+    const result = spawnSync(
+      'node',
+      ['--input-type=module', '--eval', "import('@ogi/errors')"],
+      {
+        cwd: import.meta.dir,
+        encoding: 'utf8',
+      }
+    );
+
+    expect(result.stderr).not.toContain(
+      'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING'
+    );
+    expect(result.status, result.stderr).toBe(0);
+  });
+});

--- a/packages/errors/tsdown.config.js
+++ b/packages/errors/tsdown.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: 'src/index.ts',
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  format: ['cjs', 'esm'],
+  dts: true,
+  outDir: 'build',
+  target: false,
+});


### PR DESCRIPTION
## Summary

- Detect and apply server-reported parallel download limits.
- Clean stale or corrupted chunk files before retries and merges.
- Improve download interruption, stream cleanup, and merge state handling.
- Add comprehensive downloader regression tests.

## Testing

- Added `application/tests/handler.ddl.test.ts` covering parallel-limit discovery, retry repartitioning, merge synchronization, and corrupted chunks.
- Automated test suite not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Downloads now dynamically adapt parallelism using server-provided limit headers.
  - UMU launch environment now supports merging optional custom launch-time environment variables.
- **Bug Fixes**
  - Improved multi-part parallel scheduling (including merging-part handling) and per-part abort propagation.
  - Stricter chunk resume/completion, retry behavior, and merge validation for corrupted/inconsistent on-disk layouts.
  - Enhanced merge/interrupt handling to detect premature termination and reduce resource leakage.
- **Tests**
  - Updated parallel-limit and merging-related handler tests; added UMU environment test coverage.
- **Chores**
  - Updated shared errors package build/publish setup and added ignores for build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->