### PR TITLE
fix(executor): expose Bun tools to addon setup

### DIFF
--- a/packages/executor/lib/addon-setup.test.ts
+++ b/packages/executor/lib/addon-setup.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Addon, AddonSetup } from '@ogi-sdk/executor';
@@ -48,5 +54,40 @@ describe('Addon setup scripts', () => {
     });
 
     await Effect.runPromise(setup.preSetup());
+  });
+
+  test('makes bunx available when Bun is outside PATH', async () => {
+    const path = mkdtempSync(join(tmpdir(), 'ogi-addon-setup-'));
+    const toolsPath = mkdtempSync(join(tmpdir(), 'ogi-addon-tools-'));
+    const bunPath = mkdtempSync(join(tmpdir(), 'ogi-addon-bun-'));
+    temporaryDirectories.push(path, toolsPath, bunPath);
+    const bunExecutable = join(bunPath, 'bun');
+    symlinkSync(process.execPath, bunExecutable);
+    symlinkSync(process.execPath, join(bunPath, 'bunx'));
+    const whichPath = join(toolsPath, 'which');
+    writeFileSync(
+      whichPath,
+      `#!/bin/sh\nprintf '%s\\n' ${JSON.stringify(bunExecutable)}\n`
+    );
+    chmodSync(whichPath, 0o755);
+
+    const originalPath = process.env.PATH;
+    process.env.PATH = toolsPath;
+
+    try {
+      expect(await Effect.runPromise(Addon.getBunPath())).toBe(bunExecutable);
+      const setup = new AddonSetup({
+        path,
+        name: 'test-addon',
+        scripts: {
+          run: 'bun index.ts',
+          preSetup: 'bun --version && bunx --version',
+        },
+      });
+
+      await Effect.runPromise(setup.preSetup());
+    } finally {
+      process.env.PATH = originalPath;
+    }
   });
 });

--- a/packages/executor/lib/addon-setup.ts
+++ b/packages/executor/lib/addon-setup.ts
@@ -80,10 +80,12 @@ export class AddonSetup {
         process.platform === 'win32'
           ? yield* Addon.getScriptSpawnCommand(script)
           : { command: '/bin/sh', args: ['-c', startCommand] };
+      const env = yield* Addon.getEnvironmentWithBun();
       const child = yield* Effect.try({
         try: () =>
           spawn(command, args, {
             cwd: this.config.path,
+            env,
             stdio: ['ignore', 'pipe', 'pipe'],
           }),
         catch: (cause) =>

--- a/packages/executor/lib/addon.ts
+++ b/packages/executor/lib/addon.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import { execFile, execFileSync, spawn } from 'node:child_process';
-import { join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 import { AddonError, FileSystemError, ValidationError } from '@ogi-sdk/errors';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Deferred, Effect, Exit, Schema, Scope } from 'effect';
@@ -60,7 +60,11 @@ export class Addon {
     }
 
     return Effect.try({
-      try: () => execFileSync('which', ['bun'], { encoding: 'utf-8' }).trim(),
+      try: () =>
+        execFileSync('which', ['bun'], {
+          encoding: 'utf-8',
+          env: process.env,
+        }).trim(),
       catch: () =>
         new AddonError({ message: 'Unable to find bun through which' }),
     }).pipe(
@@ -71,6 +75,21 @@ export class Addon {
       Effect.catchAll(() =>
         Effect.succeed(join(process.env.HOME || '', '.bun', 'bin', 'bun'))
       )
+    );
+  }
+
+  public static getEnvironmentWithBun(): Effect.Effect<
+    NodeJS.ProcessEnv,
+    AddonError
+  > {
+    return Addon.getBunPath().pipe(
+      Effect.map((bunPath) => {
+        const currentPath = process.env.PATH ?? process.env.Path;
+        return {
+          ...process.env,
+          PATH: [dirname(bunPath), currentPath].filter(Boolean).join(delimiter),
+        };
+      })
     );
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved addon setup so Bun can be discovered reliably, even when it is not directly available through the current `PATH`.
  - Setup commands can now consistently run both `bun` and `bunx` across supported environments.
  - Preserved the existing working directory and output behavior during setup.

- **Tests**
  - Added integration coverage for Bun discovery and execution in restricted `PATH` environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->