### PR TITLE
fix(application): forked Deck Steam shortcut setup

### DIFF
--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -678,7 +678,9 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                 return 'setup-prefix-required';
               }
 
-              yield* addDeckGameToSteam(mainWindow, data.appID);
+              yield* Effect.forkDaemon(
+                addDeckGameToSteam(mainWindow, data.appID)
+              );
               return 'setup-success';
             }
           }

--- a/application/src/electron/handlers/handler.redists.ts
+++ b/application/src/electron/handlers/handler.redists.ts
@@ -112,7 +112,7 @@ const installRedistributables = (
         new LibraryError({ message: formatError(cause), gameId: appID }),
     });
 
-    yield* addDeckGameToSteam(mainWindow, appID);
+    yield* Effect.forkDaemon(addDeckGameToSteam(mainWindow, appID));
     return result;
   });
 

--- a/application/src/electron/handlers/handler.steam.ts
+++ b/application/src/electron/handlers/handler.steam.ts
@@ -147,47 +147,43 @@ export function addUmuGameToSteam(
 export function addDeckGameToSteam(
   mainWindow: BrowserWindow,
   appID: number
-): Effect.Effect<void> {
+): Effect.Effect<void, SteamServiceError | FileSystemError> {
   if (!isLinux() || getCurrentUsername()?.toLowerCase() !== 'deck') {
     return Effect.void;
   }
 
-  // Shortcut setup is optional tail work; detaching it lets completed installs
-  // release the power-save blocker without waiting for Steam.
-  return Effect.forkDaemon(
-    Effect.gen(function* () {
-      const result = yield* addUmuGameToSteam(mainWindow, { appID });
-      if (result.status === 'cancelled') {
+  return Effect.gen(function* () {
+    const result = yield* addUmuGameToSteam(mainWindow, { appID });
+    if (result.status === 'cancelled') {
+      sendNotification({
+        message:
+          'Steam shortcut setup was cancelled. Add the game to Steam later from its configuration page.',
+        id: generateNotificationId(),
+        type: 'info',
+      });
+    } else if (result.warning) {
+      sendNotification({
+        message: result.warning,
+        id: generateNotificationId(),
+        type: 'warning',
+      });
+    }
+  }).pipe(
+    Effect.tapError((error) =>
+      Effect.gen(function* () {
+        yield* logger.error(
+          `[steam] Failed to add Deck game ${appID} to Steam`,
+          error
+        );
         sendNotification({
           message:
-            'Steam shortcut setup was cancelled. Add the game to Steam later from its configuration page.',
+            'Failed to add the game to Steam. Try again from its configuration page.',
           id: generateNotificationId(),
-          type: 'info',
+          type: 'error',
         });
-      } else if (result.warning) {
-        sendNotification({
-          message: result.warning,
-          id: generateNotificationId(),
-          type: 'warning',
-        });
-      }
-    }).pipe(
-      Effect.catchAll((error) =>
-        Effect.gen(function* () {
-          yield* logger.error(
-            `[steam] Failed to add Deck game ${appID} to Steam`,
-            error
-          );
-          sendNotification({
-            message:
-              'Failed to add the game to Steam. Try again from its configuration page.',
-            id: generateNotificationId(),
-            type: 'error',
-          });
-        })
-      )
+      })
     )
-  ).pipe(Effect.asVoid);
+  );
 }
 
 const launchViaSteam = (

--- a/application/src/electron/handlers/handler.steam.ts
+++ b/application/src/electron/handlers/handler.steam.ts
@@ -7,6 +7,7 @@ import {
   ipcBoundary,
   SteamRunningError,
 } from '@ogi-sdk/errors';
+import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect, Layer } from 'effect';
 import { type BrowserWindow, dialog } from 'electron';
 import {
@@ -43,6 +44,8 @@ import { ElectronRpc } from '@/lib/electron-rpc.js';
 export type SteamOperationResult =
   | SteamMutationResult
   | { status: 'cancelled'; message: string };
+
+const logger = createLogger(LOGGER_PREFIXES.electron);
 
 const SteamLive = SteamServiceLive.pipe(
   Layer.provide(Layer.merge(SteamRepositoryLive(), SteamProcessLive))
@@ -144,28 +147,47 @@ export function addUmuGameToSteam(
 export function addDeckGameToSteam(
   mainWindow: BrowserWindow,
   appID: number
-): Effect.Effect<void, SteamServiceError | FileSystemError> {
+): Effect.Effect<void> {
   if (!isLinux() || getCurrentUsername()?.toLowerCase() !== 'deck') {
     return Effect.void;
   }
 
-  return Effect.gen(function* () {
-    const result = yield* addUmuGameToSteam(mainWindow, { appID });
-    if (result.status === 'cancelled') {
-      sendNotification({
-        message:
-          'Steam shortcut setup was cancelled. Add the game to Steam later from its configuration page.',
-        id: generateNotificationId(),
-        type: 'info',
-      });
-    } else if (result.warning) {
-      sendNotification({
-        message: result.warning,
-        id: generateNotificationId(),
-        type: 'warning',
-      });
-    }
-  });
+  // Shortcut setup is optional tail work; detaching it lets completed installs
+  // release the power-save blocker without waiting for Steam.
+  return Effect.forkDaemon(
+    Effect.gen(function* () {
+      const result = yield* addUmuGameToSteam(mainWindow, { appID });
+      if (result.status === 'cancelled') {
+        sendNotification({
+          message:
+            'Steam shortcut setup was cancelled. Add the game to Steam later from its configuration page.',
+          id: generateNotificationId(),
+          type: 'info',
+        });
+      } else if (result.warning) {
+        sendNotification({
+          message: result.warning,
+          id: generateNotificationId(),
+          type: 'warning',
+        });
+      }
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.gen(function* () {
+          yield* logger.error(
+            `[steam] Failed to add Deck game ${appID} to Steam`,
+            error
+          );
+          sendNotification({
+            message:
+              'Failed to add the game to Steam. Try again from its configuration page.',
+            id: generateNotificationId(),
+            type: 'error',
+          });
+        })
+      )
+    )
+  ).pipe(Effect.asVoid);
 }
 
 const launchViaSteam = (


### PR DESCRIPTION
# Description

Forks automatic Deck Steam shortcut creation at the two setup call sites. The Steam helper remains a normal fallible Effect, while setup can finish and release the power-save blocker as the optional Steam step continues in the background. Failures are still logged and surfaced through an error notification.

# Example

```ts
yield* Effect.forkDaemon(addDeckGameToSteam(mainWindow, appID));
```

# Next Steps

- Verify the console can sleep after installation completes while Steam shortcut setup is still running.
- Confirm cancellation, warning, and failure notifications on a Steam Deck.

## Validation

- `bun run --cwd application typecheck`
- `bun run --cwd application lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Game setup and redistributable installation now return success sooner while Steam registration continues in the background.

* **Bug Fixes**
  * Improved error handling when adding games to Steam.
  * Failed Steam registration now produces an error notification and is recorded for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->