### PR TITLE
fix(updater): preserve bleeding-edge setup state

### DIFF
--- a/updater/src/bleeding-edge-flow.ts
+++ b/updater/src/bleeding-edge-flow.ts
@@ -1,0 +1,19 @@
+import { Effect } from 'effect';
+
+export type BleedingEdgeSelection = {
+  readonly branch: string;
+  readonly commit: string;
+};
+
+export function selectAndBuildBleedingEdge<A, PersistError, BuildError>(
+  selection: BleedingEdgeSelection,
+  persist: (
+    selection: BleedingEdgeSelection
+  ) => Effect.Effect<void, PersistError>,
+  build: (selection: BleedingEdgeSelection) => Effect.Effect<A, BuildError>
+): Effect.Effect<A, PersistError | BuildError> {
+  return Effect.gen(function* () {
+    yield* persist(selection);
+    return yield* build(selection);
+  });
+}

--- a/updater/src/bleeding-edge-flow.ts
+++ b/updater/src/bleeding-edge-flow.ts
@@ -5,6 +5,18 @@ export type BleedingEdgeSelection = {
   readonly commit: string;
 };
 
+export function normalizeBleedingEdgeSelection(
+  branch: unknown,
+  commit: unknown,
+  defaultBranch: string
+): BleedingEdgeSelection {
+  const normalizedBranch = typeof branch === 'string' ? branch.trim() : '';
+  return {
+    branch: normalizedBranch || defaultBranch,
+    commit: typeof commit === 'string' ? commit.trim() : '',
+  };
+}
+
 export function selectAndBuildBleedingEdge<A, PersistError, BuildError>(
   selection: BleedingEdgeSelection,
   persist: (

--- a/updater/src/git-sync.ts
+++ b/updater/src/git-sync.ts
@@ -4,7 +4,12 @@ export type CommandResult = { stdout: string; stderr: string };
 
 export class GitSyncError extends Data.TaggedError('GitSyncError')<{
   readonly message: string;
-  readonly operation: 'fetch' | 'resolve-head' | 'checkout';
+  readonly operation:
+    | 'fetch'
+    | 'resolve-head'
+    | 'checkout'
+    | 'rebase'
+    | 'stash';
   readonly cause?: unknown;
 }> {}
 
@@ -49,6 +54,7 @@ export function syncBleedingEdgeRepo(
   getRepoHeadSha: (repoDir: string) => Effect.Effect<string, GitSyncError>
 ): Effect.Effect<BleedingEdgeSyncResult, GitSyncError> {
   const targetBranch = branch || defaultBranch;
+  const remoteBranch = `refs/remotes/origin/${targetBranch}`;
 
   return Effect.gen(function* () {
     yield* withOperation(
@@ -63,22 +69,55 @@ export function syncBleedingEdgeRepo(
       'resolve-head',
       getRepoHeadSha(repoDir)
     );
-    // This is an updater-owned build cache, so the fetched remote branch is the
-    // source of truth even when a feature branch has been force-pushed.
-    yield* withOperation(
-      'checkout',
-      runCommand(
-        'git',
-        [
-          'checkout',
-          '--force',
-          '-B',
-          targetBranch,
-          `refs/remotes/origin/${targetBranch}`,
-        ],
-        { cwd: repoDir }
-      )
+    const checkoutExisting = yield* Effect.either(
+      runCommand('git', ['checkout', targetBranch], { cwd: repoDir })
     );
+    const checkoutResult =
+      checkoutExisting._tag === 'Right'
+        ? checkoutExisting
+        : yield* Effect.either(
+            runCommand(
+              'git',
+              ['checkout', '--track', '-b', targetBranch, remoteBranch],
+              { cwd: repoDir }
+            )
+          );
+    const rebaseResult =
+      checkoutResult._tag === 'Right'
+        ? yield* Effect.either(
+            runCommand('git', ['rebase', remoteBranch], { cwd: repoDir })
+          )
+        : checkoutResult;
+
+    if (rebaseResult._tag === 'Left') {
+      yield* runCommand('git', ['rebase', '--abort'], {
+        cwd: repoDir,
+      }).pipe(Effect.ignore);
+      yield* withOperation(
+        'stash',
+        runCommand(
+          'git',
+          [
+            'stash',
+            'push',
+            '--include-untracked',
+            '-m',
+            'OpenGameInstaller updater recovery',
+          ],
+          { cwd: repoDir }
+        )
+      );
+      // Rebase could not safely preserve the cache. Keep dirty files in the
+      // stash, then force-align the updater branch to the fetched remote.
+      yield* withOperation(
+        'checkout',
+        runCommand(
+          'git',
+          ['checkout', '--force', '-B', targetBranch, remoteBranch],
+          { cwd: repoDir }
+        )
+      );
+    }
     const afterSyncSha = yield* withOperation(
       'resolve-head',
       getRepoHeadSha(repoDir)

--- a/updater/src/git-sync.ts
+++ b/updater/src/git-sync.ts
@@ -69,6 +69,17 @@ export function syncBleedingEdgeRepo(
       'resolve-head',
       getRepoHeadSha(repoDir)
     );
+    const remoteBranchResult = yield* Effect.either(
+      runCommand('git', ['rev-parse', '--verify', remoteBranch], {
+        cwd: repoDir,
+      })
+    );
+    if (remoteBranchResult._tag === 'Left') {
+      return yield* withOperation(
+        'checkout',
+        Effect.fail(remoteBranchResult.left)
+      );
+    }
     const checkoutExisting = yield* Effect.either(
       runCommand('git', ['checkout', targetBranch], { cwd: repoDir })
     );

--- a/updater/src/main.ts
+++ b/updater/src/main.ts
@@ -10,6 +10,7 @@ import path, { join } from 'path';
 import yauzl, { type ZipFile } from 'yauzl';
 import zlib from 'zlib';
 import pjson from '../package.json' with { type: 'json' };
+import { selectAndBuildBleedingEdge } from './bleeding-edge-flow.js';
 import {
   type BleedingEdgeSyncResult,
   GitSyncError,
@@ -946,6 +947,24 @@ function logUpdater(message: string, ...args: unknown[]) {
   console.log(`[updater] ${message}`, ...args);
 }
 
+function showBleedingEdgeSetupError(
+  error: UpdaterError,
+  returnToPicker: boolean
+) {
+  const phase = error instanceof UpdateError ? error.phase : error.operation;
+  const detail = phase ? `${error.message}\n\nPhase: ${phase}` : error.message;
+  sendUpdaterStatus(
+    'Bleeding Edge Failed',
+    undefined,
+    undefined,
+    error.message
+  );
+  dialog.showErrorBox('Bleeding Edge setup failed', detail);
+  if (returnToPicker && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('show-channel-picker');
+  }
+}
+
 function sleep(ms: number) {
   return Effect.sleep(ms);
 }
@@ -1101,19 +1120,24 @@ function createWindow(): Effect.Effect<void, UpdaterError> {
         });
         usingBleedingEdge = true;
       } else if (channel === 'bleeding-edge') {
+        const selection = {
+          commit: (choice?.commit || '').trim(),
+          branch: (choice?.branch || DEFAULT_BLEEDING_EDGE_BRANCH).trim(),
+        };
         const buildResult = yield* Effect.either(
-          ensureBleedingEdgeBuild(
-            (choice?.commit || '').trim(),
-            (choice?.branch || DEFAULT_BLEEDING_EDGE_BRANCH).trim()
+          selectAndBuildBleedingEdge(
+            selection,
+            (target) =>
+              tryFileSystem('write-commit-state', './COMMIT_EDGE.txt', () =>
+                writeCommitEdgeFile(target.branch, target.commit)
+              ),
+            (target) => ensureBleedingEdgeBuild(target.commit, target.branch)
           )
         );
         if (buildResult._tag === 'Left') {
           console.error(buildResult.left);
-          mainWindow.webContents.send(
-            'text',
-            'Bleeding Edge Failed',
-            buildResult.left.message
-          );
+          showBleedingEdgeSetupError(buildResult.left, true);
+          return;
         } else {
           mainWindow.webContents.send('text', 'Launching OpenGameInstaller');
         }
@@ -1127,11 +1151,8 @@ function createWindow(): Effect.Effect<void, UpdaterError> {
       );
       if (buildResult._tag === 'Left') {
         console.error(buildResult.left);
-        mainWindow.webContents.send(
-          'text',
-          'Bleeding Edge Failed',
-          buildResult.left.message
-        );
+        showBleedingEdgeSetupError(buildResult.left, false);
+        return;
       } else {
         mainWindow.webContents.send('text', 'Launching OpenGameInstaller');
       }

--- a/updater/src/main.ts
+++ b/updater/src/main.ts
@@ -10,7 +10,10 @@ import path, { join } from 'path';
 import yauzl, { type ZipFile } from 'yauzl';
 import zlib from 'zlib';
 import pjson from '../package.json' with { type: 'json' };
-import { selectAndBuildBleedingEdge } from './bleeding-edge-flow.js';
+import {
+  normalizeBleedingEdgeSelection,
+  selectAndBuildBleedingEdge,
+} from './bleeding-edge-flow.js';
 import {
   type BleedingEdgeSyncResult,
   GitSyncError,
@@ -947,10 +950,7 @@ function logUpdater(message: string, ...args: unknown[]) {
   console.log(`[updater] ${message}`, ...args);
 }
 
-function showBleedingEdgeSetupError(
-  error: UpdaterError,
-  returnToPicker: boolean
-) {
+function showBleedingEdgeSetupError(error: UpdaterError) {
   const phase = error instanceof UpdateError ? error.phase : error.operation;
   const detail = phase ? `${error.message}\n\nPhase: ${phase}` : error.message;
   sendUpdaterStatus(
@@ -960,9 +960,36 @@ function showBleedingEdgeSetupError(
     error.message
   );
   dialog.showErrorBox('Bleeding Edge setup failed', detail);
-  if (returnToPicker && mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send('show-channel-picker');
-  }
+}
+
+type UpdateChannelChoice = {
+  readonly channel?: string;
+  readonly branch?: string;
+  readonly commit?: string;
+};
+
+function waitForUpdateChannelChoice() {
+  return tryUpdatePromise<UpdateChannelChoice>(
+    'choose-update-channel',
+    (signal) =>
+      new Promise((resolve, reject) => {
+        const onChoice = (_event: unknown, payload: unknown) => {
+          signal.removeEventListener('abort', onAbort);
+          resolve(
+            typeof payload === 'object' && payload !== null
+              ? (payload as UpdateChannelChoice)
+              : {}
+          );
+        };
+        const onAbort = () => {
+          ipcMain.removeListener('choose-channel', onChoice);
+          reject(signal.reason ?? new Error('Channel selection cancelled'));
+        };
+        ipcMain.once('choose-channel', onChoice);
+        signal.addEventListener('abort', onAbort, { once: true });
+        mainWindow?.webContents.send('show-channel-picker');
+      })
+  );
 }
 
 function sleep(ms: number) {
@@ -1089,60 +1116,50 @@ function createWindow(): Effect.Effect<void, UpdaterError> {
     }
 
     if (hasArg('--gui')) {
-      mainWindow.webContents.send('show-channel-picker');
-      const choice: any = yield* tryUpdatePromise(
-        'choose-update-channel',
-        (signal) =>
-          new Promise((resolve, reject) => {
-            const onChoice = (_event, payload): void => {
-              signal.removeEventListener('abort', onAbort);
-              resolve(payload);
-            };
-            const onAbort = (): void => {
-              ipcMain.removeListener('choose-channel', onChoice);
-              reject(signal.reason ?? new Error('Channel selection cancelled'));
-            };
-            ipcMain.once('choose-channel', onChoice);
-            signal.addEventListener('abort', onAbort, { once: true });
-          })
-      );
-      const channel = choice?.channel || 'stable';
-      if (channel === 'stable') {
-        yield* tryFileSystem('select-stable-channel', undefined, () => {
-          fs.rmSync('./bleeding-edge.txt', { force: true });
-          fs.rmSync('./COMMIT_EDGE.txt', { force: true });
-        });
-        usingBleedingEdge = false;
-      } else if (channel === 'unstable') {
-        yield* tryFileSystem('select-unstable-channel', undefined, () => {
-          fs.writeFileSync('./bleeding-edge.txt', 'true');
-          fs.rmSync('./COMMIT_EDGE.txt', { force: true });
-        });
-        usingBleedingEdge = true;
-      } else if (channel === 'bleeding-edge') {
-        const selection = {
-          commit: (choice?.commit || '').trim(),
-          branch: (choice?.branch || DEFAULT_BLEEDING_EDGE_BRANCH).trim(),
-        };
-        const buildResult = yield* Effect.either(
-          selectAndBuildBleedingEdge(
-            selection,
-            (target) =>
-              tryFileSystem('write-commit-state', './COMMIT_EDGE.txt', () =>
-                writeCommitEdgeFile(target.branch, target.commit)
-              ),
-            (target) => ensureBleedingEdgeBuild(target.commit, target.branch)
-          )
-        );
-        if (buildResult._tag === 'Left') {
-          console.error(buildResult.left);
-          showBleedingEdgeSetupError(buildResult.left, true);
-          return;
-        } else {
-          mainWindow.webContents.send('text', 'Launching OpenGameInstaller');
+      while (true) {
+        const choice = yield* waitForUpdateChannelChoice();
+        const channel = choice.channel || 'stable';
+        if (channel === 'stable') {
+          yield* tryFileSystem('select-stable-channel', undefined, () => {
+            fs.rmSync('./bleeding-edge.txt', { force: true });
+            fs.rmSync('./COMMIT_EDGE.txt', { force: true });
+          });
+          usingBleedingEdge = false;
+          break;
         }
-        launchApp(true);
-        return;
+        if (channel === 'unstable') {
+          yield* tryFileSystem('select-unstable-channel', undefined, () => {
+            fs.writeFileSync('./bleeding-edge.txt', 'true');
+            fs.rmSync('./COMMIT_EDGE.txt', { force: true });
+          });
+          usingBleedingEdge = true;
+          break;
+        }
+        if (channel === 'bleeding-edge') {
+          const selection = normalizeBleedingEdgeSelection(
+            choice.branch,
+            choice.commit,
+            DEFAULT_BLEEDING_EDGE_BRANCH
+          );
+          const buildResult = yield* Effect.either(
+            selectAndBuildBleedingEdge(
+              selection,
+              (target) =>
+                tryFileSystem('write-commit-state', './COMMIT_EDGE.txt', () =>
+                  writeCommitEdgeFile(target.branch, target.commit)
+                ),
+              (target) => ensureBleedingEdgeBuild(target.commit, target.branch)
+            )
+          );
+          if (buildResult._tag === 'Left') {
+            console.error(buildResult.left);
+            showBleedingEdgeSetupError(buildResult.left);
+            continue;
+          }
+          mainWindow.webContents.send('text', 'Launching OpenGameInstaller');
+          launchApp(true);
+          return;
+        }
       }
     } else if (updateChannel === 'bleeding-edge') {
       const { branch, commit } = getCommitEdgeTarget();
@@ -1151,7 +1168,7 @@ function createWindow(): Effect.Effect<void, UpdaterError> {
       );
       if (buildResult._tag === 'Left') {
         console.error(buildResult.left);
-        showBleedingEdgeSetupError(buildResult.left, false);
+        showBleedingEdgeSetupError(buildResult.left);
         return;
       } else {
         mainWindow.webContents.send('text', 'Launching OpenGameInstaller');

--- a/updater/test/bleeding-edge-flow.test.ts
+++ b/updater/test/bleeding-edge-flow.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import { Effect } from 'effect';
+import { selectAndBuildBleedingEdge } from '../src/bleeding-edge-flow.js';
+
+test('persists a bleeding-edge selection before a build can fail', async () => {
+  const events: string[] = [];
+  const selection = { branch: 'feature/test', commit: 'abc123' };
+
+  const exit = await Effect.runPromiseExit(
+    selectAndBuildBleedingEdge(
+      selection,
+      (target) =>
+        Effect.sync(() => {
+          events.push(`persist:${target.branch}:${target.commit}`);
+        }),
+      () =>
+        Effect.gen(function* () {
+          events.push('build');
+          return yield* Effect.fail('build failed');
+        })
+    )
+  );
+
+  expect(exit._tag).toBe('Failure');
+  expect(events).toEqual(['persist:feature/test:abc123', 'build']);
+});

--- a/updater/test/bleeding-edge-flow.test.ts
+++ b/updater/test/bleeding-edge-flow.test.ts
@@ -1,6 +1,16 @@
 import { expect, test } from 'bun:test';
 import { Effect } from 'effect';
-import { selectAndBuildBleedingEdge } from '../src/bleeding-edge-flow.js';
+import {
+  normalizeBleedingEdgeSelection,
+  selectAndBuildBleedingEdge,
+} from '../src/bleeding-edge-flow.js';
+
+test('uses the default branch for a whitespace-only selection', () => {
+  expect(normalizeBleedingEdgeSelection('   ', ' abc123 ', 'main')).toEqual({
+    branch: 'main',
+    commit: 'abc123',
+  });
+});
 
 test('persists a bleeding-edge selection before a build can fail', async () => {
   const events: string[] = [];

--- a/updater/test/git-sync.test.ts
+++ b/updater/test/git-sync.test.ts
@@ -174,3 +174,93 @@ test('stashes dirty files before force-aligning when rebase cannot start', async
     (await git(client, 'stash', 'show', '-p', 'stash@{0}')).stdout
   ).toContain('dirty local change');
 });
+
+test('returns a missing remote branch error without starting recovery', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'ogi-git-sync-'));
+  temporaryDirectories.push(root);
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const client = path.join(root, 'client');
+  const commands: string[][] = [];
+
+  await git(root, 'init', '--bare', remote);
+  await git(root, 'init', '-b', 'main', seed);
+  await git(seed, 'config', 'user.email', 'updater-test@example.invalid');
+  await git(seed, 'config', 'user.name', 'updater-test');
+  await writeFile(path.join(seed, 'file.txt'), 'base\n');
+  await git(seed, 'add', 'file.txt');
+  await git(seed, 'commit', '-m', 'base');
+  await git(seed, 'remote', 'add', 'origin', remote);
+  await git(seed, 'push', 'origin', 'main');
+  await git(root, 'clone', '--branch', 'main', remote, client);
+
+  const error = await Effect.runPromise(
+    Effect.flip(
+      syncBleedingEdgeRepo(
+        client,
+        'missing',
+        'main',
+        (command, args, options) => {
+          commands.push(args);
+          return runCommand(command, args, options);
+        },
+        getHeadSha
+      )
+    )
+  );
+
+  expect(error.operation).toBe('checkout');
+  expect(commands.some((args) => args[0] === 'stash')).toBe(false);
+  expect(commands.some((args) => args.includes('--force'))).toBe(false);
+});
+
+test('recovers a dirty detached cache when the target branch exists', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'ogi-git-sync-'));
+  temporaryDirectories.push(root);
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const client = path.join(root, 'client');
+  const commands: string[][] = [];
+
+  await git(root, 'init', '--bare', remote);
+  await git(root, 'init', '-b', 'main', seed);
+  await git(seed, 'config', 'user.email', 'updater-test@example.invalid');
+  await git(seed, 'config', 'user.name', 'updater-test');
+  await writeFile(path.join(seed, 'file.txt'), 'base\n');
+  await git(seed, 'add', 'file.txt');
+  await git(seed, 'commit', '-m', 'base');
+  await git(seed, 'remote', 'add', 'origin', remote);
+  await git(seed, 'push', 'origin', 'main');
+  await git(root, 'clone', '--branch', 'main', remote, client);
+  await git(client, 'config', 'user.email', 'updater-test@example.invalid');
+  await git(client, 'config', 'user.name', 'updater-test');
+
+  await git(client, 'checkout', '--detach');
+  await writeFile(path.join(client, 'file.txt'), 'detached commit\n');
+  await git(client, 'commit', '-am', 'detached commit');
+  await writeFile(path.join(client, 'file.txt'), 'dirty detached change\n');
+  await writeFile(path.join(seed, 'file.txt'), 'remote change\n');
+  await git(seed, 'commit', '-am', 'remote change');
+  await git(seed, 'push', 'origin', 'main');
+  const remoteSha = await Effect.runPromise(getHeadSha(seed));
+
+  const result = await Effect.runPromise(
+    syncBleedingEdgeRepo(
+      client,
+      'main',
+      'main',
+      (command, args, options) => {
+        commands.push(args);
+        return runCommand(command, args, options);
+      },
+      getHeadSha
+    )
+  );
+
+  expect(result.afterSyncSha).toBe(remoteSha);
+  expect(commands.some((args) => args[0] === 'stash')).toBe(true);
+  expect(commands.some((args) => args.includes('--force'))).toBe(true);
+  expect(
+    (await git(client, 'stash', 'show', '-p', 'stash@{0}')).stdout
+  ).toContain('dirty detached change');
+});

--- a/updater/test/git-sync.test.ts
+++ b/updater/test/git-sync.test.ts
@@ -100,3 +100,77 @@ test('synchronizes a cached branch after the remote branch is force-pushed', asy
   expect(result.afterSyncSha).toBe(remoteSha);
   expect(await Effect.runPromise(getHeadSha(client))).toBe(remoteSha);
 });
+
+test('rebases local branch commits onto the fetched remote branch', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'ogi-git-sync-'));
+  temporaryDirectories.push(root);
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const client = path.join(root, 'client');
+
+  await git(root, 'init', '--bare', remote);
+  await git(root, 'init', '-b', 'main', seed);
+  await git(seed, 'config', 'user.email', 'updater-test@example.invalid');
+  await git(seed, 'config', 'user.name', 'updater-test');
+  await writeFile(path.join(seed, 'base.txt'), 'base\n');
+  await git(seed, 'add', 'base.txt');
+  await git(seed, 'commit', '-m', 'base');
+  await git(seed, 'remote', 'add', 'origin', remote);
+  await git(seed, 'push', 'origin', 'main');
+  await git(root, 'clone', '--branch', 'main', remote, client);
+  await git(client, 'config', 'user.email', 'updater-test@example.invalid');
+  await git(client, 'config', 'user.name', 'updater-test');
+
+  await writeFile(path.join(client, 'local.txt'), 'local\n');
+  await git(client, 'add', 'local.txt');
+  await git(client, 'commit', '-m', 'local change');
+  await writeFile(path.join(seed, 'remote.txt'), 'remote\n');
+  await git(seed, 'add', 'remote.txt');
+  await git(seed, 'commit', '-m', 'remote change');
+  await git(seed, 'push', 'origin', 'main');
+  const remoteSha = await Effect.runPromise(getHeadSha(seed));
+
+  const result = await Effect.runPromise(
+    syncBleedingEdgeRepo(client, 'main', 'main', runCommand, getHeadSha)
+  );
+
+  expect(result.afterSyncSha).not.toBe(remoteSha);
+  expect(
+    (await git(client, 'merge-base', 'HEAD', `origin/main`)).stdout.trim()
+  ).toBe(remoteSha);
+  expect((await git(client, 'show', 'HEAD:local.txt')).stdout).toBe('local\n');
+});
+
+test('stashes dirty files before force-aligning when rebase cannot start', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'ogi-git-sync-'));
+  temporaryDirectories.push(root);
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const client = path.join(root, 'client');
+
+  await git(root, 'init', '--bare', remote);
+  await git(root, 'init', '-b', 'main', seed);
+  await git(seed, 'config', 'user.email', 'updater-test@example.invalid');
+  await git(seed, 'config', 'user.name', 'updater-test');
+  await writeFile(path.join(seed, 'file.txt'), 'base\n');
+  await git(seed, 'add', 'file.txt');
+  await git(seed, 'commit', '-m', 'base');
+  await git(seed, 'remote', 'add', 'origin', remote);
+  await git(seed, 'push', 'origin', 'main');
+  await git(root, 'clone', '--branch', 'main', remote, client);
+
+  await writeFile(path.join(client, 'file.txt'), 'dirty local change\n');
+  await writeFile(path.join(seed, 'file.txt'), 'remote change\n');
+  await git(seed, 'commit', '-am', 'remote change');
+  await git(seed, 'push', 'origin', 'main');
+  const remoteSha = await Effect.runPromise(getHeadSha(seed));
+
+  const result = await Effect.runPromise(
+    syncBleedingEdgeRepo(client, 'main', 'main', runCommand, getHeadSha)
+  );
+
+  expect(result.afterSyncSha).toBe(remoteSha);
+  expect(
+    (await git(client, 'stash', 'show', '-p', 'stash@{0}')).stdout
+  ).toContain('dirty local change');
+});


### PR DESCRIPTION
# Description

Persist bleeding-edge branch and commit selection before setup begins, surface setup failures in a native popup, and stop silently launching the previous stable build. Cached repositories now rebase onto the fetched branch first, then stash dirty files and force-align only when rebase cannot complete.

# Example

```text
fetch -> checkout -> rebase
                     \ failure -> abort -> stash -> force-align
```

# Next Steps

- Validate an interactive bleeding-edge build on Linux and Windows.
- Confirm retrying from the channel picker preserves the selected target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved bleeding-edge version setup with normalized branch and commit selections.
  - Selected bleeding-edge versions are saved before building, enabling clearer recovery when builds fail.
  - Added retry handling and consistent error reporting during bleeding-edge setup.

- **Bug Fixes**
  - Improved synchronization by rebasing local changes onto remote branches when possible.
  - Safer recovery now preserves tracked and untracked work before aligning with the remote version.
  - Added clearer handling for missing or invalid remote branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->