### PR TITLE
fix(downloads): handle torrent failures and reset button state

### DIFF
--- a/application/src/electron/handlers/handler.torrent.ts
+++ b/application/src/electron/handlers/handler.torrent.ts
@@ -8,7 +8,7 @@ import {
 import axios from 'axios';
 import { Deferred, Effect, Fiber } from 'effect';
 import { BrowserWindow } from 'electron';
-import parseTorrent from 'parse-torrent';
+import { getTorrentInfoHash } from '@/electron/lib/torrent-hash.js';
 import { sendNotification } from '@/electron/main.js';
 import {
   getStoredValue,
@@ -33,19 +33,6 @@ import { ElectronRpc } from '@/lib/electron-rpc.js';
 function torrentError(message: string, cause?: unknown): TorrentError {
   if (cause instanceof TorrentError) return cause;
   return new TorrentError({ message, cause });
-}
-
-function getTorrentInfoHash(
-  input: string | Buffer | Uint8Array
-): Effect.Effect<string, TorrentError> {
-  return Effect.try({
-    try: () => {
-      const parsed = parseTorrent(input);
-      return (parsed as { infoHash: string }).infoHash;
-    },
-    catch: (cause) =>
-      torrentError(`Failed to parse torrent: ${formatError(cause)}`, cause),
-  });
 }
 
 function getErrorMessage(error: unknown): string {

--- a/application/src/electron/lib/torrent-hash.ts
+++ b/application/src/electron/lib/torrent-hash.ts
@@ -1,0 +1,16 @@
+import { formatError, TorrentError } from '@ogi/errors';
+import { Effect } from 'effect';
+import parseTorrent from 'parse-torrent';
+
+export function getTorrentInfoHash(
+  input: string | Buffer | Uint8Array
+): Effect.Effect<string, TorrentError> {
+  return Effect.tryPromise({
+    try: async () => (await parseTorrent(input)).infoHash,
+    catch: (cause) =>
+      new TorrentError({
+        message: `Failed to parse torrent: ${formatError(cause)}`,
+        cause,
+      }),
+  });
+}

--- a/application/src/frontend/lib/downloads/button-state.ts
+++ b/application/src/frontend/lib/downloads/button-state.ts
@@ -1,0 +1,6 @@
+import { Effect } from 'effect';
+
+export const resetButtonOnExit = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  reset: () => void
+): Effect.Effect<A, E, R> => effect.pipe(Effect.ensuring(Effect.sync(reset)));

--- a/application/src/frontend/lib/downloads/lifecycle.ts
+++ b/application/src/frontend/lib/downloads/lifecycle.ts
@@ -2,6 +2,7 @@ import { DownloadError, formatError } from '@ogi/errors';
 import { Effect } from 'effect';
 import { get } from 'svelte/store';
 import { getConfigClientOption } from '@/frontend/lib/config/client';
+import { resetButtonOnExit } from '@/frontend/lib/downloads/button-state';
 import { ALL_SERVICES } from '@/frontend/lib/downloads/services';
 import type { SearchResultWithAddon } from '@/frontend/lib/tasks/runner';
 import {
@@ -14,7 +15,7 @@ import {
 /**
  * Resolves download handler from config, finds the matching service, and starts the download.
  * Preserves failures for callers that need to react to whether the download started.
- * The download button is reset before a failure is returned.
+ * The download button is reset whenever the service exits, including defects.
  * @param result - Search result with addon and download URL/type
  * @param appID - Application ID for the download
  * @param event - Mouse event (used to resolve button if htmlButton not provided)
@@ -36,57 +37,60 @@ export function startDownloadEffect(
     }
   };
 
-  return Effect.gen(function* () {
-    let downloadHandler: string = result.downloadType;
-    if (downloadHandler === 'torrent' || downloadHandler === 'magnet') {
-      const generalOptions = getConfigClientOption<{
-        torrentClient?: string;
-      }>('general');
-      const torrentClient = generalOptions?.torrentClient ?? 'disable';
-      if (torrentClient === 'disable') {
+  return resetButtonOnExit(
+    Effect.gen(function* () {
+      let downloadHandler: string = result.downloadType;
+      if (downloadHandler === 'torrent' || downloadHandler === 'magnet') {
+        const generalOptions = getConfigClientOption<{
+          torrentClient?: string;
+        }>('general');
+        const torrentClient = generalOptions?.torrentClient ?? 'disable';
+        if (torrentClient === 'disable') {
+          return yield* Effect.fail(
+            new DownloadError({
+              message: 'Torrenting is disabled in the settings.',
+            })
+          );
+        }
+        if (
+          torrentClient === 'real-debrid' ||
+          torrentClient === 'all-debrid' ||
+          torrentClient === 'torbox' ||
+          torrentClient === 'premiumize'
+        ) {
+          downloadHandler = `${torrentClient}-${downloadHandler}`;
+        }
+      }
+
+      const sanitizedResult = {
+        ...result,
+        name: result.name.replace(/[\\/:*?"<>|]/g, '-'),
+      };
+      const service = ALL_SERVICES.find((candidate) =>
+        candidate.types.includes(downloadHandler)
+      );
+      console.log('Service:', service);
+      if (!service) {
         return yield* Effect.fail(
           new DownloadError({
-            message: 'Torrenting is disabled in the settings.',
+            message: `No service found for download type: ${downloadHandler}`,
           })
         );
       }
-      if (
-        torrentClient === 'real-debrid' ||
-        torrentClient === 'all-debrid' ||
-        torrentClient === 'torbox' ||
-        torrentClient === 'premiumize'
-      ) {
-        downloadHandler = `${torrentClient}-${downloadHandler}`;
+
+      if (resolvedButton) {
+        resolvedButton.textContent = 'Downloading...';
+        resolvedButton.disabled = true;
       }
-    }
-
-    const sanitizedResult = {
-      ...result,
-      name: result.name.replace(/[\\/:*?"<>|]/g, '-'),
-    };
-    const service = ALL_SERVICES.find((candidate) =>
-      candidate.types.includes(downloadHandler)
-    );
-    console.log('Service:', service);
-    if (!service) {
-      return yield* Effect.fail(
-        new DownloadError({
-          message: `No service found for download type: ${downloadHandler}`,
-        })
+      yield* service.startDownload(
+        sanitizedResult,
+        appID,
+        event,
+        resolvedButton ?? undefined
       );
-    }
-
-    if (resolvedButton) {
-      resolvedButton.textContent = 'Downloading...';
-      resolvedButton.disabled = true;
-    }
-    yield* service.startDownload(
-      sanitizedResult,
-      appID,
-      event,
-      resolvedButton ?? undefined
-    );
-  }).pipe(Effect.tapError(() => Effect.sync(resetButton)));
+    }),
+    resetButton
+  );
 }
 
 /** Starts a download and reports failures through the standard notification UI. */

--- a/application/tests/download-lifecycle.test.ts
+++ b/application/tests/download-lifecycle.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { Effect } from 'effect';
+import { resetButtonOnExit } from '../src/frontend/lib/downloads/button-state.js';
+
+describe('download lifecycle', () => {
+  test('runs button cleanup when a download service defects', async () => {
+    let reset = false;
+
+    await Effect.runPromiseExit(
+      resetButtonOnExit(Effect.die(new Error('schema decode failed')), () => {
+        reset = true;
+      })
+    );
+
+    expect(reset).toBe(true);
+  });
+});

--- a/application/tests/torrent-hash.test.ts
+++ b/application/tests/torrent-hash.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { Effect } from 'effect';
+import { getTorrentInfoHash } from '../src/electron/lib/torrent-hash.js';
+
+describe('torrent hashing', () => {
+  test('resolves the info hash returned by parse-torrent', async () => {
+    const hash = '0123456789abcdef0123456789abcdef01234567';
+    const magnet = `magnet:?xt=urn:btih:${hash}`;
+
+    expect(await Effect.runPromise(getTorrentInfoHash(magnet))).toBe(hash);
+  });
+});


### PR DESCRIPTION
## Summary

- Handle torrent info-hash parsing through Effect-based error handling.
- Reset download button state on all service exits, including defects.
- Start addon runtime before startup tasks and simplify updater shutdown handling.

## Testing

- Added download lifecycle coverage for cleanup after defects.
- Added torrent info-hash parsing coverage.
- Removed obsolete system updater shutdown tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Download controls now reset reliably whenever a download operation ends, including unexpected failures.
  * Improved BitTorrent metadata hash extraction and error handling.

* **Tests**
  * Added coverage for download cleanup after unexpected failures.
  * Added validation for extracting hashes from magnet links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->