### PR TITLE
fix(updater): reset cached bleeding-edge repos to remote branch

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,22 +27,22 @@ jobs:
           fetch-depth: 0 # Fetch full history for consistency
           persist-credentials: false
 
-      - name: Check for changes in application directory
+      - name: Check for release build changes
         id: check_changes
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
           GITHUB_SHA: ${{ github.sha }}
-        run: node .github/workflows/js/check-application-changes.js
+        run: node .github/workflows/js/check-build-changes.js
 
       - name: Setup Bun
-        if: steps.check_changes.outputs.has_application_changes == 'true'
+        if: steps.check_changes.outputs.has_build_changes == 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
 
       - name: Cache Bun dependencies
-        if: steps.check_changes.outputs.has_application_changes == 'true'
+        if: steps.check_changes.outputs.has_build_changes == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -52,43 +52,43 @@ jobs:
             bun-deps-${{ runner.os }}-
 
       - name: Install Dependencies
-        if: steps.check_changes.outputs.has_application_changes == 'true'
+        if: steps.check_changes.outputs.has_build_changes == 'true'
         shell: bash
         run: |
           bun install --frozen-lockfile --linker=hoisted && cp -r ./node_modules/electron ./application/node_modules/electron && mkdir -p ./updater/node_modules && cp -r ./node_modules/electron ./updater/node_modules/electron
 
       - name: Build Release Client
-        if: steps.check_changes.outputs.has_application_changes == 'true'
+        if: steps.check_changes.outputs.has_build_changes == 'true'
         run: cd application && bun run electron-pack
 
       - name: Build Release Updater
-        if: steps.check_changes.outputs.has_application_changes == 'true'
+        if: steps.check_changes.outputs.has_build_changes == 'true'
         run: cd updater && bun run electron-pack
 
       - name: Zip for Windows Portable
-        if: matrix.os == 'windows-latest' && steps.check_changes.outputs.has_application_changes == 'true'
+        if: matrix.os == 'windows-latest' && steps.check_changes.outputs.has_build_changes == 'true'
         run: |
           Compress-Archive -Path application/dist/win-unpacked/* -Destination application/dist/OpenGameInstaller-Portable.zip
 
       - name: Generate Windows blockmaps
-        if: matrix.os == 'windows-latest' && steps.check_changes.outputs.has_application_changes == 'true'
+        if: matrix.os == 'windows-latest' && steps.check_changes.outputs.has_build_changes == 'true'
         run: |
           bun run .github/workflows/js/generate-blockmaps.mjs application/dist/OpenGameInstaller-Portable.zip updater/dist/OpenGameInstaller-Setup.exe
 
       - name: Generate Linux blockmaps
-        if: matrix.os == 'ubuntu-latest' && steps.check_changes.outputs.has_application_changes == 'true'
+        if: matrix.os == 'ubuntu-latest' && steps.check_changes.outputs.has_build_changes == 'true'
         run: |
           bun run .github/workflows/js/generate-blockmaps.mjs updater/dist/OpenGameInstaller-Setup.AppImage application/dist/OpenGameInstaller-linux-pt.AppImage
 
       - name: What's in the folders? (Windows)
-        if: steps.check_changes.outputs.has_application_changes == 'true'
+        if: steps.check_changes.outputs.has_build_changes == 'true'
         shell: bash
         run: |
           ls -la application/dist/
           ls -la updater/dist/
 
       - name: Upload Windows Assets as Artifacts
-        if: matrix.os == 'windows-latest' && steps.check_changes.outputs.has_application_changes == 'true'
+        if: matrix.os == 'windows-latest' && steps.check_changes.outputs.has_build_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: windows-assets
@@ -99,7 +99,7 @@ jobs:
             updater/dist/OpenGameInstaller-Setup.exe.blockmap
 
       - name: Upload Linux Assets as Artifacts
-        if: matrix.os == 'ubuntu-latest' && steps.check_changes.outputs.has_application_changes == 'true'
+        if: matrix.os == 'ubuntu-latest' && steps.check_changes.outputs.has_build_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: linux-assets

--- a/.github/workflows/js/check-build-changes.js
+++ b/.github/workflows/js/check-build-changes.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// Decide whether a push affects the desktop release artifacts.
+
 const { execSync } = require('child_process');
 const fs = require('fs');
 
@@ -8,10 +10,19 @@ const eventBefore = process.env.GITHUB_EVENT_BEFORE;
 const githubSha = process.env.GITHUB_SHA;
 const githubOutput = process.env.GITHUB_OUTPUT;
 
-function checkApplicationChanges() {
+function hasReleaseBuildChanges(changedFiles) {
+  return changedFiles.some(
+    (file) =>
+      file.startsWith('application/') ||
+      file.startsWith('updater/') ||
+      file.startsWith('.github/workflows/')
+  );
+}
+
+function checkReleaseBuildChanges() {
   // For tags or workflow_dispatch, assume changes exist
   if (eventName !== 'push' || !eventBefore) {
-    setOutput('has_application_changes', 'true');
+    setOutput('has_build_changes', 'true');
     console.log('Not a push event or no before commit, assuming changes exist');
     return;
   }
@@ -26,25 +37,16 @@ function checkApplicationChanges() {
       .split('\n')
       .filter(Boolean);
 
-    // Check if any file starts with application/
-    const hasChanges = changedFiles.some((file) =>
-      file.startsWith('application/')
-    );
-
-    const hasWorkflowChanges = changedFiles.some((file) =>
-      file.startsWith('.github/workflows/')
-    );
-
-    if (hasChanges || hasWorkflowChanges) {
-      setOutput('has_application_changes', 'true');
-      console.log('Found changes in application directory');
+    if (hasReleaseBuildChanges(changedFiles)) {
+      setOutput('has_build_changes', 'true');
+      console.log('Found release build changes');
     } else {
-      setOutput('has_application_changes', 'false');
-      console.log('No changes in application directory');
+      setOutput('has_build_changes', 'false');
+      console.log('No release build changes');
     }
   } catch (error) {
     // If git diff fails, assume changes exist to be safe
-    setOutput('has_application_changes', 'true');
+    setOutput('has_build_changes', 'true');
     console.log(
       'Error checking changes, assuming changes exist:',
       error.message
@@ -60,4 +62,8 @@ function setOutput(name, value) {
   }
 }
 
-checkApplicationChanges();
+if (require.main === module) {
+  checkReleaseBuildChanges();
+}
+
+module.exports = { hasReleaseBuildChanges };

--- a/.github/workflows/js/check-build-changes.test.js
+++ b/.github/workflows/js/check-build-changes.test.js
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { hasReleaseBuildChanges } = require('./check-build-changes.js');
+
+test('builds for application changes', () => {
+  assert.equal(
+    hasReleaseBuildChanges(['application/src/electron/updater.ts']),
+    true
+  );
+});
+
+test('builds for updater changes', () => {
+  assert.equal(hasReleaseBuildChanges(['updater/src/main.ts']), true);
+});
+
+test('builds for workflow changes', () => {
+  assert.equal(
+    hasReleaseBuildChanges(['.github/workflows/build-release.yml']),
+    true
+  );
+});
+
+test('skips unrelated changes', () => {
+  assert.equal(hasReleaseBuildChanges(['README.md']), false);
+});

--- a/updater/package.json
+++ b/updater/package.json
@@ -29,7 +29,7 @@
     "mac": {}
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "bun test",
     "build": "tsc -p tsconfig.json",
     "dev": "bun run build && electron .",
     "preelectron-pack": "bun run build",

--- a/updater/src/git-sync.ts
+++ b/updater/src/git-sync.ts
@@ -1,0 +1,50 @@
+export type CommandResult = { stdout: string; stderr: string };
+
+export type GitCommandRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string }
+) => Promise<CommandResult>;
+
+export type BleedingEdgeSyncResult = {
+  beforeSyncSha: string;
+  afterSyncSha: string;
+  syncWasNoop: boolean;
+};
+
+const ALL_ORIGIN_HEADS_REFSPEC = '+refs/heads/*:refs/remotes/origin/*';
+
+export async function syncBleedingEdgeRepo(
+  repoDir: string,
+  branch: string,
+  defaultBranch: string,
+  runCommand: GitCommandRunner,
+  getRepoHeadSha: (repoDir: string) => Promise<string>
+): Promise<BleedingEdgeSyncResult> {
+  const targetBranch = branch || defaultBranch;
+  await runCommand(
+    'git',
+    ['fetch', '--prune', '--tags', 'origin', ALL_ORIGIN_HEADS_REFSPEC],
+    { cwd: repoDir }
+  );
+  const beforeSyncSha = await getRepoHeadSha(repoDir);
+  // This is an updater-owned build cache, so the fetched remote branch is the
+  // source of truth even when a feature branch has been force-pushed.
+  await runCommand(
+    'git',
+    [
+      'checkout',
+      '--force',
+      '-B',
+      targetBranch,
+      `refs/remotes/origin/${targetBranch}`,
+    ],
+    { cwd: repoDir }
+  );
+  const afterSyncSha = await getRepoHeadSha(repoDir);
+  return {
+    beforeSyncSha,
+    afterSyncSha,
+    syncWasNoop: beforeSyncSha === afterSyncSha,
+  };
+}

--- a/updater/src/main.ts
+++ b/updater/src/main.ts
@@ -11,6 +11,10 @@ import path, { join } from 'path';
 import yauzl, { type ZipFile } from 'yauzl';
 import zlib from 'zlib';
 import pjson from '../package.json' with { type: 'json' };
+import {
+  type BleedingEdgeSyncResult,
+  syncBleedingEdgeRepo as syncBleedingEdgeGitRepo,
+} from './git-sync.js';
 
 class UpdateError extends Data.TaggedError('UpdateError')<{
   readonly message: string;
@@ -247,13 +251,6 @@ function getApplicationBuildCommand() {
 }
 
 type CommandResult = { stdout: string; stderr: string };
-type BleedingEdgeSyncResult = {
-  beforePullSha: string;
-  afterPullSha: string;
-  pullOutput: string;
-  pullWasNoop: boolean;
-};
-
 type RunCommandOptions = {
   cwd?: string;
   /** Skip UI status updates (e.g. git metadata for branch/commit picker). */
@@ -311,25 +308,13 @@ async function syncBleedingEdgeRepo(
   repoDir: string,
   branch: string
 ): Promise<BleedingEdgeSyncResult> {
-  const targetBranch = branch || DEFAULT_BLEEDING_EDGE_BRANCH;
-  await runCommand(
-    'git',
-    ['fetch', '--prune', '--tags', 'origin', ALL_ORIGIN_HEADS_REFSPEC],
-    { cwd: repoDir }
+  return syncBleedingEdgeGitRepo(
+    repoDir,
+    branch,
+    DEFAULT_BLEEDING_EDGE_BRANCH,
+    runCommand,
+    getRepoHeadSha
   );
-  await runCommand('git', ['checkout', targetBranch], { cwd: repoDir });
-  const beforePullSha = await getRepoHeadSha(repoDir);
-  const pullResult = await runCommand(
-    'git',
-    ['pull', '--ff-only', 'origin', targetBranch],
-    { cwd: repoDir }
-  );
-  const afterPullSha = await getRepoHeadSha(repoDir);
-  const pullOutput = `${pullResult.stdout}\n${pullResult.stderr}`;
-  const pullWasNoop =
-    /already up[ -]to[ -]date/i.test(pullOutput) &&
-    beforePullSha === afterPullSha;
-  return { beforePullSha, afterPullSha, pullOutput, pullWasNoop };
 }
 
 /** Match .github/workflows/build-release.yml after hoisted `bun install`. */
@@ -396,7 +381,7 @@ function ensureBleedingEdgeBuild(
     );
     if (
       !commit &&
-      syncResult?.pullWasNoop &&
+      syncResult?.syncWasNoop &&
       shouldSkipBranchOnlyBleedingEdgeBuild(targetBranch, headSha)
     ) {
       sendUpdaterStatus(

--- a/updater/test/git-sync.test.ts
+++ b/updater/test/git-sync.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, expect, test } from 'bun:test';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { type CommandResult, syncBleedingEdgeRepo } from '../src/git-sync.js';
+
+const execFileAsync = promisify(execFile);
+const temporaryDirectories: string[] = [];
+
+async function git(cwd: string, ...args: string[]): Promise<CommandResult> {
+  const result = await execFileAsync('git', args, { cwd });
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+async function getHeadSha(repoDir: string): Promise<string> {
+  return (await git(repoDir, 'rev-parse', 'HEAD')).stdout.trim();
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string }
+): Promise<CommandResult> {
+  if (command !== 'git') {
+    throw new Error(`Unexpected command: ${command}`);
+  }
+  return git(options.cwd, ...args);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+test('synchronizes a cached branch after the remote branch is force-pushed', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'ogi-git-sync-'));
+  temporaryDirectories.push(root);
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const client = path.join(root, 'client');
+  const branch = 't3code/fix-parallel-limit-downloads';
+
+  await git(root, 'init', '--bare', remote);
+  await git(root, 'init', '-b', 'main', seed);
+  await git(seed, 'config', 'user.email', 'updater-test@example.invalid');
+  await git(seed, 'config', 'user.name', 'updater-test');
+  await writeFile(path.join(seed, 'file.txt'), 'base\n');
+  await git(seed, 'add', 'file.txt');
+  await git(seed, 'commit', '-m', 'base');
+  await git(seed, 'checkout', '-b', branch);
+  await writeFile(path.join(seed, 'file.txt'), 'old branch\n');
+  await git(seed, 'commit', '-am', 'old branch');
+  await git(seed, 'remote', 'add', 'origin', remote);
+  await git(seed, 'push', 'origin', 'main', branch);
+  await git(root, 'clone', '--branch', branch, remote, client);
+
+  await git(seed, 'checkout', 'main');
+  await git(seed, 'checkout', '-B', branch, 'main');
+  await writeFile(path.join(seed, 'file.txt'), 'rewritten branch\n');
+  await git(seed, 'add', 'file.txt');
+  await git(seed, 'commit', '-m', 'rewritten branch');
+  await git(seed, 'push', '--force', 'origin', branch);
+  const remoteSha = await getHeadSha(seed);
+
+  const result = await syncBleedingEdgeRepo(
+    client,
+    branch,
+    'main',
+    runCommand,
+    getHeadSha
+  );
+
+  expect(result.afterSyncSha).toBe(remoteSha);
+  expect(await getHeadSha(client)).toBe(remoteSha);
+});


### PR DESCRIPTION
## Summary

- Reset cached bleeding-edge repositories to the fetched remote branch, including force-pushed branches.
- Extract Git synchronization logic into a tested helper.
- Trigger release builds for application, updater, and workflow changes.
- Add release-build change detection tests and enable updater tests.

## Testing

- Added `updater/test/git-sync.test.ts` covering force-pushed branch synchronization.
- Added `.github/workflows/js/check-build-changes.test.js` covering build-trigger detection.
- Not run locally.