### PR TITLE
fix(executor): supported chained Windows setup scripts

### DIFF
--- a/packages/executor/lib/addon-setup.test.ts
+++ b/packages/executor/lib/addon-setup.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { AddonSetup } from '@ogi-sdk/executor';
+import { Addon, AddonSetup } from '@ogi-sdk/executor';
 import { Effect } from 'effect';
 
 const temporaryDirectories: string[] = [];
@@ -14,6 +14,26 @@ afterEach(() => {
 });
 
 describe('Addon setup scripts', () => {
+  test('uses the Windows command shell for chained commands', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    try {
+      const invocation = await Effect.runPromise(
+        Addon.getScriptSpawnCommand(
+          'bun install --ignore-scripts && bun --version'
+        )
+      );
+
+      expect(invocation.command).toBe(
+        process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe'
+      );
+      expect(invocation.args.at(-1)).toContain('&&');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
   test('runs chained shell commands', async () => {
     const path = mkdtempSync(join(tmpdir(), 'ogi-addon-setup-'));
     temporaryDirectories.push(path);

--- a/packages/executor/lib/addon.ts
+++ b/packages/executor/lib/addon.ts
@@ -83,20 +83,12 @@ export class Addon {
     });
   }
 
-  private static intoPowerShellScript(
-    fullCommand: string
-  ): Effect.Effect<string, AddonError> {
-    return Addon.intoExecutor(fullCommand).pipe(
-      Effect.map((command) => command.replace(/^"([^"]+)"/, '& "$1"'))
-    );
-  }
-
   public static getPowerShellExecutable(): string {
     return 'powershell.exe';
   }
 
-  private static quotePowerShellArgument(value: string): string {
-    return `'${value.replace(/'/g, "''")}'`;
+  private static quoteWindowsShellArgument(value: string): string {
+    return `"${value.replace(/%/g, '%%').replace(/"/g, '""')}"`;
   }
 
   public static getScriptSpawnCommand(
@@ -105,21 +97,14 @@ export class Addon {
   ): Effect.Effect<ScriptSpawnCommand, AddonError | ValidationError> {
     return Effect.gen(function* () {
       if (process.platform === 'win32') {
-        const scriptCommand = yield* Addon.intoPowerShellScript(script);
+        const scriptCommand = yield* Addon.intoExecutor(script);
         const command = [
           scriptCommand,
-          ...extraArgs.map(Addon.quotePowerShellArgument),
+          ...extraArgs.map(Addon.quoteWindowsShellArgument),
         ].join(' ');
         return {
-          command: Addon.getPowerShellExecutable(),
-          args: [
-            '-NoProfile',
-            '-NonInteractive',
-            '-ExecutionPolicy',
-            'Bypass',
-            '-Command',
-            command,
-          ],
+          command: process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe',
+          args: ['/d', '/s', '/c', command],
         };
       }
 


### PR DESCRIPTION
# Description

Routes Windows addon scripts through the native command shell so chained commands work on systems using Windows PowerShell 5. Preserves safe quoting for appended addon arguments and adds a focused regression check.

# Example

Before: powershell.exe rejected setup commands containing && as an invalid statement separator.

After: cmd.exe /d /s /c executes the same chained setup command.

# Next Steps

- Release the updated executor package and application build.
- Verify addon installation on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of chained addon commands on Windows.
  * Windows addon scripts now use the standard command shell and correctly preserve command chaining and special characters.

* **Tests**
  * Added coverage to verify Windows command execution and argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->