### PR TITLE
refactor(frontend): replace try-catch with Effect error handling

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,50 @@
+{
+  "languages": {
+    "Astro": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "CSS": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true
+      }
+    },
+    "HTML": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true
+      }
+    },
+    "JSON": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true
+      }
+    },
+    "JavaScript": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "Svelte": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TypeScript": {
+      "formatter": { "language_server": { "name": "biome" } },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    }
+  }
+}

--- a/application/src/frontend/App.svelte
+++ b/application/src/frontend/App.svelte
@@ -170,17 +170,16 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 async function initializeSearch() {
-  try {
-    const addonData = await Effect.runPromise(
-      queryConnectedAddons<ConfigTemplateAndInfo>()
-    );
-    addons = addonData;
-
-    const online = await Effect.runPromise(electronRpc.app.isOnline());
-    isOnline.set(online);
-  } catch (error) {
-    console.error('Failed to initialize search:', error);
-  }
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      addons = yield* queryConnectedAddons<ConfigTemplateAndInfo>();
+      isOnline.set(yield* electronRpc.app.isOnline());
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() => console.error('Failed to initialize search:', error))
+      )
+    )
+  );
 }
 
 let activeQuery: string | null = $state(null);
@@ -419,16 +418,20 @@ document.addEventListener('all-addons-started', async () => {
     addonUpdates.set([]);
     // restart the addon server
     await Effect.runPromise(electronRpc.restartAddonServer());
-    try {
-      await Effect.runPromise(reconnectClientSdk());
-    } catch (error) {
-      console.error('Failed to reconnect to the addon server:', error);
-      createNotification({
-        id: Math.random().toString(36).substring(7),
-        message: 'Failed to reconnect to the addon server',
-        type: 'error',
-      });
-    }
+    await Effect.runPromise(
+      reconnectClientSdk().pipe(
+        Effect.catchAll((error) =>
+          Effect.sync(() => {
+            console.error('Failed to reconnect to the addon server:', error);
+            createNotification({
+              id: Math.random().toString(36).substring(7),
+              message: 'Failed to reconnect to the addon server',
+              type: 'error',
+            });
+          })
+        )
+      )
+    );
   }
 });
 document.addEventListener('addon:updated', (event) => {

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -149,38 +149,50 @@ async function removeFromList() {
 
 async function addToSteam(button: HTMLButtonElement) {
   button.disabled = true;
-  try {
-    const requiredReadd = getRequiredReadd(gameInfo.appID);
-    const result = await Effect.runPromise(
-      electronRpc.app.addToSteam(
+  const requiredReadd = getRequiredReadd(gameInfo.appID);
+  await Effect.runPromise(
+    electronRpc.app
+      .addToSteam(
         gameInfo.appID,
         requiredReadd?.steamAppId ?? gameInfo.umu?.steamShortcutReaddId
       )
-    );
-
-    if (result.status === 'success') {
-      completeRequiredReadd(gameInfo.appID);
-      createNotification({
-        id: Math.random().toString(36).substring(7),
-        message: result.warning ?? 'Game added to Steam',
-        type: result.warning ? 'warning' : 'success',
-      });
-    } else {
-      createNotification({
-        id: Math.random().toString(36).substring(7),
-        message: result.status === 'cancelled' ? result.message : result.error,
-        type: result.status === 'cancelled' ? 'warning' : 'error',
-      });
-    }
-  } catch (error) {
-    console.error(error);
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: 'Failed to add game to Steam',
-      type: 'error',
-    });
-  }
-  button.disabled = false;
+      .pipe(
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            if (result.status === 'success') {
+              completeRequiredReadd(gameInfo.appID);
+              createNotification({
+                id: Math.random().toString(36).substring(7),
+                message: result.warning ?? 'Game added to Steam',
+                type: result.warning ? 'warning' : 'success',
+              });
+              return;
+            }
+            createNotification({
+              id: Math.random().toString(36).substring(7),
+              message:
+                result.status === 'cancelled' ? result.message : result.error,
+              type: result.status === 'cancelled' ? 'warning' : 'error',
+            });
+          })
+        ),
+        Effect.catchAll((error) =>
+          Effect.sync(() => {
+            console.error(error);
+            createNotification({
+              id: Math.random().toString(36).substring(7),
+              message: 'Failed to add game to Steam',
+              type: 'error',
+            });
+          })
+        ),
+        Effect.ensuring(
+          Effect.sync(() => {
+            button.disabled = false;
+          })
+        )
+      )
+  );
 }
 
 function getInputType(

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -17,6 +17,7 @@ import InputModal from '@/frontend/components/modal/InputModal.svelte';
 import Modal from '@/frontend/components/modal/Modal.svelte';
 import TitleModal from '@/frontend/components/modal/TitleModal.svelte';
 import WineDllOverridesModal from '@/frontend/components/modal/WineDllOverridesModal.svelte';
+import { addToSteam as addToSteamEffect } from '@/frontend/lib/core/steam';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import {
   completeRequiredReadd,
@@ -148,50 +149,22 @@ async function removeFromList() {
 }
 
 async function addToSteam(button: HTMLButtonElement) {
-  button.disabled = true;
   const requiredReadd = getRequiredReadd(gameInfo.appID);
   await Effect.runPromise(
-    electronRpc.app
-      .addToSteam(
-        gameInfo.appID,
-        requiredReadd?.steamAppId ?? gameInfo.umu?.steamShortcutReaddId
-      )
-      .pipe(
-        Effect.tap((result) =>
-          Effect.sync(() => {
-            if (result.status === 'success') {
-              completeRequiredReadd(gameInfo.appID);
-              createNotification({
-                id: Math.random().toString(36).substring(7),
-                message: result.warning ?? 'Game added to Steam',
-                type: result.warning ? 'warning' : 'success',
-              });
-              return;
-            }
-            createNotification({
-              id: Math.random().toString(36).substring(7),
-              message:
-                result.status === 'cancelled' ? result.message : result.error,
-              type: result.status === 'cancelled' ? 'warning' : 'error',
-            });
-          })
-        ),
-        Effect.catchAll((error) =>
-          Effect.sync(() => {
-            console.error(error);
-            createNotification({
-              id: Math.random().toString(36).substring(7),
-              message: 'Failed to add game to Steam',
-              type: 'error',
-            });
-          })
-        ),
-        Effect.ensuring(
-          Effect.sync(() => {
-            button.disabled = false;
-          })
-        )
-      )
+    addToSteamEffect({
+      appID: gameInfo.appID,
+      oldSteamAppId:
+        requiredReadd?.steamAppId ?? gameInfo.umu?.steamShortcutReaddId,
+      button,
+      onSuccess: (warning) => {
+        completeRequiredReadd(gameInfo.appID);
+        createNotification({
+          id: Math.random().toString(36).substring(7),
+          message: warning ?? 'Game added to Steam',
+          type: warning ? 'warning' : 'success',
+        });
+      },
+    })
   );
 }
 

--- a/application/src/frontend/components/GameLaunchOverlay.svelte
+++ b/application/src/frontend/components/GameLaunchOverlay.svelte
@@ -66,9 +66,10 @@ onMount(async () => {
         `[GameLaunchOverlay] Running ${hookType}-launch hooks for ${gameName}`
       );
 
-      try {
-        await Effect.runPromise(runLaunchAppAddons(libraryInfo, hookType));
-
+      const hookResult = await Effect.runPromise(
+        runLaunchAppAddons(libraryInfo, hookType).pipe(Effect.either)
+      );
+      if (hookResult._tag === 'Right') {
         status = 'success';
         console.log(`[GameLaunchOverlay] ${hookType}-launch hooks completed`);
 
@@ -79,7 +80,8 @@ onMount(async () => {
           }
         }, 2000);
         timeouts.push(t);
-      } catch (error) {
+      } else {
+        const error = hookResult.left;
         console.error(
           `[GameLaunchOverlay] ${hookType}-launch hooks failed:`,
           error
@@ -100,9 +102,11 @@ onMount(async () => {
         `[GameLaunchOverlay] Running wrapped launch for ${gameName}: ${wrapperCommand}`
       );
 
-      try {
-        await Effect.runPromise(runLaunchAppAddons(libraryInfo, 'pre'));
-      } catch (error) {
+      const preLaunchResult = await Effect.runPromise(
+        runLaunchAppAddons(libraryInfo, 'pre').pipe(Effect.either)
+      );
+      if (preLaunchResult._tag === 'Left') {
+        const error = preLaunchResult.left;
         console.error('[GameLaunchOverlay] Pre-launch hooks failed:', error);
         status = 'error';
         errorMessage =
@@ -126,9 +130,11 @@ onMount(async () => {
       await Effect.runPromise(electronRpc.app.showWindow());
 
       let postLaunchError: string | null = null;
-      try {
-        await Effect.runPromise(runLaunchAppAddons(libraryInfo, 'post'));
-      } catch (error) {
+      const postLaunchResult = await Effect.runPromise(
+        runLaunchAppAddons(libraryInfo, 'post').pipe(Effect.either)
+      );
+      if (postLaunchResult._tag === 'Left') {
+        const error = postLaunchResult.left;
         console.error('[GameLaunchOverlay] Post-launch hooks failed:', error);
         postLaunchError =
           error instanceof Error ? error.message : 'Post-launch failed';

--- a/application/src/frontend/components/GameLaunchOverlay.svelte
+++ b/application/src/frontend/components/GameLaunchOverlay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { formatError } from '@ogi/errors';
 import { Effect } from 'effect';
 import { onDestroy, onMount } from 'svelte';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
@@ -87,8 +88,7 @@ onMount(async () => {
           error
         );
         status = 'error';
-        errorMessage =
-          error instanceof Error ? error.message : 'Hook execution failed';
+        errorMessage = formatError(error) || 'Hook execution failed';
         onError(errorMessage);
 
         const t = setTimeout(() => {
@@ -109,8 +109,7 @@ onMount(async () => {
         const error = preLaunchResult.left;
         console.error('[GameLaunchOverlay] Pre-launch hooks failed:', error);
         status = 'error';
-        errorMessage =
-          error instanceof Error ? error.message : 'Pre-launch failed';
+        errorMessage = formatError(error) || 'Pre-launch failed';
         onError(errorMessage);
         const t = setTimeout(() => {
           if (isMounted) Effect.runPromise(electronRpc.app.quit());
@@ -136,8 +135,7 @@ onMount(async () => {
       if (postLaunchResult._tag === 'Left') {
         const error = postLaunchResult.left;
         console.error('[GameLaunchOverlay] Post-launch hooks failed:', error);
-        postLaunchError =
-          error instanceof Error ? error.message : 'Post-launch failed';
+        postLaunchError = formatError(error) || 'Post-launch failed';
       }
 
       if (wrapperError || postLaunchError) {

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -259,55 +259,113 @@ async function migrateToUmu() {
   if (isMigratingToUmu) return;
   isMigratingToUmu = true;
 
-  try {
-    const steamAppIdResult = await Effect.runPromise(
-      electronRpc.app.getSteamAppId(libraryInfo.appID)
-    );
-    const oldSteamAppId =
-      steamAppIdResult.status === 'success'
-        ? steamAppIdResult.appId
-        : undefined;
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const steamAppIdResult = yield* electronRpc.app.getSteamAppId(
+        libraryInfo.appID
+      );
+      const oldSteamAppId =
+        steamAppIdResult.status === 'success'
+          ? steamAppIdResult.appId
+          : undefined;
 
-    const migrationResult = await Effect.runPromise(
-      electronRpc.app.migrateToUmu(libraryInfo.appID, oldSteamAppId)
-    );
+      const migrationResult = yield* electronRpc.app.migrateToUmu(
+        libraryInfo.appID,
+        oldSteamAppId
+      );
 
-    if (!migrationResult.success) {
+      if (!migrationResult.success) {
+        createNotification({
+          id: Math.random().toString(36).substring(7),
+          type: 'error',
+          message: migrationResult.error || 'Failed to migrate game to UMU',
+        });
+        return;
+      }
+
+      const updatedLibraryInfo = yield* electronRpc.app.getLibraryInfo(
+        libraryInfo.appID
+      );
+      if (updatedLibraryInfo) {
+        libraryInfo = updatedLibraryInfo;
+      }
+
+      // Queue Steam re-add requirement so the existing banner appears
+      // and persistence writes update-state.json automatically.
+      queueRequiredReadd(libraryInfo.appID, oldSteamAppId);
+
       createNotification({
         id: Math.random().toString(36).substring(7),
-        type: 'error',
-        message: migrationResult.error || 'Failed to migrate game to UMU',
+        type: 'success',
+        message: 'Successfully migrated game prefix to UMU',
       });
-      return;
-    }
+      showUmuMigrationCompletePrompt();
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          console.error(error);
+          createNotification({
+            id: Math.random().toString(36).substring(7),
+            type: 'error',
+            message: 'Failed to migrate game to UMU',
+          });
+        })
+      ),
+      Effect.ensuring(
+        Effect.sync(() => {
+          isMigratingToUmu = false;
+        })
+      )
+    )
+  );
+}
 
-    const updatedLibraryInfo = await Effect.runPromise(
-      electronRpc.app.getLibraryInfo(libraryInfo.appID)
-    );
-    if (updatedLibraryInfo) {
-      libraryInfo = updatedLibraryInfo;
-    }
+function addRequiredReaddToSteam(button: HTMLButtonElement): Promise<void> {
+  button.disabled = true;
+  const requiredReadd = getRequiredReadd(libraryInfo.appID);
 
-    // Queue Steam re-add requirement so the existing banner appears
-    // and persistence writes update-state.json automatically.
-    queueRequiredReadd(libraryInfo.appID, oldSteamAppId);
+  return Effect.runPromise(
+    electronRpc.app
+      .addToSteam(
+        libraryInfo.appID,
+        requiredReadd?.steamAppId ?? libraryInfo.umu?.steamShortcutReaddId
+      )
+      .pipe(
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            if (result.status === 'success') {
+              completeRequiredReadd(libraryInfo.appID);
+              if (libraryInfo.umu) {
+                delete libraryInfo.umu.steamShortcutReaddId;
+                libraryInfo = { ...libraryInfo };
+              }
+              if (result.warning) {
+                createNotification({
+                  id: Math.random().toString(36).substring(7),
+                  message: result.warning,
+                  type: 'warning',
+                });
+              }
+              return;
+            }
 
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      type: 'success',
-      message: 'Successfully migrated game prefix to UMU',
-    });
-    showUmuMigrationCompletePrompt();
-  } catch (error) {
-    console.error(error);
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      type: 'error',
-      message: 'Failed to migrate game to UMU',
-    });
-  } finally {
-    isMigratingToUmu = false;
-  }
+            createNotification({
+              id: Math.random().toString(36).substring(7),
+              message:
+                result.status === 'cancelled' ? result.message : result.error,
+              type: result.status === 'cancelled' ? 'info' : 'error',
+            });
+            button.disabled = false;
+          })
+        ),
+        Effect.catchAll((error) =>
+          Effect.sync(() => {
+            console.error(error);
+            button.disabled = false;
+          })
+        )
+      )
+  );
 }
 
 let searchingAddons: { [key: string]: SearchResult[] | undefined } = $state({});
@@ -673,45 +731,7 @@ function handleRunTask(task: SearchResult, addonID: string) {
               class="flex flex-1 items-center justify-center gap-2 rounded-lg border-none bg-accent-light px-4 py-2 font-archivo font-semibold text-accent-dark transition-colors duration-200 hover:bg-accent-light/80 disabled:cursor-not-allowed disabled:bg-disabled/50"
               onclick={async (event) => {
                 const button = event.currentTarget as HTMLButtonElement;
-                try {
-                  button.disabled = true;
-
-                  const requiredReadd = getRequiredReadd(libraryInfo.appID);
-                  const result = await Effect.runPromise(electronRpc.app.addToSteam(
-                    libraryInfo.appID,
-                    requiredReadd?.steamAppId ??
-                      libraryInfo.umu?.steamShortcutReaddId
-                  ));
-
-                  if (result.status === 'success') {
-                    completeRequiredReadd(libraryInfo.appID);
-                    if (libraryInfo.umu) {
-                      delete libraryInfo.umu.steamShortcutReaddId;
-                      libraryInfo = { ...libraryInfo };
-                    }
-                    if (result.warning) {
-                      createNotification({
-                        id: Math.random().toString(36).substring(7),
-                        message: result.warning,
-                        type: 'warning',
-                      });
-                    }
-                  } else {
-                    createNotification({
-                      id: Math.random().toString(36).substring(7),
-                      message:
-                        result.status === 'cancelled'
-                          ? result.message
-                          : result.error,
-                      type: result.status === 'cancelled' ? 'info' : 'error',
-                    });
-                    button.disabled = false;
-                  }
-                } catch (error) {
-                  console.error(error);
-                  // Re-enable button on error
-                  button.disabled = false;
-                }
+                await addRequiredReaddToSteam(button);
               }}
             >
               <svg

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -13,6 +13,7 @@ import PlayIcon from '@/frontend/Icons/PlayIcon.svelte';
 import SettingsFilled from '@/frontend/Icons/SettingsFilled.svelte';
 import UpdateIcon from '@/frontend/Icons/UpdateIcon.svelte';
 import { runDetached } from '@/frontend/lib/core/runtime';
+import { addToSteam } from '@/frontend/lib/core/steam';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import {
   appUpdates,
@@ -321,50 +322,29 @@ async function migrateToUmu() {
 }
 
 function addRequiredReaddToSteam(button: HTMLButtonElement): Promise<void> {
-  button.disabled = true;
   const requiredReadd = getRequiredReadd(libraryInfo.appID);
 
   return Effect.runPromise(
-    electronRpc.app
-      .addToSteam(
-        libraryInfo.appID,
-        requiredReadd?.steamAppId ?? libraryInfo.umu?.steamShortcutReaddId
-      )
-      .pipe(
-        Effect.tap((result) =>
-          Effect.sync(() => {
-            if (result.status === 'success') {
-              completeRequiredReadd(libraryInfo.appID);
-              if (libraryInfo.umu) {
-                delete libraryInfo.umu.steamShortcutReaddId;
-                libraryInfo = { ...libraryInfo };
-              }
-              if (result.warning) {
-                createNotification({
-                  id: Math.random().toString(36).substring(7),
-                  message: result.warning,
-                  type: 'warning',
-                });
-              }
-              return;
-            }
-
-            createNotification({
-              id: Math.random().toString(36).substring(7),
-              message:
-                result.status === 'cancelled' ? result.message : result.error,
-              type: result.status === 'cancelled' ? 'info' : 'error',
-            });
-            button.disabled = false;
-          })
-        ),
-        Effect.catchAll((error) =>
-          Effect.sync(() => {
-            console.error(error);
-            button.disabled = false;
-          })
-        )
-      )
+    addToSteam({
+      appID: libraryInfo.appID,
+      oldSteamAppId:
+        requiredReadd?.steamAppId ?? libraryInfo.umu?.steamShortcutReaddId,
+      button,
+      onSuccess: (warning) => {
+        completeRequiredReadd(libraryInfo.appID);
+        if (libraryInfo.umu) {
+          delete libraryInfo.umu.steamShortcutReaddId;
+          libraryInfo = { ...libraryInfo };
+        }
+        if (warning) {
+          createNotification({
+            id: Math.random().toString(36).substring(7),
+            message: warning,
+            type: 'warning',
+          });
+        }
+      },
+    })
   );
 }
 

--- a/application/src/frontend/components/built/UpdateAppModal.svelte
+++ b/application/src/frontend/components/built/UpdateAppModal.svelte
@@ -15,7 +15,7 @@ import {
   findAddonsSupportingStorefront,
   isAddonEventAvailable,
   type SearchResultWithAddon,
-  startDownload,
+  startDownloadEffect,
 } from '@/frontend/utils';
 import { supportsStorefront } from '@/lib/storefronts';
 
@@ -221,7 +221,7 @@ async function handleDownloadClick(
   } as SearchResultWithAddon & { isUpdate: boolean; updateVersion: string };
 
   const started = await Effect.runPromise(
-    startDownload(updateResult, appID, event).pipe(
+    startDownloadEffect(updateResult, appID, event).pipe(
       Effect.as(true),
       Effect.catchAll((error) =>
         Effect.sync(() => {

--- a/application/src/frontend/components/built/UpdateAppModal.svelte
+++ b/application/src/frontend/components/built/UpdateAppModal.svelte
@@ -220,17 +220,23 @@ async function handleDownloadClick(
     updateVersion: updateVersion,
   } as SearchResultWithAddon & { isUpdate: boolean; updateVersion: string };
 
-  try {
-    await Effect.runPromise(startDownload(updateResult, appID, event));
-  } catch (error) {
-    console.error('Failed to start update download:', error);
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: `Failed to start update download for ${gameName}`,
-      type: 'error',
-    });
-    return;
-  }
+  const started = await Effect.runPromise(
+    startDownload(updateResult, appID, event).pipe(
+      Effect.as(true),
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          console.error('Failed to start update download:', error);
+          createNotification({
+            id: Math.random().toString(36).substring(7),
+            message: `Failed to start update download for ${gameName}`,
+            type: 'error',
+          });
+          return false;
+        })
+      )
+    )
+  );
+  if (!started) return;
   onClose();
 
   createNotification({

--- a/application/src/frontend/lib/core/steam.ts
+++ b/application/src/frontend/lib/core/steam.ts
@@ -1,0 +1,54 @@
+import { Effect } from 'effect';
+import { electronRpc } from '@/frontend/lib/electron-rpc';
+import { createNotification } from '@/frontend/store.svelte';
+
+interface AddToSteamOptions {
+  appID: number;
+  oldSteamAppId?: number;
+  button: HTMLButtonElement;
+  onSuccess: (warning?: string) => void;
+}
+
+/** Runs the shared Steam-add workflow and always restores the triggering button. */
+export function addToSteam({
+  appID,
+  oldSteamAppId,
+  button,
+  onSuccess,
+}: AddToSteamOptions): Effect.Effect<void, never> {
+  button.disabled = true;
+
+  return electronRpc.app.addToSteam(appID, oldSteamAppId).pipe(
+    Effect.tap((result) =>
+      Effect.sync(() => {
+        if (result.status === 'success') {
+          onSuccess(result.warning);
+          return;
+        }
+
+        createNotification({
+          id: Math.random().toString(36).substring(7),
+          message:
+            result.status === 'cancelled' ? result.message : result.error,
+          type: result.status === 'cancelled' ? 'info' : 'error',
+        });
+      })
+    ),
+    Effect.catchAll((error) =>
+      Effect.sync(() => {
+        console.error(error);
+        createNotification({
+          id: Math.random().toString(36).substring(7),
+          message: 'Failed to add game to Steam',
+          type: 'error',
+        });
+      })
+    ),
+    Effect.ensuring(
+      Effect.sync(() => {
+        button.disabled = false;
+      })
+    ),
+    Effect.asVoid
+  );
+}

--- a/application/src/frontend/lib/core/steam.ts
+++ b/application/src/frontend/lib/core/steam.ts
@@ -16,9 +16,10 @@ export function addToSteam({
   button,
   onSuccess,
 }: AddToSteamOptions): Effect.Effect<void, never> {
-  button.disabled = true;
-
-  return electronRpc.app.addToSteam(appID, oldSteamAppId).pipe(
+  return Effect.sync(() => {
+    button.disabled = true;
+  }).pipe(
+    Effect.flatMap(() => electronRpc.app.addToSteam(appID, oldSteamAppId)),
     Effect.tap((result) =>
       Effect.sync(() => {
         if (result.status === 'success') {

--- a/application/src/frontend/lib/downloads/lifecycle.ts
+++ b/application/src/frontend/lib/downloads/lifecycle.ts
@@ -13,7 +13,8 @@ import {
 
 /**
  * Resolves download handler from config, finds the matching service, and starts the download.
- * Resets the button and notifies on failure if startDownload throws.
+ * Preserves failures for callers that need to react to whether the download started.
+ * The download button is reset before a failure is returned.
  * @param result - Search result with addon and download URL/type
  * @param appID - Application ID for the download
  * @param event - Mouse event (used to resolve button if htmlButton not provided)
@@ -85,10 +86,19 @@ export function startDownloadEffect(
       event,
       resolvedButton ?? undefined
     );
-  }).pipe(
+  }).pipe(Effect.tapError(() => Effect.sync(resetButton)));
+}
+
+/** Starts a download and reports failures through the standard notification UI. */
+export function startDownload(
+  result: SearchResultWithAddon,
+  appID: number,
+  event: MouseEvent | null,
+  htmlButton?: HTMLButtonElement
+) {
+  return startDownloadEffect(result, appID, event, htmlButton).pipe(
     Effect.catchAll((error) =>
       Effect.sync(() => {
-        resetButton();
         console.error('startDownload failed:', error);
         createNotification({
           id: Math.random().toString(36).substring(7),
@@ -99,8 +109,6 @@ export function startDownloadEffect(
     )
   );
 }
-
-export const startDownload = startDownloadEffect;
 
 /**
  * Updates a download's status and optional fields in the currentDownloads store.

--- a/application/src/frontend/lib/downloads/pause-resume.ts
+++ b/application/src/frontend/lib/downloads/pause-resume.ts
@@ -1,6 +1,7 @@
 import { DownloadError, formatError } from '@ogi/errors';
 import { Deferred, Effect } from 'effect';
 import { get } from 'svelte/store';
+import { runDetached } from '@/frontend/lib/core/runtime';
 import {
   getDownloadItem,
   updateDownloadStatus,
@@ -239,15 +240,9 @@ export function cancelPausedDownload(downloadId: string) {
     const pausedState = pausedDownloadStates.get(downloadId);
     const item = pausedState?.downloadInfo ?? getDownloadItem(downloadId);
     pausedDownloadStates.delete(downloadId);
-    yield* electronRpc.queue.cancel(downloadId).pipe(
-      Effect.mapError(
-        (cause) =>
-          new DownloadError({
-            message: `Failed to cancel download: ${formatError(cause)}`,
-            downloadId,
-            cause,
-          })
-      )
+    runDetached(
+      electronRpc.queue.cancel(downloadId),
+      `Failed to cancel download ${downloadId}`
     );
     yield* deleteDownloadedItems(downloadId);
     deletePersistedDownload(downloadId);

--- a/application/src/frontend/lib/downloads/pause-resume.ts
+++ b/application/src/frontend/lib/downloads/pause-resume.ts
@@ -48,32 +48,28 @@ function backendAction(
 ) {
   const operation =
     download.downloadType === 'direct' || download.usedDebridService
-      ? () =>
-          action === 'pause'
-            ? Effect.runPromise(electronRpc.ddl.pauseDownload(download.id))
-            : Effect.runPromise(electronRpc.ddl.resumeDownload(download.id))
+      ? action === 'pause'
+        ? electronRpc.ddl.pauseDownload(download.id)
+        : electronRpc.ddl.resumeDownload(download.id)
       : download.downloadType === 'torrent' ||
           download.downloadType === 'magnet'
-        ? () =>
-            action === 'pause'
-              ? Effect.runPromise(
-                  electronRpc.torrent.pauseDownload(download.id)
-                )
-              : Effect.runPromise(
-                  electronRpc.torrent.resumeDownload(download.id)
-                )
+        ? action === 'pause'
+          ? electronRpc.torrent.pauseDownload(download.id)
+          : electronRpc.torrent.resumeDownload(download.id)
         : undefined;
 
   return operation
-    ? Effect.tryPromise({
-        try: () => operation().then(() => undefined),
-        catch: (cause) =>
-          new DownloadError({
-            message: `Failed to ${action} download: ${formatError(cause)}`,
-            downloadId: download.id,
-            cause,
-          }),
-      }).pipe(Effect.as(true))
+    ? operation.pipe(
+        Effect.mapError(
+          (cause) =>
+            new DownloadError({
+              message: `Failed to ${action} download: ${formatError(cause)}`,
+              downloadId: download.id,
+              cause,
+            })
+        ),
+        Effect.as(true)
+      )
     : Effect.succeed(false);
 }
 
@@ -243,7 +239,16 @@ export function cancelPausedDownload(downloadId: string) {
     const pausedState = pausedDownloadStates.get(downloadId);
     const item = pausedState?.downloadInfo ?? getDownloadItem(downloadId);
     pausedDownloadStates.delete(downloadId);
-    Effect.runPromise(electronRpc.queue.cancel(downloadId));
+    yield* electronRpc.queue.cancel(downloadId).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DownloadError({
+            message: `Failed to cancel download: ${formatError(cause)}`,
+            downloadId,
+            cause,
+          })
+      )
+    );
     yield* deleteDownloadedItems(downloadId);
     deletePersistedDownload(downloadId);
     currentDownloads.update((downloads) =>

--- a/application/src/frontend/lib/downloads/restart.ts
+++ b/application/src/frontend/lib/downloads/restart.ts
@@ -20,20 +20,21 @@ export interface PausedDownloadState {
   files?: unknown[];
 }
 
-const downloadPromise = <A>(
-  operation: () => Promise<A>,
+const downloadRpc = <A, E>(
+  operation: Effect.Effect<A, E>,
   download: DownloadStatusAndInfo,
   message: string
 ) =>
-  Effect.tryPromise({
-    try: operation,
-    catch: (cause) =>
-      new DownloadError({
-        message: `${message}: ${formatError(cause)}`,
-        downloadId: download.id,
-        cause,
-      }),
-  });
+  operation.pipe(
+    Effect.mapError(
+      (cause) =>
+        new DownloadError({
+          message: `${message}: ${formatError(cause)}`,
+          downloadId: download.id,
+          cause,
+        })
+    )
+  );
 
 function effectiveDownloadUrl(
   download: DownloadStatusAndInfo
@@ -101,8 +102,8 @@ function restartDirectDownload(download: DownloadStatusAndInfo) {
       );
     }
 
-    const handshake = yield* downloadPromise(
-      () => Effect.runPromise(electronRpc.ddl.download(files, download.part)),
+    const handshake = yield* downloadRpc(
+      electronRpc.ddl.download(files, download.part),
       download,
       'Failed to restart direct download'
     );
@@ -144,15 +145,9 @@ function restartTorrentDownload(download: DownloadStatusAndInfo) {
     const path = folderPath;
     const operation =
       download.downloadType === 'torrent'
-        ? () =>
-            Effect.runPromise(
-              electronRpc.torrent.downloadTorrent(effectiveUrl, path)
-            )
-        : () =>
-            Effect.runPromise(
-              electronRpc.torrent.downloadMagnet(effectiveUrl, path)
-            );
-    const handshake = yield* downloadPromise(
+        ? electronRpc.torrent.downloadTorrent(effectiveUrl, path)
+        : electronRpc.torrent.downloadMagnet(effectiveUrl, path);
+    const handshake = yield* downloadRpc(
       operation,
       download,
       'Failed to restart torrent download'

--- a/application/src/frontend/lib/downloads/services/AllDebridService.ts
+++ b/application/src/frontend/lib/downloads/services/AllDebridService.ts
@@ -23,18 +23,19 @@ type AllDebridSearchResult = SearchResultWithAddon & {
   filename?: string;
 };
 
-const allDebridPromise = <A>(
-  operation: () => Promise<A>,
+const allDebridRpc = <A, E>(
+  operation: Effect.Effect<A, E>,
   message: string
 ): Effect.Effect<A, DebridError> =>
-  Effect.tryPromise({
-    try: operation,
-    catch: (cause) =>
-      new DebridError({
-        message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
-        service: 'alldebrid',
-      }),
-  });
+  operation.pipe(
+    Effect.mapError(
+      (cause) =>
+        new DebridError({
+          message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          service: 'alldebrid',
+        })
+    )
+  );
 
 function localNamesForLinks(
   links: string[],
@@ -62,8 +63,8 @@ function waitForTorrentReady(id: string) {
   return Effect.gen(function* () {
     for (let attempt = 0; attempt < 200; attempt++) {
       if (
-        yield* allDebridPromise(
-          () => Effect.runPromise(electronRpc.alldebrid.isTorrentReady(id)),
+        yield* allDebridRpc(
+          electronRpc.alldebrid.isTorrentReady(id),
           'Failed to check AllDebrid torrent status'
         )
       ) {
@@ -102,8 +103,8 @@ export class AllDebridService extends BaseService {
           })
         );
       }
-      const worked = yield* allDebridPromise(
-        () => Effect.runPromise(electronRpc.alldebrid.updateKey()),
+      const worked = yield* allDebridRpc(
+        electronRpc.alldebrid.updateKey(),
         'Failed to update AllDebrid API key'
       );
       if (!worked) {
@@ -152,11 +153,8 @@ export class AllDebridService extends BaseService {
 
   private getTorrentIdFromMagnet(result: AllDebridSearchResult) {
     return Effect.gen(function* () {
-      const magnet = yield* allDebridPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.alldebrid.addMagnet(result.downloadURL)
-          ),
+      const magnet = yield* allDebridRpc(
+        electronRpc.alldebrid.addMagnet(result.downloadURL),
         'Failed to add magnet to AllDebrid'
       );
       return magnet.id;
@@ -191,11 +189,8 @@ export class AllDebridService extends BaseService {
           })
         );
       }
-      const torrent = yield* allDebridPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.alldebrid.addTorrent(result.downloadURL)
-          ),
+      const torrent = yield* allDebridRpc(
+        electronRpc.alldebrid.addTorrent(result.downloadURL),
         'Failed to add torrent to AllDebrid'
       );
       if (!torrent) {
@@ -218,21 +213,19 @@ export class AllDebridService extends BaseService {
   ) {
     return Effect.gen(function* () {
       const torrentId = yield* getTorrentId;
-      const isReady = yield* allDebridPromise(
-        () =>
-          Effect.runPromise(electronRpc.alldebrid.isTorrentReady(torrentId)),
+      const isReady = yield* allDebridRpc(
+        electronRpc.alldebrid.isTorrentReady(torrentId),
         'Failed to check AllDebrid torrent status'
       );
       if (!isReady) {
-        yield* allDebridPromise(
-          () => Effect.runPromise(electronRpc.alldebrid.selectTorrent()),
+        yield* allDebridRpc(
+          electronRpc.alldebrid.selectTorrent(),
           'Failed to select AllDebrid torrent files'
         );
         yield* waitForTorrentReady(torrentId);
       }
-      const torrentInfo = yield* allDebridPromise(
-        () =>
-          Effect.runPromise(electronRpc.alldebrid.getTorrentInfo(torrentId)),
+      const torrentInfo = yield* allDebridRpc(
+        electronRpc.alldebrid.getTorrentInfo(torrentId),
         'Failed to load AllDebrid torrent info'
       );
       const markError = () =>
@@ -256,8 +249,8 @@ export class AllDebridService extends BaseService {
       });
       const resolvedLinks: string[] = [];
       for (const link of torrentInfo.links) {
-        const download = yield* allDebridPromise(
-          () => Effect.runPromise(electronRpc.alldebrid.unrestrictLink(link)),
+        const download = yield* allDebridRpc(
+          electronRpc.alldebrid.unrestrictLink(link),
           'Failed to unrestrict AllDebrid link'
         );
         if (!download) {
@@ -278,17 +271,14 @@ export class AllDebridService extends BaseService {
         torrentInfo.files,
         result.filename
       );
-      const handshake = yield* allDebridPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.ddl.download(
-              resolvedLinks.map((link, index) => ({
-                link,
-                path: safePath + localNames[index],
-                headers: { 'OGI-Parallel-Limit': '1' },
-              }))
-            )
-          ),
+      const handshake = yield* allDebridRpc(
+        electronRpc.ddl.download(
+          resolvedLinks.map((link, index) => ({
+            link,
+            path: safePath + localNames[index],
+            headers: { 'OGI-Parallel-Limit': '1' },
+          }))
+        ),
         'Failed to start AllDebrid download'
       );
       if (handshake.status === 'error' || !handshake.id) {

--- a/application/src/frontend/lib/downloads/services/AllDebridService.ts
+++ b/application/src/frontend/lib/downloads/services/AllDebridService.ts
@@ -1,4 +1,4 @@
-import { DebridError, ValidationError } from '@ogi/errors';
+import { DebridError, formatError, ValidationError } from '@ogi/errors';
 import { Effect } from 'effect';
 import { getDownloadPath } from '@/frontend/lib/core/fs';
 import {
@@ -31,7 +31,7 @@ const allDebridRpc = <A, E>(
     Effect.mapError(
       (cause) =>
         new DebridError({
-          message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          message: `${message}: ${formatError(cause)}`,
           service: 'alldebrid',
         })
     )

--- a/application/src/frontend/lib/downloads/services/PremiumizeService.ts
+++ b/application/src/frontend/lib/downloads/services/PremiumizeService.ts
@@ -1,4 +1,4 @@
-import { DebridError } from '@ogi/errors';
+import { DebridError, formatError } from '@ogi/errors';
 import { Effect } from 'effect';
 import { getConfigClientOption } from '@/frontend/lib/config/client';
 import { getDownloadPath } from '@/frontend/lib/core/fs';
@@ -46,7 +46,7 @@ const premiumizeRpc = <A, E>(operation: Effect.Effect<A, E>, message: string) =>
     Effect.mapError(
       (cause) =>
         new DebridError({
-          message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          message: `${message}: ${formatError(cause)}`,
           service: 'premiumize' as const,
         })
     )

--- a/application/src/frontend/lib/downloads/services/PremiumizeService.ts
+++ b/application/src/frontend/lib/downloads/services/PremiumizeService.ts
@@ -41,15 +41,16 @@ type PremiumizeZipGenerateResponse =
   | PremiumizeErrorResponse
   | { status: 'success'; location: string };
 
-const premiumizePromise = <A>(operation: () => Promise<A>, message: string) =>
-  Effect.tryPromise({
-    try: operation,
-    catch: (cause) =>
-      new DebridError({
-        message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
-        service: 'premiumize' as const,
-      }),
-  });
+const premiumizeRpc = <A, E>(operation: Effect.Effect<A, E>, message: string) =>
+  operation.pipe(
+    Effect.mapError(
+      (cause) =>
+        new DebridError({
+          message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          service: 'premiumize' as const,
+        })
+    )
+  );
 
 export class PremiumizeService extends BaseService {
   readonly types = ['premiumize-magnet', 'premiumize-torrent'];
@@ -88,33 +89,27 @@ export class PremiumizeService extends BaseService {
       }
       const { premiumizeApiKey } = options;
 
-      const responseFolder = yield* premiumizePromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.app.axios({
-              method: 'POST',
-              url: `${BASE_URL}/folder/create?apikey=${premiumizeApiKey}`,
-              data: { name: 'OpenGameInstaller' },
-              headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                Accept: 'application/json',
-              },
-            })
-          ),
+      const responseFolder = yield* premiumizeRpc(
+        electronRpc.app.axios({
+          method: 'POST',
+          url: `${BASE_URL}/folder/create?apikey=${premiumizeApiKey}`,
+          data: { name: 'OpenGameInstaller' },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
+        }),
         'Failed to create Premiumize folder'
       );
       const folderData = responseFolder.data as ResponseFolder;
       let folderId = folderData.status === 'success' ? folderData.id : '';
       if (folderData.status === 'error') {
-        const searchResponse = yield* premiumizePromise(
-          () =>
-            Effect.runPromise(
-              electronRpc.app.axios({
-                method: 'GET',
-                url: `${BASE_URL}/folder/search?apikey=${premiumizeApiKey}&q=OpenGameInstaller`,
-                headers: { Accept: 'application/json' },
-              })
-            ),
+        const searchResponse = yield* premiumizeRpc(
+          electronRpc.app.axios({
+            method: 'GET',
+            url: `${BASE_URL}/folder/search?apikey=${premiumizeApiKey}&q=OpenGameInstaller`,
+            headers: { Accept: 'application/json' },
+          }),
           'Failed to search Premiumize folders'
         );
         const searchData = searchResponse.data as PremiumizeFolderResponse;
@@ -141,11 +136,8 @@ export class PremiumizeService extends BaseService {
 
       const formData = new FormData();
       if (result.downloadType === 'torrent') {
-        const torrentData = yield* premiumizePromise(
-          () =>
-            Effect.runPromise(
-              electronRpc.downloadTorrentInto(result.downloadURL!)
-            ),
+        const torrentData = yield* premiumizeRpc(
+          electronRpc.downloadTorrentInto(result.downloadURL!),
           'Failed to download torrent data'
         );
         formData.append('file', new Blob([torrentData.buffer as ArrayBuffer]));
@@ -153,19 +145,16 @@ export class PremiumizeService extends BaseService {
         formData.append('src', result.downloadURL!);
       }
       formData.append('folder_id', folderId);
-      const transferResponse = yield* premiumizePromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.app.axios<PremiumizeTransferResponse>({
-              method: 'POST',
-              url: `${BASE_URL}/transfer/create?apikey=${premiumizeApiKey}`,
-              data: Object.fromEntries(formData.entries()),
-              headers: {
-                'Content-Type': 'multipart/form-data',
-                Accept: 'application/json',
-              },
-            })
-          ),
+      const transferResponse = yield* premiumizeRpc(
+        electronRpc.app.axios<PremiumizeTransferResponse>({
+          method: 'POST',
+          url: `${BASE_URL}/transfer/create?apikey=${premiumizeApiKey}`,
+          data: Object.fromEntries(formData.entries()),
+          headers: {
+            'Content-Type': 'multipart/form-data',
+            Accept: 'application/json',
+          },
+        }),
         'Failed to create Premiumize transfer'
       );
       if (transferResponse.data.status === 'error') {
@@ -180,14 +169,11 @@ export class PremiumizeService extends BaseService {
 
       let foundFolderId = '';
       for (let attempt = 0; attempt <= 120; attempt++) {
-        const transfersResponse = yield* premiumizePromise(
-          () =>
-            Effect.runPromise(
-              electronRpc.app.axios<PremiumizeTransfersListResponse>({
-                method: 'GET',
-                url: `${BASE_URL}/transfer/list?apikey=${premiumizeApiKey}`,
-              })
-            ),
+        const transfersResponse = yield* premiumizeRpc(
+          electronRpc.app.axios<PremiumizeTransfersListResponse>({
+            method: 'GET',
+            url: `${BASE_URL}/transfer/list?apikey=${premiumizeApiKey}`,
+          }),
           'Failed to check Premiumize transfer'
         );
         if (
@@ -213,19 +199,16 @@ export class PremiumizeService extends BaseService {
         );
       }
 
-      const zipResponse = yield* premiumizePromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.app.axios<PremiumizeZipGenerateResponse>({
-              method: 'POST',
-              url: `${BASE_URL}/zip/generate?apikey=${premiumizeApiKey}`,
-              data: { 'folders[]': foundFolderId },
-              headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                Accept: 'application/json',
-              },
-            })
-          ),
+      const zipResponse = yield* premiumizeRpc(
+        electronRpc.app.axios<PremiumizeZipGenerateResponse>({
+          method: 'POST',
+          url: `${BASE_URL}/zip/generate?apikey=${premiumizeApiKey}`,
+          data: { 'folders[]': foundFolderId },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
+        }),
         'Failed to generate Premiumize download'
       );
       if (zipResponse.status !== 200 || zipResponse.data.status === 'error') {
@@ -247,17 +230,14 @@ export class PremiumizeService extends BaseService {
         result.name,
         zipFilename
       );
-      const handshake = yield* premiumizePromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.ddl.download([
-              {
-                link: directDownloadUrl,
-                path: targetPath,
-                headers: { 'OGI-Parallel-Limit': '1' },
-              },
-            ])
-          ),
+      const handshake = yield* premiumizeRpc(
+        electronRpc.ddl.download([
+          {
+            link: directDownloadUrl,
+            path: targetPath,
+            headers: { 'OGI-Parallel-Limit': '1' },
+          },
+        ]),
         'Failed to start Premiumize download'
       );
       if (handshake.status === 'error' || !handshake.id) {

--- a/application/src/frontend/lib/downloads/services/RealDebridService.ts
+++ b/application/src/frontend/lib/downloads/services/RealDebridService.ts
@@ -14,25 +14,26 @@ type RealDebridSearchResult = SearchResultWithAddon & {
   downloadURL: string;
 };
 
-const realDebridPromise = <A>(
-  operation: () => Promise<A>,
+const realDebridRpc = <A, E>(
+  operation: Effect.Effect<A, E>,
   message: string
 ): Effect.Effect<A, DebridError> =>
-  Effect.tryPromise({
-    try: operation,
-    catch: (cause) =>
-      new DebridError({
-        message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
-        service: 'realdebrid',
-      }),
-  });
+  operation.pipe(
+    Effect.mapError(
+      (cause) =>
+        new DebridError({
+          message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          service: 'realdebrid',
+        })
+    )
+  );
 
 function waitForTorrentReady(id: string) {
   return Effect.gen(function* () {
     for (let attempt = 0; attempt < 200; attempt++) {
       if (
-        yield* realDebridPromise(
-          () => Effect.runPromise(electronRpc.realdebrid.isTorrentReady(id)),
+        yield* realDebridRpc(
+          electronRpc.realdebrid.isTorrentReady(id),
           'Failed to check Real-Debrid torrent status'
         )
       ) {
@@ -72,8 +73,8 @@ export class RealDebridService extends BaseService {
         );
       }
 
-      const worked = yield* realDebridPromise(
-        () => Effect.runPromise(electronRpc.realdebrid.updateKey()),
+      const worked = yield* realDebridRpc(
+        electronRpc.realdebrid.updateKey(),
         'Failed to update Real-Debrid API key'
       );
       if (!worked) {
@@ -85,8 +86,8 @@ export class RealDebridService extends BaseService {
         );
       }
 
-      const hosts = yield* realDebridPromise(
-        () => Effect.runPromise(electronRpc.realdebrid.getHosts()),
+      const hosts = yield* realDebridRpc(
+        electronRpc.realdebrid.getHosts(),
         'Failed to load Real-Debrid hosts'
       );
       const debridResult = result as RealDebridSearchResult;
@@ -131,11 +132,8 @@ export class RealDebridService extends BaseService {
   ) {
     return Effect.gen(this, function* () {
       if (result.downloadType !== 'magnet') return;
-      const magnet = yield* realDebridPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.realdebrid.addMagnet(result.downloadURL!, host)
-          ),
+      const magnet = yield* realDebridRpc(
+        electronRpc.realdebrid.addMagnet(result.downloadURL!, host),
         'Failed to add magnet to Real-Debrid'
       );
       yield* this.finishDebridDownload(result, appID, tempId, magnet.id);
@@ -160,11 +158,8 @@ export class RealDebridService extends BaseService {
           })
         );
       }
-      const torrent = yield* realDebridPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.realdebrid.addTorrent(result.downloadURL!, host)
-          ),
+      const torrent = yield* realDebridRpc(
+        electronRpc.realdebrid.addTorrent(result.downloadURL!, host),
         'Failed to add torrent to Real-Debrid'
       );
       yield* this.finishDebridDownload(result, appID, tempId, torrent.id);
@@ -178,30 +173,24 @@ export class RealDebridService extends BaseService {
     torrentId: string
   ) {
     return Effect.gen(this, function* () {
-      const isReady = yield* realDebridPromise(
-        () =>
-          Effect.runPromise(electronRpc.realdebrid.isTorrentReady(torrentId)),
+      const isReady = yield* realDebridRpc(
+        electronRpc.realdebrid.isTorrentReady(torrentId),
         'Failed to check Real-Debrid torrent status'
       );
       if (!isReady) {
-        yield* realDebridPromise(
-          () =>
-            Effect.runPromise(electronRpc.realdebrid.selectTorrent(torrentId)),
+        yield* realDebridRpc(
+          electronRpc.realdebrid.selectTorrent(torrentId),
           'Failed to select Real-Debrid torrent files'
         );
         yield* waitForTorrentReady(torrentId);
       }
 
-      const torrentInfo = yield* realDebridPromise(
-        () =>
-          Effect.runPromise(electronRpc.realdebrid.getTorrentInfo(torrentId)),
+      const torrentInfo = yield* realDebridRpc(
+        electronRpc.realdebrid.getTorrentInfo(torrentId),
         'Failed to load Real-Debrid torrent info'
       );
-      const download = yield* realDebridPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.realdebrid.unrestrictLink(torrentInfo.links[0])
-          ),
+      const download = yield* realDebridRpc(
+        electronRpc.realdebrid.unrestrictLink(torrentInfo.links[0]),
         'Failed to unrestrict Real-Debrid link'
       );
       if (download === null) {
@@ -225,17 +214,14 @@ export class RealDebridService extends BaseService {
           downloadURL: download.download,
         },
       ];
-      const handshake = yield* realDebridPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.ddl.download([
-              {
-                link: download.download,
-                path: targetPath,
-                headers: { 'OGI-Parallel-Limit': '1' },
-              },
-            ])
-          ),
+      const handshake = yield* realDebridRpc(
+        electronRpc.ddl.download([
+          {
+            link: download.download,
+            path: targetPath,
+            headers: { 'OGI-Parallel-Limit': '1' },
+          },
+        ]),
         'Failed to start Real-Debrid download'
       );
       if (handshake.status === 'error' || !handshake.id) {

--- a/application/src/frontend/lib/downloads/services/RealDebridService.ts
+++ b/application/src/frontend/lib/downloads/services/RealDebridService.ts
@@ -1,4 +1,4 @@
-import { DebridError, ValidationError } from '@ogi/errors';
+import { DebridError, formatError, ValidationError } from '@ogi/errors';
 import { Effect } from 'effect';
 import { getDownloadPath } from '@/frontend/lib/core/fs';
 import { finalizeDownloadCard } from '@/frontend/lib/downloads/events';
@@ -22,7 +22,7 @@ const realDebridRpc = <A, E>(
     Effect.mapError(
       (cause) =>
         new DebridError({
-          message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          message: `${message}: ${formatError(cause)}`,
           service: 'realdebrid',
         })
     )

--- a/application/src/frontend/lib/downloads/services/TorboxService.ts
+++ b/application/src/frontend/lib/downloads/services/TorboxService.ts
@@ -22,15 +22,16 @@ type TorboxTorrentListResponse = {
   data: TorboxTorrent[];
 };
 
-const torboxPromise = <A>(operation: () => Promise<A>, message: string) =>
-  Effect.tryPromise({
-    try: operation,
-    catch: (cause) =>
-      new DebridError({
-        message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
-        service: 'torbox' as const,
-      }),
-  });
+const torboxRpc = <A, E>(operation: Effect.Effect<A, E>, message: string) =>
+  operation.pipe(
+    Effect.mapError(
+      (cause) =>
+        new DebridError({
+          message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          service: 'torbox' as const,
+        })
+    )
+  );
 
 export class TorboxService extends BaseService {
   readonly types = ['torbox-magnet', 'torbox-torrent'];
@@ -69,23 +70,19 @@ export class TorboxService extends BaseService {
       const formData = new FormData();
       let torrentHash = '';
       if (result.downloadType === 'torrent') {
-        const torrentData = yield* torboxPromise(
-          () =>
-            Effect.runPromise(
-              electronRpc.downloadTorrentInto(result.downloadURL!)
-            ),
+        const torrentData = yield* torboxRpc(
+          electronRpc.downloadTorrentInto(result.downloadURL!),
           'Failed to load torrent data'
         );
         formData.append('file', new Blob([torrentData.buffer as ArrayBuffer]));
-        torrentHash = yield* torboxPromise(
-          () => Effect.runPromise(electronRpc.getTorrentHash(torrentData)),
+        torrentHash = yield* torboxRpc(
+          electronRpc.getTorrentHash(torrentData),
           'Failed to hash torrent'
         );
       } else {
         formData.append('magnet', result.downloadURL!);
-        torrentHash = yield* torboxPromise(
-          () =>
-            Effect.runPromise(electronRpc.getTorrentHash(result.downloadURL!)),
+        torrentHash = yield* torboxRpc(
+          electronRpc.getTorrentHash(result.downloadURL!),
           'Failed to hash magnet'
         );
       }
@@ -93,26 +90,23 @@ export class TorboxService extends BaseService {
       formData.append('allow_zip', 'true');
       formData.append('as_queued', 'false');
 
-      const response = yield* torboxPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.app.axios<{
-              success: boolean;
-              error: string | null;
-              detail: string;
-              data:
-                | { hash: string; queued_id?: number; torrent_id?: number }
-                | { cooldown_until: number };
-            }>({
-              url: `${BASE_URL}/api/torrents/createtorrent`,
-              method: 'post',
-              data: Object.fromEntries(formData.entries()),
-              headers: {
-                'Content-Type': 'multipart/form-data',
-                Authorization: `Bearer ${torboxApiKey}`,
-              },
-            })
-          ),
+      const response = yield* torboxRpc(
+        electronRpc.app.axios<{
+          success: boolean;
+          error: string | null;
+          detail: string;
+          data:
+            | { hash: string; queued_id?: number; torrent_id?: number }
+            | { cooldown_until: number };
+        }>({
+          url: `${BASE_URL}/api/torrents/createtorrent`,
+          method: 'post',
+          data: Object.fromEntries(formData.entries()),
+          headers: {
+            'Content-Type': 'multipart/form-data',
+            Authorization: `Bearer ${torboxApiKey}`,
+          },
+        }),
         'Failed to create TorBox torrent'
       );
       if (response.status !== 200) {
@@ -154,16 +148,13 @@ export class TorboxService extends BaseService {
       }
 
       if (queued_id) {
-        const startResponse = yield* torboxPromise(
-          () =>
-            Effect.runPromise(
-              electronRpc.app.axios({
-                url: `${BASE_URL}/api/queued/controlqueued`,
-                method: 'post',
-                data: { queued_id, operation: 'start', all: false },
-                headers: { Authorization: `Bearer ${torboxApiKey}` },
-              })
-            ),
+        const startResponse = yield* torboxRpc(
+          electronRpc.app.axios({
+            url: `${BASE_URL}/api/queued/controlqueued`,
+            method: 'post',
+            data: { queued_id, operation: 'start', all: false },
+            headers: { Authorization: `Bearer ${torboxApiKey}` },
+          }),
           'Failed to start queued TorBox torrent'
         );
         if (startResponse.status !== 200) {
@@ -180,15 +171,12 @@ export class TorboxService extends BaseService {
       let finalTorrentId = torrent_id;
       if (!finalTorrentId) {
         for (let attempt = 0; attempt < 217; attempt++) {
-          const list = yield* torboxPromise(
-            () =>
-              Effect.runPromise(
-                electronRpc.app.axios<TorboxTorrentListResponse>({
-                  url: `${BASE_URL}/api/torrents/mylist?bypass_cache=true`,
-                  method: 'get',
-                  headers: { Authorization: `Bearer ${torboxApiKey}` },
-                })
-              ),
+          const list = yield* torboxRpc(
+            electronRpc.app.axios<TorboxTorrentListResponse>({
+              url: `${BASE_URL}/api/torrents/mylist?bypass_cache=true`,
+              method: 'get',
+              headers: { Authorization: `Bearer ${torboxApiKey}` },
+            }),
             'Failed to poll TorBox torrent'
           );
           const torrent = list.data.success
@@ -222,17 +210,14 @@ export class TorboxService extends BaseService {
         result.name,
         zipFilename
       );
-      const handshake = yield* torboxPromise(
-        () =>
-          Effect.runPromise(
-            electronRpc.ddl.download([
-              {
-                link: downloadUrl,
-                path: targetPath,
-                headers: { 'OGI-Parallel-Limit': '1' },
-              },
-            ])
-          ),
+      const handshake = yield* torboxRpc(
+        electronRpc.ddl.download([
+          {
+            link: downloadUrl,
+            path: targetPath,
+            headers: { 'OGI-Parallel-Limit': '1' },
+          },
+        ]),
         'Failed to start TorBox download'
       );
       if (handshake.status === 'error' || !handshake.id) {

--- a/application/src/frontend/lib/downloads/services/TorboxService.ts
+++ b/application/src/frontend/lib/downloads/services/TorboxService.ts
@@ -1,4 +1,4 @@
-import { DebridError } from '@ogi/errors';
+import { DebridError, formatError } from '@ogi/errors';
 import { Effect } from 'effect';
 import { getConfigClientOption } from '@/frontend/lib/config/client';
 import { getDownloadPath } from '@/frontend/lib/core/fs';
@@ -27,7 +27,7 @@ const torboxRpc = <A, E>(operation: Effect.Effect<A, E>, message: string) =>
     Effect.mapError(
       (cause) =>
         new DebridError({
-          message: `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          message: `${message}: ${formatError(cause)}`,
           service: 'torbox' as const,
         })
     )

--- a/application/src/frontend/managers/AppUpdateManager.svelte
+++ b/application/src/frontend/managers/AppUpdateManager.svelte
@@ -19,16 +19,25 @@ document.addEventListener('addon-runtime-ready', () => {
 });
 
 async function onAddonRuntimeReady() {
-  try {
-    await Effect.runPromise(reconnectClientSdk());
-    await Effect.runPromise(fetchAddonsWithConfigure());
-    await checkForAppUpdates();
-  } catch (error) {
-    console.error('Failed to refresh addon runtime for update checks:', error);
-  }
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* reconnectClientSdk();
+      yield* fetchAddonsWithConfigure();
+      yield* checkForAppUpdates();
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() =>
+          console.error(
+            'Failed to refresh addon runtime for update checks:',
+            error
+          )
+        )
+      )
+    )
+  );
 }
 
-async function checkForAppUpdates() {
+function checkForAppUpdates() {
   const runId = ++updateCheckRunId;
   updatesManager.clearAppUpdates();
   console.log('checking for app updates');
@@ -94,6 +103,6 @@ async function checkForAppUpdates() {
     );
   });
 
-  await Effect.runPromise(workflow);
+  return workflow;
 }
 </script>

--- a/application/src/frontend/managers/Debug.svelte
+++ b/application/src/frontend/managers/Debug.svelte
@@ -34,12 +34,13 @@ function insertDebugApp(
     electronRpc.app.insertApp(app).pipe(
       Effect.tap((result) =>
         Effect.sync(() => {
+          const succeeded = result.includes('success');
           createNotification({
             id: Math.random().toString(36).substring(2, 9),
-            type: result.includes('success') ? 'success' : 'error',
+            type: succeeded ? 'success' : 'error',
             message: `App insertion result: ${result}`,
           });
-          showInsertAppModal = false;
+          if (succeeded) showInsertAppModal = false;
         })
       ),
       Effect.catchAll((error) =>
@@ -51,7 +52,8 @@ function insertDebugApp(
             message: `Failed to insert test app: ${error instanceof Error ? error.message : String(error)}`,
           });
         })
-      )
+      ),
+      Effect.asVoid
     )
   );
 }

--- a/application/src/frontend/managers/Debug.svelte
+++ b/application/src/frontend/managers/Debug.svelte
@@ -26,6 +26,36 @@ let priorityModals = $state({
 let showEventsPerSec = $state(false);
 let showNotificationSideView = $state(false);
 let showInsertAppModal = $state(false);
+
+function insertDebugApp(
+  app: Parameters<typeof electronRpc.app.insertApp>[0]
+): Promise<void> {
+  return Effect.runPromise(
+    electronRpc.app.insertApp(app).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          createNotification({
+            id: Math.random().toString(36).substring(2, 9),
+            type: result.includes('success') ? 'success' : 'error',
+            message: `App insertion result: ${result}`,
+          });
+          showInsertAppModal = false;
+        })
+      ),
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          console.error('Error inserting test app:', error);
+          createNotification({
+            id: Math.random().toString(36).substring(2, 9),
+            type: 'error',
+            message: `Failed to insert test app: ${error instanceof Error ? error.message : String(error)}`,
+          });
+        })
+      )
+    )
+  );
+}
+
 // Build test config with real StringOption instances (matches production shape)
 let isDev = window.electronAPI.isDev();
 const optionConfig: {
@@ -183,47 +213,29 @@ onMount(() => {
       text="Insert Test App with Dependencies"
       variant="primary"
       onclick={async () => {
-        try {
-          const mockAppData = {
-            name: 'Test Game with Dependencies',
-            version: '1.0.0',
-            cwd: '/path/to/game',
-            appID: 12345,
-            launchExecutable: 'game.exe',
-            launchArguments: '--debug',
-            capsuleImage:
-              'https://via.placeholder.com/600x900/428a91/ffffff?text=Test+Game',
-            coverImage:
-              'https://via.placeholder.com/920x430/428a91/ffffff?text=Cover+Image',
-            titleImage:
-              'https://via.placeholder.com/920x430/2d626a/ffffff?text=Title+Image',
-            storefront: 'steam',
-            addonsource: 'test-addon',
-            redistributables: [
-              {
-                name: 'dotnet48',
-                path: 'winetricks',
-              },
-            ],
-          };
-
-          const result = await Effect.runPromise(electronRpc.app.insertApp(mockAppData));
-
-          createNotification({
-            id: Math.random().toString(36).substring(2, 9),
-            type: result.includes('success') ? 'success' : 'error',
-            message: `App insertion result: ${result}`,
-          });
-
-          showInsertAppModal = false;
-        } catch (error) {
-          console.error('Error inserting test app:', error);
-          createNotification({
-            id: Math.random().toString(36).substring(2, 9),
-            type: 'error',
-            message: `Failed to insert test app: ${error instanceof Error ? error.message : String(error)}`,
-          });
-        }
+        const mockAppData: Parameters<typeof electronRpc.app.insertApp>[0] = {
+          name: 'Test Game with Dependencies',
+          version: '1.0.0',
+          cwd: '/path/to/game',
+          appID: 12345,
+          launchExecutable: 'game.exe',
+          launchArguments: '--debug',
+          capsuleImage:
+            'https://via.placeholder.com/600x900/428a91/ffffff?text=Test+Game',
+          coverImage:
+            'https://via.placeholder.com/920x430/428a91/ffffff?text=Cover+Image',
+          titleImage:
+            'https://via.placeholder.com/920x430/2d626a/ffffff?text=Title+Image',
+          storefront: 'steam',
+          addonsource: 'test-addon',
+          redistributables: [
+            {
+              name: 'dotnet48',
+              path: 'winetricks',
+            },
+          ],
+        };
+        await insertDebugApp(mockAppData);
       }}
     />
 
@@ -231,39 +243,21 @@ onMount(() => {
       text="Insert Test App without Dependencies"
       variant="secondary"
       onclick={async () => {
-        try {
-          const mockAppData = {
-            name: 'Test Game (No Dependencies)',
-            version: '1.0.0',
-            cwd: '/path/to/game',
-            appID: 67890,
-            launchExecutable: 'game.exe',
-            launchArguments: '',
-            capsuleImage:
-              'https://via.placeholder.com/600x900/B0DFD5/ffffff?text=Simple+Game',
-            coverImage:
-              'https://via.placeholder.com/920x430/B0DFD5/ffffff?text=Simple+Cover',
-            storefront: 'steam',
-            addonsource: 'test-addon',
-          };
-
-          const result = await Effect.runPromise(electronRpc.app.insertApp(mockAppData));
-
-          createNotification({
-            id: Math.random().toString(36).substring(2, 9),
-            type: result.includes('success') ? 'success' : 'error',
-            message: `App insertion result: ${result}`,
-          });
-
-          showInsertAppModal = false;
-        } catch (error) {
-          console.error('Error inserting test app:', error);
-          createNotification({
-            id: Math.random().toString(36).substring(2, 9),
-            type: 'error',
-            message: `Failed to insert test app: ${error instanceof Error ? error.message : String(error)}`,
-          });
-        }
+        const mockAppData: Parameters<typeof electronRpc.app.insertApp>[0] = {
+          name: 'Test Game (No Dependencies)',
+          version: '1.0.0',
+          cwd: '/path/to/game',
+          appID: 67890,
+          launchExecutable: 'game.exe',
+          launchArguments: '',
+          capsuleImage:
+            'https://via.placeholder.com/600x900/B0DFD5/ffffff?text=Simple+Game',
+          coverImage:
+            'https://via.placeholder.com/920x430/B0DFD5/ffffff?text=Simple+Cover',
+          storefront: 'steam',
+          addonsource: 'test-addon',
+        };
+        await insertDebugApp(mockAppData);
       }}
     />
 

--- a/application/src/frontend/managers/GamepadManager.ts
+++ b/application/src/frontend/managers/GamepadManager.ts
@@ -729,27 +729,35 @@ export class GamepadNavigator {
     this.allowProgrammaticTextFocus();
     element.focus();
 
-    try {
-      // Try to open Steam keyboard overlay
-      // The keyboard injects text directly into the focused input
-      const opened = await Effect.runPromise(
-        electronRpc.app.openSteamKeyboard({
+    await Effect.runPromise(
+      electronRpc.app
+        .openSteamKeyboard({
           x: 0,
           y: 0,
           width: 500,
           height: 500,
         })
-      );
-
-      if (!opened) {
-        // Steam keyboard not available (not on Steam Deck/Big Picture)
-        // Element is already focused for manual input
-        console.log('Steam keyboard not available, element focused for input');
-      }
-    } catch (error) {
-      // Steam keyboard not available, element is already focused
-      console.log('Steam keyboard error, focusing input instead:', error);
-    }
+        .pipe(
+          Effect.tap((opened) =>
+            Effect.sync(() => {
+              if (!opened) {
+                // Steam keyboard is unavailable, but the input is already focused.
+                console.log(
+                  'Steam keyboard not available, element focused for input'
+                );
+              }
+            })
+          ),
+          Effect.catchAll((error) =>
+            Effect.sync(() =>
+              console.log(
+                'Steam keyboard error, focusing input instead:',
+                error
+              )
+            )
+          )
+        )
+    );
   }
 
   goBack() {

--- a/application/src/frontend/views/ClientOptionsView.svelte
+++ b/application/src/frontend/views/ClientOptionsView.svelte
@@ -537,14 +537,23 @@ async function updateAddons() {
 
 async function restartAddonServer() {
   isRestartingServer = true;
-  try {
-    await Effect.runPromise(electronRpc.restartAddonServer());
-    await Effect.runPromise(reconnectClientSdk());
-  } catch (err) {
-    console.error('Failed to restart addon server:', err);
-  } finally {
-    isRestartingServer = false;
-  }
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* electronRpc.restartAddonServer();
+      yield* reconnectClientSdk();
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() =>
+          console.error('Failed to restart addon server:', error)
+        )
+      ),
+      Effect.ensuring(
+        Effect.sync(() => {
+          isRestartingServer = false;
+        })
+      )
+    )
+  );
 }
 
 let showPassword: { [key: string]: boolean } = $state({});

--- a/application/src/frontend/views/ClientOptionsView.svelte
+++ b/application/src/frontend/views/ClientOptionsView.svelte
@@ -703,13 +703,20 @@ onMount(() => {
     reasonForSteamGridLaunch = (event as CustomEvent).detail || '';
   }
   async function handleAddonConnected() {
-    try {
-      await Effect.runPromise(fetchAddonsWithConfigure());
-    } catch (error) {
-      console.error('Failed to configure addons after reconnect:', error);
-    } finally {
-      isRestartingServer = false;
-    }
+    await Effect.runPromise(
+      fetchAddonsWithConfigure().pipe(
+        Effect.catchAll((error) =>
+          Effect.sync(() =>
+            console.error('Failed to configure addons after reconnect:', error)
+          )
+        ),
+        Effect.ensuring(
+          Effect.sync(() => {
+            isRestartingServer = false;
+          })
+        )
+      )
+    );
   }
   document.addEventListener('steamgriddb-launch', steamgriddbLaunch);
   document.addEventListener('addon-connected', handleAddonConnected);

--- a/application/src/frontend/views/CommunityAddonsList.svelte
+++ b/application/src/frontend/views/CommunityAddonsList.svelte
@@ -41,16 +41,20 @@ async function installAddon(marketplaceURL: string, addon: CommunityAddon) {
       electronRpc.installAddons([addonWithMarketplace])
     ),
   };
-  try {
-    await Effect.runPromise(reconnectClientSdk());
-  } catch (error) {
-    console.error('Failed to reconnect after installing addon:', error);
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: `Failed to finish installing ${addon.name}`,
-      type: 'error',
-    });
-  }
+  await Effect.runPromise(
+    reconnectClientSdk().pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          console.error('Failed to reconnect after installing addon:', error);
+          createNotification({
+            id: Math.random().toString(36).substring(7),
+            message: `Failed to finish installing ${addon.name}`,
+            type: 'error',
+          });
+        })
+      )
+    )
+  );
 }
 
 function addonConfigMatchesSource(configAddon: string, addonSource: string) {
@@ -92,18 +96,25 @@ async function deleteAddon(addon: CommunityAddon) {
   currentAddons = JSON.parse(
     window.electronAPI.fs.read('./config/option/general.json')
   );
-  try {
-    await Effect.runPromise(reconnectClientSdk());
-  } catch (error) {
-    console.error('Failed to reconnect after deleting addon:', error);
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: `Deleted ${addon.name}, but failed to reconnect`,
-      type: 'error',
-    });
-  } finally {
-    deleteConfirmationModalAddon = null;
-  }
+  await Effect.runPromise(
+    reconnectClientSdk().pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          console.error('Failed to reconnect after deleting addon:', error);
+          createNotification({
+            id: Math.random().toString(36).substring(7),
+            message: `Deleted ${addon.name}, but failed to reconnect`,
+            type: 'error',
+          });
+        })
+      ),
+      Effect.ensuring(
+        Effect.sync(() => {
+          deleteConfirmationModalAddon = null;
+        })
+      )
+    )
+  );
 }
 
 async function deleteAddonWarning(addon: CommunityAddon) {

--- a/application/src/frontend/views/ConfigView.svelte
+++ b/application/src/frontend/views/ConfigView.svelte
@@ -84,27 +84,36 @@ async function updateAddons() {
     button.setAttribute('disabled', 'true');
   });
 
-  try {
-    await Effect.runPromise(electronRpc.updateAddons());
-    addonUpdates.set([]);
-    await Effect.runPromise(electronRpc.restartAddonServer());
-    await Effect.runPromise(reconnectClientSdk());
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: 'Addons updated successfully',
-      type: 'success',
-    });
-  } catch (error) {
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: 'Failed to update addons',
-      type: 'error',
-    });
-  } finally {
-    buttonsToDisable.forEach((button) => {
-      button.removeAttribute('disabled');
-    });
-  }
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* electronRpc.updateAddons();
+      addonUpdates.set([]);
+      yield* electronRpc.restartAddonServer();
+      yield* reconnectClientSdk();
+      createNotification({
+        id: Math.random().toString(36).substring(7),
+        message: 'Addons updated successfully',
+        type: 'success',
+      });
+    }).pipe(
+      Effect.catchAll(() =>
+        Effect.sync(() =>
+          createNotification({
+            id: Math.random().toString(36).substring(7),
+            message: 'Failed to update addons',
+            type: 'error',
+          })
+        )
+      ),
+      Effect.ensuring(
+        Effect.sync(() =>
+          buttonsToDisable.forEach((button) => {
+            button.removeAttribute('disabled');
+          })
+        )
+      )
+    )
+  );
 }
 
 async function addAddon() {
@@ -115,18 +124,24 @@ async function addAddon() {
     message: 'Installing addon...',
     type: 'info',
   });
-  try {
-    await Effect.runPromise(electronRpc.installAddons([addonUrl]));
-    addonUrl = '';
-    await Effect.runPromise(reconnectClientSdk());
-  } catch (error) {
-    console.error('Failed to add addon:', error);
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: 'Failed to add addon',
-      type: 'error',
-    });
-  }
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* electronRpc.installAddons([addonUrl]);
+      addonUrl = '';
+      yield* reconnectClientSdk();
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          console.error('Failed to add addon:', error);
+          createNotification({
+            id: Math.random().toString(36).substring(7),
+            message: 'Failed to add addon',
+            type: 'error',
+          });
+        })
+      )
+    )
+  );
 }
 
 function openMarketplaceSourceManager() {

--- a/application/src/frontend/views/DownloadView.svelte
+++ b/application/src/frontend/views/DownloadView.svelte
@@ -145,17 +145,21 @@ async function runDownloadAction<A, E>(
   effect: Effect.Effect<A, E>,
   description: string
 ): Promise<A | undefined> {
-  try {
-    return await Effect.runPromise(effect);
-  } catch (error) {
-    console.error(`${description}:`, error);
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: description,
-      type: 'error',
-    });
-    return undefined;
-  }
+  return Effect.runPromise(
+    effect.pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          console.error(`${description}:`, error);
+          createNotification({
+            id: Math.random().toString(36).substring(7),
+            message: description,
+            type: 'error',
+          });
+          return undefined;
+        })
+      )
+    )
+  );
 }
 
 async function handleRetry(failedSetup: FailedSetup) {

--- a/application/src/frontend/views/FocusedAddonView.svelte
+++ b/application/src/frontend/views/FocusedAddonView.svelte
@@ -378,19 +378,19 @@ async function handleActionClick(key: string) {
   runningActions = { ...runningActions, [key]: true };
   await Effect.runPromise(
     runTask(
-        {
-          addonSource: selectedAddon.id,
-          addonName: selectedAddon.name,
-          manifest,
-          name: actionOption.displayName,
-          downloadType: 'task' as const,
-          taskName,
-          capsuleImage: '',
-          coverImage: '',
-          storefront: '',
-        },
-        ''
-      ).pipe(
+      {
+        addonSource: selectedAddon.id,
+        addonName: selectedAddon.name,
+        manifest,
+        name: actionOption.displayName,
+        downloadType: 'task' as const,
+        taskName,
+        capsuleImage: '',
+        coverImage: '',
+        storefront: '',
+      },
+      ''
+    ).pipe(
       Effect.catchAll((error) =>
         Effect.sync(() =>
           notifications.update((update) => [

--- a/application/src/frontend/views/FocusedAddonView.svelte
+++ b/application/src/frontend/views/FocusedAddonView.svelte
@@ -296,43 +296,49 @@ async function deleteAddon() {
 
 async function deleteAddonGO() {
   if (!selectedAddon) return;
-  try {
-    const result = await Effect.runPromise(
-      electronRpc.deleteInstalledAddon(selectedAddon.id)
-    );
-    if (result.success) {
-      notifications.update((update) => [
-        ...update,
-        {
-          id: Math.random().toString(36).substring(7),
-          type: 'success',
-          message: `Addon '${selectedAddon!.name}' deleted successfully.`,
-        },
-      ]);
-      refreshAddon();
-      onBack();
-    } else {
-      notifications.update((update) => [
-        ...update,
-        {
-          id: Math.random().toString(36).substring(7),
-          type: 'error',
-          message:
-            result.message ||
-            `Failed to delete addon '${selectedAddon!.name}'.`,
-        },
-      ]);
-    }
-  } catch (e) {
-    notifications.update((update) => [
-      ...update,
-      {
-        id: Math.random().toString(36).substring(7),
-        type: 'error',
-        message: `Error deleting addon: ${e}`,
-      },
-    ]);
-  }
+  await Effect.runPromise(
+    electronRpc.deleteInstalledAddon(selectedAddon.id).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          if (result.success) {
+            notifications.update((update) => [
+              ...update,
+              {
+                id: Math.random().toString(36).substring(7),
+                type: 'success',
+                message: `Addon '${selectedAddon!.name}' deleted successfully.`,
+              },
+            ]);
+            refreshAddon();
+            onBack();
+            return;
+          }
+          notifications.update((update) => [
+            ...update,
+            {
+              id: Math.random().toString(36).substring(7),
+              type: 'error',
+              message:
+                result.message ||
+                `Failed to delete addon '${selectedAddon!.name}'.`,
+            },
+          ]);
+        })
+      ),
+      Effect.catchAll((error) =>
+        Effect.sync(() =>
+          notifications.update((update) => [
+            ...update,
+            {
+              id: Math.random().toString(36).substring(7),
+              type: 'error',
+              message: `Error deleting addon: ${error}`,
+            },
+          ])
+        )
+      )
+    )
+  );
 }
 
 function hasConfigErrors() {
@@ -370,9 +376,8 @@ async function handleActionClick(key: string) {
   };
 
   runningActions = { ...runningActions, [key]: true };
-  try {
-    await Effect.runPromise(
-      runTask(
+  await Effect.runPromise(
+    runTask(
         {
           addonSource: selectedAddon.id,
           addonName: selectedAddon.name,
@@ -385,20 +390,26 @@ async function handleActionClick(key: string) {
           storefront: '',
         },
         ''
+      ).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() =>
+          notifications.update((update) => [
+            ...update,
+            {
+              id: Math.random().toString(36).substring(7),
+              type: 'error',
+              message: `Failed to run action: ${error}`,
+            },
+          ])
+        )
+      ),
+      Effect.ensuring(
+        Effect.sync(() => {
+          runningActions = { ...runningActions, [key]: false };
+        })
       )
-    );
-  } catch (error) {
-    notifications.update((update) => [
-      ...update,
-      {
-        id: Math.random().toString(36).substring(7),
-        type: 'error',
-        message: `Failed to run action: ${error}`,
-      },
-    ]);
-  } finally {
-    runningActions = { ...runningActions, [key]: false };
-  }
+    )
+  );
 }
 </script>
 


### PR DESCRIPTION
## Summary

- Replace frontend try-catch blocks with Effect-based error handling.
- Compose RPC and download workflows directly as Effects.
- Preserve user notifications, cleanup, and domain-specific error mapping.

## Testing

- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across downloads, addon management, game launching, Steam integration, and app updates.
  * Failed downloads now keep the update dialog open and provide clearer feedback.
  * UI controls and migration states reliably reset after successful or failed operations.
  * Addon installation, deletion, reconnection, and update actions provide more consistent notifications.
  * Improved reliability for third-party download services and torrent operations.
* **Refactor**
  * Standardized background operation handling to improve consistency and prevent unreported failures.
  * Streamlined Steam game additions and download workflows for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->