### PR TITLE
fix(electron): accept explicit undefined in RPC payloads

### DIFF
--- a/application/src/lib/electron-rpc.ts
+++ b/application/src/lib/electron-rpc.ts
@@ -74,8 +74,12 @@ const rpc = <
 
 const Void = Schema.Void;
 const StringArray = Schema.mutable(Schema.Array(Schema.String));
-const OptionalString = Schema.optionalElement(Schema.String);
-const OptionalNumber = Schema.optionalElement(Schema.Number);
+const OptionalString = Schema.optionalElement(
+  Schema.UndefinedOr(Schema.String)
+);
+const OptionalNumber = Schema.optionalElement(
+  Schema.UndefinedOr(Schema.Number)
+);
 const ErrorResponse = Schema.Struct({
   status: Schema.Literal('error'),
   error: Schema.String,
@@ -180,8 +184,12 @@ export const ElectronRpc = {
         Schema.String,
         OptionalString,
         OptionalString,
-        Schema.optionalElement(opaque<LibraryInfo['umu']>()),
-        Schema.optionalElement(opaque<LibraryInfo['launchEnv']>()),
+        Schema.optionalElement(
+          Schema.UndefinedOr(opaque<LibraryInfo['umu']>())
+        ),
+        Schema.optionalElement(
+          Schema.UndefinedOr(opaque<LibraryInfo['launchEnv']>())
+        ),
       ],
       Schema.Literal('success', 'app-not-found')
     ),

--- a/application/tests/electron-rpc-schema.test.ts
+++ b/application/tests/electron-rpc-schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { Schema } from 'effect';
+import { ElectronRpc } from '../src/lib/electron-rpc.js';
+
+describe('Electron RPC payload schemas', () => {
+  test('accept explicit undefined for optional positional arguments', () => {
+    const payloads = [
+      [ElectronRpc.app.addToSteam.payloadSchema, [1, undefined]],
+      [
+        ElectronRpc.app.updateAppVersion.payloadSchema,
+        [
+          1,
+          '1.0.0',
+          '/tmp/game',
+          'game.exe',
+          undefined,
+          'addon-source',
+          { umuId: 'umu:1' },
+          undefined,
+        ],
+      ],
+      [
+        ElectronRpc.realdebrid.addMagnet.payloadSchema,
+        ['magnet:?xt=urn:btih:test', undefined],
+      ],
+      [ElectronRpc.ddl.download.payloadSchema, [[], undefined]],
+    ] as const;
+
+    for (const [schema, payload] of payloads) {
+      expect(() => Schema.decodeUnknownSync(schema)(payload)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Allow explicit `undefined` values in optional Electron RPC payload fields.
- Add schema coverage for optional positional arguments across RPC procedures.

## Testing

- `bun test application/tests/electron-rpc-schema.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional values in Electron RPC requests, preventing valid operations from being rejected when optional fields are explicitly left undefined.

* **Tests**
  * Added coverage for optional arguments across app updates, Real-Debrid operations, and download requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->