### PR TITLE
fix(application): complete installer update shutdown

### DIFF
--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -163,11 +163,12 @@ async function handleLaunchHooks(
 
   if (mainWindow) {
     registerMainHandlers(mainWindow);
-    await startAddonRuntime();
     const startupResult = await runElectronEffect(runStartupTasks(mainWindow));
     if (startupResult.shutdownPending) {
+      shutdownForInstallerUpdate(mainWindow);
       return;
     }
+    await startAddonRuntime();
 
     // Load the main app with game ID and hook flags
     const baseUrl = isDev()
@@ -200,12 +201,13 @@ async function launchGameById(gameId: number, wrapperCommand?: string | null) {
 
   if (mainWindow) {
     registerMainHandlers(mainWindow);
-    await startAddonRuntime();
     // Run startup tasks first
     const startupResult = await runElectronEffect(runStartupTasks(mainWindow));
     if (startupResult.shutdownPending) {
+      shutdownForInstallerUpdate(mainWindow);
       return;
     }
+    await startAddonRuntime();
 
     // Load the main app with the game ID in the query params
     // The Svelte frontend will detect this and show the GameLaunchOverlay
@@ -556,8 +558,11 @@ async function startAppFlow(win: BrowserWindow) {
   }
 
   if (shutdownPending) {
+    shutdownForInstallerUpdate(win);
     return;
   }
+
+  await startAddonRuntime();
 
   // Load the main app into the same window (replaces splash)
   if (win && !win.isDestroyed()) {
@@ -574,6 +579,14 @@ async function startAppFlow(win: BrowserWindow) {
     }
     win.once('ready-to-show', onMainAppReady);
   }
+}
+
+function shutdownForInstallerUpdate(win: BrowserWindow): void {
+  if (!win.isDestroyed()) {
+    win.close();
+    return;
+  }
+  app.quit();
 }
 
 function focusMainWindow(): boolean {
@@ -804,7 +817,6 @@ app.on('ready', async () => {
 
   if (mainWindow) {
     registerMainHandlers(mainWindow);
-    await startAddonRuntime();
     await startAppFlow(mainWindow);
   }
 });

--- a/application/src/electron/startup-runner.ts
+++ b/application/src/electron/startup-runner.ts
@@ -10,7 +10,7 @@ import {
 } from '@/electron/startup.js';
 import {
   createDefaultSystemUpdateManager,
-  type SystemUpdateResult,
+  requiresSystemUpdateShutdown,
 } from '@/electron/system-updater.js';
 import type { UpdaterCallbacks } from '@/electron/updater.js';
 
@@ -100,10 +100,6 @@ export type StartupTasksResult = {
   /** When true, an installer update is shutting the app down; do not load the main UI. */
   shutdownPending: boolean;
 };
-
-function isShutdownPendingFromUpdates(results: SystemUpdateResult[]): boolean {
-  return results.some((result) => result.updated === true);
-}
 
 /**
  * Runs all pre-launch startup tasks with splash screen feedback.
@@ -215,7 +211,7 @@ export function runStartupTasks(
           updaterCallbacks
         );
 
-      shutdownPending = isShutdownPendingFromUpdates(updateResults);
+      shutdownPending = requiresSystemUpdateShutdown(updateResults);
 
       // Final status before main window loads (skip when installer update will exit)
       if (!shutdownPending) {

--- a/application/src/electron/system-updater.ts
+++ b/application/src/electron/system-updater.ts
@@ -11,8 +11,16 @@ export type SystemUpdateResult = {
   id: string;
   success: boolean;
   updated?: boolean;
+  /** Stop startup and close the app after this updater finishes. */
+  shutdownRequired?: boolean;
   error?: string;
 };
+
+export function requiresSystemUpdateShutdown(
+  results: readonly SystemUpdateResult[]
+): boolean {
+  return results.some((result) => result.shutdownRequired === true);
+}
 
 export interface SystemUpdater {
   id: string;
@@ -79,6 +87,9 @@ export class SystemUpdateManager {
           })
         );
         results.push(result);
+        if (result.shutdownRequired) {
+          break;
+        }
       }
 
       return results;
@@ -109,6 +120,7 @@ export class SetupAppImageUpdater implements SystemUpdater {
         id: this.id,
         success: result.success,
         updated: result.updated,
+        shutdownRequired: result.updated,
         error: result.error,
       }))
     );

--- a/application/src/electron/updater.ts
+++ b/application/src/electron/updater.ts
@@ -1013,22 +1013,25 @@ export function checkIfInstallerUpdateAvailable(
 
           updateStatus('Starting Setup');
 
-          setTimeout(() => {
-            try {
-              spawn(directory, {
-                detached: true,
-                stdio: 'ignore',
-              }).unref();
-              process.exit(0);
-            } catch (spawnError: any) {
-              console.error(
-                '[updater] Failed to launch setup:',
-                spawnError.message
-              );
-              updateStatus('Update Failed', 'Please try again later');
-              process.exit(1);
-            }
-          }, 500);
+          await setTimeoutPromise(500);
+          try {
+            spawn(directory, {
+              detached: true,
+              stdio: 'ignore',
+            }).unref();
+          } catch (spawnError: any) {
+            console.error(
+              '[updater] Failed to launch setup:',
+              spawnError.message
+            );
+            updateStatus('Update Failed', 'Please try again later');
+            resolve({
+              success: false,
+              updated: false,
+              error: spawnError.message,
+            });
+            return;
+          }
           resolve({ success: true, updated: true });
         } else if (process.platform === 'linux') {
           await setTimeoutPromise(3000);
@@ -1045,43 +1048,41 @@ export function checkIfInstallerUpdateAvailable(
 
           updateStatus('Starting Setup');
 
-          setTimeout(async () => {
-            try {
-              // rename the temp-setup-OGI.AppImage to the OpenGameInstaller-Setup.AppImage
-              console.log(
-                `[updater] Renaming setup to OpenGameInstaller-Setup.AppImage`
-              );
-              rmSync('../OpenGameInstaller-Setup.AppImage', { force: true });
-              console.log(
-                `[updater] Moving over setup to OpenGameInstaller-Setup.AppImage`
-              );
-              copyFileSync(
-                '../temp-setup-OGI.AppImage',
-                '../OpenGameInstaller-Setup.AppImage'
-              );
-              rmSync('../temp-setup-OGI.AppImage', { force: true });
-              console.log(
-                `[updater] Copied setup to OpenGameInstaller-Setup.AppImage`
-              );
-
-              // set item +x permissions
-              chmodSync('../OpenGameInstaller-Setup.AppImage', 0o755);
-            } catch (moveError: any) {
-              console.error(
-                '[updater] Failed to move setup:',
-                moveError.message
-              );
-              updateStatus('Update Failed', 'Please try again later');
-              await setTimeoutPromise(3000);
-              process.exit(1);
-            }
-            updateStatus(
-              'Shutting Down OpenGameInstaller',
-              'Please open OpenGameInstaller again'
+          await setTimeoutPromise(500);
+          try {
+            // Replace the old Setup AppImage only after the download is complete.
+            console.log(
+              `[updater] Renaming setup to OpenGameInstaller-Setup.AppImage`
             );
+            rmSync('../OpenGameInstaller-Setup.AppImage', { force: true });
+            console.log(
+              `[updater] Moving over setup to OpenGameInstaller-Setup.AppImage`
+            );
+            copyFileSync(
+              '../temp-setup-OGI.AppImage',
+              '../OpenGameInstaller-Setup.AppImage'
+            );
+            rmSync('../temp-setup-OGI.AppImage', { force: true });
+            console.log(
+              `[updater] Copied setup to OpenGameInstaller-Setup.AppImage`
+            );
+            chmodSync('../OpenGameInstaller-Setup.AppImage', 0o755);
+          } catch (moveError: any) {
+            console.error('[updater] Failed to move setup:', moveError.message);
+            updateStatus('Update Failed', 'Please try again later');
             await setTimeoutPromise(3000);
-            process.exit(0);
-          }, 500);
+            resolve({
+              success: false,
+              updated: false,
+              error: moveError.message,
+            });
+            return;
+          }
+          updateStatus(
+            'Shutting Down OpenGameInstaller',
+            'Please open OpenGameInstaller again'
+          );
+          await setTimeoutPromise(3000);
           resolve({ success: true, updated: true });
         }
       } else {

--- a/application/tests/system-updater.test.ts
+++ b/application/tests/system-updater.test.ts
@@ -1,0 +1,85 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { Effect } from 'effect';
+
+mock.module('@/electron/lib/online.js', () => ({
+  getEffectiveOnlineState: () => ({ effectiveOnline: true, reason: 'online' }),
+}));
+mock.module('@/electron/updater.js', () => ({
+  checkIfInstallerUpdateAvailable: async () => ({
+    success: true,
+    updated: false,
+  }),
+}));
+mock.module('@/electron/startup.js', () => ({
+  downloadLatestUmu: async () => ({ success: true, updated: false }),
+}));
+
+let SystemUpdateManager: typeof import('../src/electron/system-updater.js').SystemUpdateManager;
+let requiresSystemUpdateShutdown: typeof import('../src/electron/system-updater.js').requiresSystemUpdateShutdown;
+
+beforeAll(async () => {
+  ({ SystemUpdateManager, requiresSystemUpdateShutdown } = await import(
+    '../src/electron/system-updater.js'
+  ));
+});
+
+describe('SystemUpdateManager', () => {
+  test('stops running system updaters when one requires app shutdown', async () => {
+    const calls: string[] = [];
+    const manager = new SystemUpdateManager([
+      {
+        id: 'installer',
+        label: 'installer',
+        shouldRun: () => Effect.succeed(true),
+        update: () =>
+          Effect.sync(() => {
+            calls.push('installer');
+            return {
+              id: 'installer',
+              success: true,
+              updated: true,
+              shutdownRequired: true,
+            };
+          }),
+      },
+      {
+        id: 'background-tool',
+        label: 'background tool',
+        shouldRun: () => Effect.succeed(true),
+        update: () =>
+          Effect.sync(() => {
+            calls.push('background-tool');
+            return { id: 'background-tool', success: true, updated: true };
+          }),
+      },
+    ]);
+
+    const results = await Effect.runPromise(
+      manager.updateOnlineSystem({
+        onStatus: () => undefined,
+        onProgress: () => undefined,
+      })
+    );
+
+    expect(calls).toEqual(['installer']);
+    expect(results).toHaveLength(1);
+  });
+
+  test('only shuts down for updates that explicitly require it', () => {
+    expect(
+      requiresSystemUpdateShutdown([
+        { id: 'umu-launcher', success: true, updated: true },
+      ])
+    ).toBe(false);
+    expect(
+      requiresSystemUpdateShutdown([
+        {
+          id: 'installer',
+          success: true,
+          updated: true,
+          shutdownRequired: true,
+        },
+      ])
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

Complete Setup AppImage replacement before reporting the installer update as successful, stop later system updaters when shutdown is required, and close through the Electron lifecycle without starting addon processes first.

# Example

After a Setup AppImage update finishes, OpenGameInstaller now closes its splash window and process tree instead of continuing startup or leaving background runtime processes alive.

# Next Steps

- Validate the updater flow with the next packaged Linux AppImage release.
- Investigate the unrelated existing `handler.ddl.test.ts` failure separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup sequencing so required updates are handled before add-ons initialize.
  * Installer updates now close the application cleanly when a restart is required.
  * Improved reliability when launching Windows or Linux installers, including graceful handling of launch failures.
  * Prevented additional update checks from running after an update requiring shutdown is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->