### PR TITLE
fix(application): recover addon runtime during launch

### DIFF
--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -15,7 +15,7 @@ import {
 import { AddonMarketplace } from '@/electron/lib/marketplace.js';
 import { sendIPCMessage, sendNotification } from '@/electron/main.js';
 import { Addon } from '@/electron/manager/manager.addon.js';
-import { waitForAddonsConfigured } from '@/electron/manager/manager.addon-readiness.js';
+import { waitForAddonManifests } from '@/electron/manager/manager.addon-readiness.js';
 import { __dirname } from '@/electron/manager/manager.paths.js';
 import { ipcProcedure, router } from '@/electron/rpc/router-core.js';
 import { deleteInstalledAddon } from '@/electron/server/addon-lifecycle.js';
@@ -110,6 +110,10 @@ export function startAddons(): Effect.Effect<void, AddonError> {
             return;
           }
 
+          const runningAddon = Addon.running.get(addonPath);
+          if (runningAddon?.getChildProcess()) return;
+          if (runningAddon) Addon.running.delete(addonPath);
+
           logger.sync.info(`Starting addon ${addonPath}`);
           const instance = yield* Addon.load(addonPath).pipe(
             Effect.catchAll(() => Effect.succeed(null))
@@ -186,18 +190,9 @@ export function restartAddonServer(): Effect.Effect<void, AddonError> {
     logger.sync.info(`Addon Server is running on http://localhost:${port}`);
     logger.sync.info(`Server is being executed by electron!`);
     yield* startAddons();
-    const configuredAddons = yield* waitForAddonsConfigured();
-    for (const connection of configuredAddons) {
-      yield* Effect.tryPromise({
-        try: () => sendIPCMessage('addon-connected', connection.addonInfo!.id),
-        catch: (cause) =>
-          new AddonError({
-            message: `Failed to notify renderer: ${String(cause)}`,
-          }),
-      });
-    }
+    yield* waitForAddonManifests();
     yield* Effect.tryPromise({
-      try: () => sendIPCMessage('addon-runtime-ready'),
+      try: () => sendIPCMessage('addon-manifests-ready'),
       catch: (cause) =>
         new AddonError({
           message: `Failed to notify renderer: ${String(cause)}`,
@@ -624,6 +619,16 @@ export default function AddonManagerHandler(mainWindow: BrowserWindow) {
     ipcBoundary(() => restartAddonServer())
   );
 
+  const ensureAddonsSpawnedProcedure = ipcProcedure(
+    ElectronRpc.ensureAddonsSpawned,
+    ipcBoundary(() =>
+      startAddons().pipe(
+        Effect.zipRight(waitForAddonManifests()),
+        Effect.asVoid
+      )
+    )
+  );
+
   const deleteInstalledAddonProcedure = ipcProcedure(
     ElectronRpc.deleteInstalledAddon,
     ipcBoundary((_, addonID: string) =>
@@ -1034,6 +1039,7 @@ export default function AddonManagerHandler(mainWindow: BrowserWindow) {
 
   return router(
     installAddons,
+    ensureAddonsSpawnedProcedure,
     restartAddonServerProcedure,
     deleteInstalledAddonProcedure,
     cleanAddons,

--- a/application/src/electron/lib/renderer-event-readiness.ts
+++ b/application/src/electron/lib/renderer-event-readiness.ts
@@ -1,0 +1,36 @@
+export class RendererEventReadiness {
+  private ready = false;
+  private readonly waiters = new Set<() => void>();
+
+  public isReady(): boolean {
+    return this.ready;
+  }
+
+  public markReady(): void {
+    this.ready = true;
+    for (const waiter of this.waiters) waiter();
+    this.waiters.clear();
+  }
+
+  public reset(): void {
+    this.ready = false;
+  }
+
+  public wait(timeoutMs: number, onTimeout: () => void): Promise<void> {
+    if (this.ready) return Promise.resolve();
+
+    return new Promise((resolve) => {
+      const finish = (): void => {
+        clearTimeout(timeout);
+        this.waiters.delete(finish);
+        resolve();
+      };
+      const timeout = setTimeout(() => {
+        this.waiters.delete(finish);
+        onTimeout();
+        resolve();
+      }, timeoutMs);
+      this.waiters.add(finish);
+    });
+  }
+}

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -13,6 +13,7 @@ import {
 } from '@/electron/handlers/handler.library.js';
 import { loadLibraryInfo } from '@/electron/handlers/helpers.app/library.js';
 import { releasePowerSaveBlock } from '@/electron/lib/power-save.js';
+import { RendererEventReadiness } from '@/electron/lib/renderer-event-readiness.js';
 import {
   createSingleInstanceData,
   type LaunchForwardPayload,
@@ -22,7 +23,7 @@ import {
   parseWrapperAfterSeparator,
 } from '@/electron/lib/single-instance-launch.js';
 import { Addon } from '@/electron/manager/manager.addon.js';
-import { waitForAddonsConfigured } from '@/electron/manager/manager.addon-readiness.js';
+import { waitForAddonManifests } from '@/electron/manager/manager.addon-readiness.js';
 import { __dirname, isDev } from '@/electron/manager/manager.paths.js';
 import { stopClient } from '@/electron/manager/manager.webtorrent.js';
 import { createElectronRouter } from '@/electron/rpc/router.js';
@@ -195,10 +196,8 @@ export function sendNotification(notification: Notification) {
   sendIPCMessage('notification', notification);
 }
 
-let isReadyForEvents = false;
-
-let readyForEventWaiters: (() => void)[] = [];
 let clientReadyListenerRegistered = false;
+const rendererEventReadiness = new RendererEventReadiness();
 
 const IPC_READY_TIMEOUT_MS = 15000;
 
@@ -208,28 +207,14 @@ export async function sendIPCMessage(channel: string, ...args: any[]) {
     return;
   }
 
-  if (!isReadyForEvents) {
-    let resolverRef: (() => void) | null = null;
-    await Promise.race([
-      new Promise<void>((resolve) => {
-        logger.sync.info('waiting for events');
-        resolverRef = resolve;
-        readyForEventWaiters.push(resolve);
-      }),
-      new Promise<void>((resolve) => {
-        setTimeout(() => {
-          if (resolverRef !== null) {
-            const idx = readyForEventWaiters.indexOf(resolverRef);
-            if (idx !== -1) readyForEventWaiters.splice(idx, 1);
-          }
-          logger.sync.warn(
-            '[sendIPCMessage] client-ready-for-events not received within timeout, proceeding'
-          );
-          resolve();
-        }, IPC_READY_TIMEOUT_MS);
-      }),
-    ]);
-    if (isReadyForEvents) logger.sync.info('events ready');
+  if (!rendererEventReadiness.isReady()) {
+    logger.sync.info('waiting for events');
+    await rendererEventReadiness.wait(IPC_READY_TIMEOUT_MS, () =>
+      logger.sync.warn(
+        '[sendIPCMessage] client-ready-for-events not received within timeout, proceeding'
+      )
+    );
+    if (rendererEventReadiness.isReady()) logger.sync.info('events ready');
   }
   mainWindow?.webContents.send(channel, ...args);
 }
@@ -288,12 +273,8 @@ function registerClientReadyListener() {
   if (clientReadyListenerRegistered) return;
   clientReadyListenerRegistered = true;
 
-  ipcMain.on('client-ready-for-events', async () => {
-    isReadyForEvents = true;
-    for (const waiter of readyForEventWaiters) {
-      waiter();
-    }
-    readyForEventWaiters = [];
+  ipcMain.on('client-ready-for-events', () => {
+    rendererEventReadiness.markReady();
   });
 }
 
@@ -336,11 +317,8 @@ async function onMainAppReady() {
     await runElectronEffect(checkForAddonUpdates(mainWindow));
   }
   await sendIPCMessage('all-addons-started');
-  const configuredAddons = await runElectronEffect(waitForAddonsConfigured());
-  for (const connection of configuredAddons) {
-    await sendIPCMessage('addon-connected', connection.addonInfo!.id);
-  }
-  await sendIPCMessage('addon-runtime-ready');
+  await runElectronEffect(waitForAddonManifests());
+  await sendIPCMessage('addon-manifests-ready');
 
   // Register process-wide listeners only once
   if (!listenersRegistered) {
@@ -432,6 +410,13 @@ function createWindow(options: { gameLaunchMode?: boolean } = {}) {
       logger.sync.warn(`Blocked navigation to: ${navigationUrl}`);
     }
   });
+
+  mainWindow.webContents.on(
+    'did-start-navigation',
+    (_event, _url, _isInPlace, isMainFrame) => {
+      if (isMainFrame) rendererEventReadiness.reset();
+    }
+  );
 
   if (!isDev() && !ogiDebug()) mainWindow.removeMenu();
 

--- a/application/src/electron/manager/manager.addon-readiness.ts
+++ b/application/src/electron/manager/manager.addon-readiness.ts
@@ -10,18 +10,18 @@ function addonFolderName(addonPath: string): string {
   return addonPath.replace(/\/$/, '').split(/[/\\]/).pop() ?? addonPath;
 }
 
-function configuredRunningConnections(): AddonConnection[] {
-  const configured: AddonConnection[] = [];
+function manifestReadyConnections(): AddonConnection[] {
+  const ready: AddonConnection[] = [];
   for (const addonPath of Addon.running.keys()) {
     const client = addonServer.getClient(addonFolderName(addonPath));
     if (client?.addonInfo && client.configTemplate !== undefined) {
-      configured.push(client);
+      ready.push(client);
     }
   }
-  return configured;
+  return ready;
 }
 
-export function waitForAddonsConfigured(
+export function waitForAddonManifests(
   options: { timeoutMs?: number; pollIntervalMs?: number } = {}
 ): Effect.Effect<AddonConnection[]> {
   return Effect.gen(function* () {
@@ -35,16 +35,16 @@ export function waitForAddonsConfigured(
     const deadline = Date.now() + timeoutMs;
 
     while (Date.now() < deadline) {
-      const ready = configuredRunningConnections();
+      const ready = manifestReadyConnections();
       if (ready.length >= expectedCount) {
         return ready;
       }
       yield* Effect.sleep(`${pollIntervalMs} millis`);
     }
 
-    const ready = configuredRunningConnections();
+    const ready = manifestReadyConnections();
     logger.sync.warn(
-      `[addon-readiness] Timed out waiting for addons to send configure (${ready.length}/${expectedCount} ready)`
+      `[addon-readiness] Timed out waiting for addon manifests (${ready.length}/${expectedCount} ready)`
     );
     return ready;
   });

--- a/application/src/electron/preload.mts
+++ b/application/src/electron/preload.mts
@@ -272,13 +272,6 @@ ipcRenderer.on(
 );
 
 ipcRenderer.on(
-  'addon-connected',
-  wrap((_, arg) => {
-    document.dispatchEvent(new CustomEvent('addon-connected', { detail: arg }));
-  })
-);
-
-ipcRenderer.on(
   'migration:event',
   wrap((_, arg) => {
     document.dispatchEvent(
@@ -314,10 +307,10 @@ ipcRenderer.on(
 );
 
 ipcRenderer.on(
-  'addon-runtime-ready',
+  'addon-manifests-ready',
   wrap(() => {
-    logger.sync.info('ADDON RUNTIME READY');
-    document.dispatchEvent(new CustomEvent('addon-runtime-ready'));
+    logger.sync.info('ADDON MANIFESTS READY');
+    document.dispatchEvent(new CustomEvent('addon-manifests-ready'));
   })
 );
 

--- a/application/src/frontend/App.svelte
+++ b/application/src/frontend/App.svelte
@@ -47,14 +47,13 @@ import {
   viewOpenedWhenChanged,
 } from '@/frontend/store.svelte';
 import {
-  addonServer,
   fetchAddonsWithConfigure,
+  getAddonServerPromise,
   getConfigClientOption,
   initDownloadPersistence,
   initSleepLock,
   isAddonEventAvailable,
   queryConnectedAddons,
-  reconnectClientSdk,
 } from '@/frontend/utils';
 import ClientOptionsView from '@/frontend/views/ClientOptionsView.svelte';
 import ConfigView from '@/frontend/views/ConfigView.svelte';
@@ -232,6 +231,7 @@ async function performSearch(query: string) {
     emptyAddons = new Set();
 
     // Search through addons and organize results by addon
+    const addonServer = await getAddonServerPromise();
     let promises: Promise<void>[] = [];
     for (const addon of searchAddons) {
       promises.push(
@@ -419,25 +419,6 @@ document.addEventListener('all-addons-started', async () => {
       type: 'success',
     });
     addonUpdates.set([]);
-    // restart the addon server
-    await runFrontendEffect(electronRpc.restartAddonServer());
-    await runFrontendEffect(
-      reconnectClientSdk().pipe(
-        Effect.catchAll((error) =>
-          Effect.sync(() => {
-            logger.sync.error(
-              'Failed to reconnect to the addon server:',
-              error
-            );
-            createNotification({
-              id: Math.random().toString(36).substring(7),
-              message: 'Failed to reconnect to the addon server',
-              type: 'error',
-            });
-          })
-        )
-      )
-    );
   }
 });
 document.addEventListener('addon:updated', (event) => {
@@ -447,14 +428,6 @@ document.addEventListener('addon:updated', (event) => {
       value = value.filter((addon) => addon !== detail);
       return value;
     });
-  }
-});
-document.addEventListener('addon-connected', (event) => {
-  if (event instanceof CustomEvent) {
-    runDetached(
-      fetchAddonsWithConfigure().pipe(Effect.asVoid),
-      'Failed to refresh addons'
-    );
   }
 });
 currentStorePageOpened.subscribe((value) => {

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -35,8 +35,8 @@ import {
   setHeaderBackButton,
 } from '@/frontend/store.svelte';
 import {
-  addonServer,
   fetchAddonsWithConfigure,
+  getAddonServerPromise,
   isAddonEventAvailable,
   runLaunchAppAddons,
   runTask,
@@ -408,6 +408,7 @@ onMount(async () => {
   );
 
   if (addonsWithStorefront.length === 0) return;
+  const addonServer = await getAddonServerPromise();
   for (const addon of addonsWithStorefront) {
     searchingAddons[addon.id] = undefined;
     (

--- a/application/src/frontend/components/StorePage.svelte
+++ b/application/src/frontend/components/StorePage.svelte
@@ -22,9 +22,9 @@ import {
   viewOpenedWhenChanged,
 } from '@/frontend/store.svelte';
 import {
-  addonServer,
   fetchAddonsWithConfigure,
   findAddonsSupportingStorefront,
+  getAddonServerPromise,
   isAddonEventAvailable,
   runTask,
   type SearchResultWithAddon,
@@ -215,6 +215,7 @@ async function loadCustomStoreData() {
   const detailAddons = await runFrontendEffect(
     findAddonsSupportingStorefront(storefront, 'game-details')
   );
+  const addonServer = await getAddonServerPromise();
   let response: StoreData | undefined;
   for (const addon of detailAddons) {
     try {

--- a/application/src/frontend/components/built/UpdateAppModal.svelte
+++ b/application/src/frontend/components/built/UpdateAppModal.svelte
@@ -12,9 +12,9 @@ import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import { createNotification } from '@/frontend/store.svelte';
 import {
-  addonServer,
   fetchAddonsWithConfigure,
   findAddonsSupportingStorefront,
+  getAddonServerPromise,
   isAddonEventAvailable,
   type SearchResultWithAddon,
   startDownloadEffect,
@@ -113,6 +113,7 @@ async function loadUpdateSources() {
   const detailAddons = await runFrontendEffect(
     findAddonsSupportingStorefront(storefront, 'game-details')
   );
+  const addonServer = await getAddonServerPromise();
   let response: StoreData | undefined;
   for (const addon of detailAddons) {
     try {

--- a/application/src/frontend/lib/config/client.ts
+++ b/application/src/frontend/lib/config/client.ts
@@ -12,9 +12,10 @@ import {
 } from 'ogi-addon/config';
 import {
   type AddonInfo,
-  addonServer,
+  getAddonServer,
   queryConnectedAddons,
 } from '@/frontend/lib/core/ipc';
+import { runFrontendSync } from '@/frontend/lib/core/runtime';
 
 const logger = createLogger(LOGGER_PREFIXES.frontend);
 
@@ -99,7 +100,7 @@ function waitForConfiguredAddons(maxWaitMs = 15_000, pollMs = 100) {
   });
 }
 
-export function fetchAddonsWithConfigure() {
+function configureConnectedAddons() {
   return Effect.gen(function* () {
     const addons = yield* waitForConfiguredAddons();
     const results = yield* Effect.forEach(
@@ -143,6 +144,7 @@ export function fetchAddonsWithConfigure() {
             );
           }
 
+          const addonServer = yield* getAddonServer();
           yield* Effect.tryPromise({
             try: () =>
               addonServer
@@ -162,6 +164,30 @@ export function fetchAddonsWithConfigure() {
         logger.sync.error('Failed to configure addon:', result.left);
       }
     }
-    return addons;
+    return yield* queryConnectedAddons<ConfigTemplateAndInfo>();
+  });
+}
+
+let configurationInFlight: ReturnType<typeof configureConnectedAddons> | null =
+  null;
+
+// Configuration is the addon runtime handshake: its first config-update emits connect.
+export function fetchAddonsWithConfigure() {
+  return Effect.suspend(() => {
+    if (configurationInFlight) return configurationInFlight;
+
+    const sharedConfiguration = runFrontendSync(
+      Effect.cached(configureConnectedAddons())
+    ).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (configurationInFlight === sharedConfiguration) {
+            configurationInFlight = null;
+          }
+        })
+      )
+    );
+    configurationInFlight = sharedConfiguration;
+    return sharedConfiguration;
   });
 }

--- a/application/src/frontend/lib/core/addons.ts
+++ b/application/src/frontend/lib/core/addons.ts
@@ -1,20 +1,15 @@
 import type { LibraryInfo, OGIAddonSDKEventListener } from '@ogi-sdk/connect';
 import { AddonError, formatError } from '@ogi-sdk/errors';
 import { Effect } from 'effect';
+import { fetchAddonsWithConfigure } from '@/frontend/lib/config/client';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import { supportsStorefront } from '@/lib/storefronts';
-import {
-  type AddonInfo,
-  addonServer,
-  queryConnectedAddons,
-  reconnectClientSdk,
-} from './ipc';
+import { type AddonInfo, getAddonServer, queryConnectedAddons } from './ipc';
 
-export function installAddonsAndReconnect<T = AddonInfo>(addons: string[]) {
+export function installAddonsAndReconnect(addons: string[]) {
   return Effect.gen(function* () {
     yield* electronRpc.installAddons(addons);
-    yield* reconnectClientSdk();
-    return yield* queryConnectedAddons<T>();
+    return yield* fetchAddonsWithConfigure();
   });
 }
 
@@ -43,9 +38,11 @@ function runLaunchAppAddonsOnce(
   launchType: 'pre' | 'post'
 ) {
   return Effect.gen(function* () {
-    const addons = (yield* queryConnectedAddons()).filter((addon) =>
+    yield* electronRpc.ensureAddonsSpawned();
+    const addons = (yield* fetchAddonsWithConfigure()).filter((addon) =>
       isAddonEventAvailable(addon, 'launch-app')
     );
+    const addonServer = yield* getAddonServer();
     const results = yield* Effect.forEach(
       addons,
       (addon) =>
@@ -75,7 +72,6 @@ export function runLaunchAppAddons(
     Effect.catchTag('AddonError', () =>
       Effect.gen(function* () {
         yield* electronRpc.restartAddonServer();
-        yield* reconnectClientSdk();
         return yield* runLaunchAppAddonsOnce(libraryInfo, launchType);
       }).pipe(
         Effect.mapError(

--- a/application/src/frontend/lib/core/addons.ts
+++ b/application/src/frontend/lib/core/addons.ts
@@ -38,7 +38,7 @@ export function getAddonIfEventAvailable(
   );
 }
 
-export function runLaunchAppAddons(
+function runLaunchAppAddonsOnce(
   libraryInfo: LibraryInfo,
   launchType: 'pre' | 'post'
 ) {
@@ -65,6 +65,28 @@ export function runLaunchAppAddons(
       ? ({ success: false, error: failure.left } as const)
       : ({ success: true } as const);
   });
+}
+
+export function runLaunchAppAddons(
+  libraryInfo: LibraryInfo,
+  launchType: 'pre' | 'post'
+) {
+  return runLaunchAppAddonsOnce(libraryInfo, launchType).pipe(
+    Effect.catchTag('AddonError', () =>
+      Effect.gen(function* () {
+        yield* electronRpc.restartAddonServer();
+        yield* reconnectClientSdk();
+        return yield* runLaunchAppAddonsOnce(libraryInfo, launchType);
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new AddonError({
+              message: `Failed to recover the addon runtime: ${formatError(cause)}`,
+            })
+        )
+      )
+    )
+  );
 }
 
 export function findAddonsSupportingStorefront(

--- a/application/src/frontend/lib/core/ipc.ts
+++ b/application/src/frontend/lib/core/ipc.ts
@@ -63,34 +63,62 @@ export function connectClientSdk() {
   }).pipe(Effect.tap(initialize));
 }
 
-// The addon server may still be starting when the renderer loads.
-export let addonServer = await runFrontendEffect(
-  connectClientSdk().pipe(
-    Effect.tapError((error) => logger.warn('Waiting for addon server:', error)),
-    Effect.retry(Schedule.spaced('1 second'))
-  )
-);
+let addonServer: Connection | null = null;
+let connectionInFlight: Effect.Effect<Connection, NetworkError> | null = null;
 
-// Share reconnects so stale-socket recovery and explicit restarts never race.
+export function getAddonServer(): Effect.Effect<Connection, NetworkError> {
+  return Effect.suspend(() => {
+    if (addonServer) return Effect.succeed(addonServer);
+    if (connectionInFlight) return connectionInFlight;
+
+    const connect = connectClientSdk().pipe(
+      Effect.tapError((error) =>
+        logger.warn('Waiting for addon server:', error)
+      ),
+      Effect.retry(Schedule.spaced('1 second')),
+      Effect.tap((connection) =>
+        Effect.sync(() => {
+          addonServer = connection;
+        })
+      )
+    );
+    const sharedConnection = runFrontendSync(Effect.cached(connect)).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (connectionInFlight === sharedConnection)
+            connectionInFlight = null;
+        })
+      )
+    );
+    connectionInFlight = sharedConnection;
+    return sharedConnection;
+  });
+}
+
+export function getAddonServerPromise(): Promise<Connection> {
+  return runFrontendEffect(getAddonServer());
+}
+
+// Share reconnects so concurrent stale-socket recoveries never race.
 let reconnectInFlight: Effect.Effect<void, NetworkError> | null = null;
 
 function requestConnectedAddons<T>() {
-  return Effect.tryPromise({
-    try: () =>
-      addonServer.request('query-connected-addons', {
-        type: 'addons',
-      }),
-    catch: (cause) =>
-      new NetworkError({
-        message: cause instanceof Error ? cause.message : String(cause),
-      }),
-  }).pipe(
-    Effect.flatMap((response) =>
-      response.statusError
-        ? Effect.fail(new AddonError({ message: response.statusError }))
-        : Effect.succeed(response.args.addons as T[])
-    )
-  );
+  return Effect.gen(function* () {
+    const connection = yield* getAddonServer();
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        connection.request('query-connected-addons', {
+          type: 'addons',
+        }),
+      catch: (cause) =>
+        new NetworkError({
+          message: cause instanceof Error ? cause.message : String(cause),
+        }),
+    });
+    return response.statusError
+      ? yield* Effect.fail(new AddonError({ message: response.statusError }))
+      : (response.args.addons as T[]);
+  });
 }
 
 export function queryConnectedAddons<T = AddonInfo>() {
@@ -116,13 +144,17 @@ export function reconnectClientSdk(): Effect.Effect<void, NetworkError> {
     if (reconnectInFlight) return reconnectInFlight;
 
     const reconnect = Effect.gen(function* () {
-      yield* Effect.tryPromise({
-        try: () => addonServer.close(),
-        catch: (cause) =>
-          new NetworkError({
-            message: `Failed to close the addon server connection: ${cause instanceof Error ? cause.message : String(cause)}`,
-          }),
-      });
+      const staleConnection = addonServer;
+      addonServer = null;
+      if (staleConnection) {
+        yield* Effect.tryPromise({
+          try: () => staleConnection.close(),
+          catch: (cause) =>
+            new NetworkError({
+              message: `Failed to close the addon server connection: ${cause instanceof Error ? cause.message : String(cause)}`,
+            }),
+        });
+      }
       // A stale query can detect the backend between its stop and start phases.
       addonServer = yield* connectClientSdk().pipe(
         Effect.retry(

--- a/application/src/frontend/lib/core/ipc.ts
+++ b/application/src/frontend/lib/core/ipc.ts
@@ -71,36 +71,42 @@ export let addonServer = await runFrontendEffect(
   )
 );
 
-// Keep requests off the closed client while a shared reconnect swaps it out.
+// Share reconnects so stale-socket recovery and explicit restarts never race.
 let reconnectInFlight: Effect.Effect<void, NetworkError> | null = null;
 
-export function queryConnectedAddons<T = AddonInfo>() {
-  return Effect.suspend(() =>
-    (reconnectInFlight ?? Effect.void).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AddonError({
-            message: `Failed to query connected addons: ${cause.message}`,
-          })
-      ),
-      Effect.zipRight(
-        Effect.tryPromise({
-          try: () =>
-            addonServer.request('query-connected-addons', {
-              type: 'addons',
-            }),
-          catch: (cause) =>
-            new AddonError({
-              message: `Failed to query connected addons: ${cause instanceof Error ? cause.message : String(cause)}`,
-            }),
-        })
-      )
-    )
-  ).pipe(
+function requestConnectedAddons<T>() {
+  return Effect.tryPromise({
+    try: () =>
+      addonServer.request('query-connected-addons', {
+        type: 'addons',
+      }),
+    catch: (cause) =>
+      new NetworkError({
+        message: cause instanceof Error ? cause.message : String(cause),
+      }),
+  }).pipe(
     Effect.flatMap((response) =>
       response.statusError
         ? Effect.fail(new AddonError({ message: response.statusError }))
         : Effect.succeed(response.args.addons as T[])
+    )
+  );
+}
+
+export function queryConnectedAddons<T = AddonInfo>() {
+  return Effect.suspend(() =>
+    (reconnectInFlight ?? Effect.void).pipe(
+      Effect.zipRight(requestConnectedAddons<T>()),
+      Effect.catchTag('NetworkError', () =>
+        reconnectClientSdk().pipe(Effect.zipRight(requestConnectedAddons<T>()))
+      ),
+      Effect.mapError((cause) =>
+        cause._tag === 'AddonError'
+          ? cause
+          : new AddonError({
+              message: `Failed to query connected addons: ${cause.message}`,
+            })
+      )
     )
   );
 }
@@ -117,7 +123,12 @@ export function reconnectClientSdk(): Effect.Effect<void, NetworkError> {
             message: `Failed to close the addon server connection: ${cause instanceof Error ? cause.message : String(cause)}`,
           }),
       });
-      addonServer = yield* connectClientSdk();
+      // A stale query can detect the backend between its stop and start phases.
+      addonServer = yield* connectClientSdk().pipe(
+        Effect.retry(
+          Schedule.intersect(Schedule.spaced('250 millis'), Schedule.recurs(4))
+        )
+      );
     });
     const sharedReconnect = runFrontendSync(Effect.cached(reconnect)).pipe(
       Effect.ensuring(

--- a/application/src/frontend/lib/downloads/services/RequestService.ts
+++ b/application/src/frontend/lib/downloads/services/RequestService.ts
@@ -3,7 +3,7 @@ import { DownloadError } from '@ogi-sdk/errors';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect } from 'effect';
 import { getDownloadPath } from '@/frontend/lib/core/fs';
-import { addonServer } from '@/frontend/lib/core/ipc';
+import { getAddonServer } from '@/frontend/lib/core/ipc';
 import { startDownloadEffect } from '@/frontend/lib/downloads/lifecycle';
 import { safeDownloadPath } from '@/frontend/lib/downloads/paths';
 import { BaseService } from '@/frontend/lib/downloads/services/BaseService';
@@ -51,6 +51,7 @@ export class RequestService extends BaseService {
             cause,
           }),
       });
+      const addonServer = yield* getAddonServer();
       const response = yield* Effect.tryPromise({
         try: () =>
           addonServer

--- a/application/src/frontend/lib/setup/setup.ts
+++ b/application/src/frontend/lib/setup/setup.ts
@@ -12,7 +12,7 @@ import {
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect } from 'effect';
 import { get } from 'svelte/store';
-import { addonServer } from '@/frontend/lib/core/ipc';
+import { getAddonServer } from '@/frontend/lib/core/ipc';
 import { getApp } from '@/frontend/lib/core/library';
 import { updateDownloadStatus } from '@/frontend/lib/downloads/lifecycle';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
@@ -163,16 +163,19 @@ function runAddonSetup(
   callbacks: ReturnType<typeof createSetupCallbacks>
 ) {
   const { addonID, ...setupArgs } = setupPayload;
-  return Effect.tryPromise({
-    try: () =>
-      addonServer
-        .addon(addonID, callbacks)
-        .setup(setupArgs) as Promise<SetupEventResponse>,
-    catch: (cause) =>
-      new AddonError({
-        message: formatError(cause),
-        addonName: addonID,
-      }),
+  return Effect.gen(function* () {
+    const addonServer = yield* getAddonServer();
+    return yield* Effect.tryPromise({
+      try: () =>
+        addonServer
+          .addon(addonID, callbacks)
+          .setup(setupArgs) as Promise<SetupEventResponse>,
+      catch: (cause) =>
+        new AddonError({
+          message: formatError(cause),
+          addonName: addonID,
+        }),
+    });
   });
 }
 

--- a/application/src/frontend/lib/tasks/deferred.ts
+++ b/application/src/frontend/lib/tasks/deferred.ts
@@ -2,7 +2,7 @@ import type { DeferredTaskSnapshot } from '@ogi-sdk/client-kit';
 import { AddonError, formatError } from '@ogi-sdk/errors';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect } from 'effect';
-import { addonServer } from '@/frontend/lib/core/ipc';
+import { getAddonServer } from '@/frontend/lib/core/ipc';
 import {
   type DeferredTask,
   deferredTasks,
@@ -12,13 +12,16 @@ import {
 const logger = createLogger(LOGGER_PREFIXES.frontend);
 
 export function loadDeferredTasks(tasksToRemove: string[] = []) {
-  return Effect.tryPromise({
-    try: () => addonServer.getDeferredTasks(),
-    catch: (cause) =>
-      new AddonError({
-        message: `Failed to load deferred tasks: ${formatError(cause)}`,
-      }),
-  }).pipe(
+  return getAddonServer().pipe(
+    Effect.flatMap((addonServer) =>
+      Effect.tryPromise({
+        try: () => addonServer.getDeferredTasks(),
+        catch: (cause) =>
+          new AddonError({
+            message: `Failed to load deferred tasks: ${formatError(cause)}`,
+          }),
+      })
+    ),
     Effect.tap((tasks) =>
       Effect.sync(() => {
         deferredTasks.set(

--- a/application/src/frontend/lib/tasks/runner.ts
+++ b/application/src/frontend/lib/tasks/runner.ts
@@ -2,7 +2,7 @@ import type { LibraryInfo, SearchResult } from '@ogi-sdk/connect';
 import { AddonError, formatError } from '@ogi-sdk/errors';
 import { Effect, Exit } from 'effect';
 import { get } from 'svelte/store';
-import { addonServer } from '@/frontend/lib/core/ipc';
+import { getAddonServer } from '@/frontend/lib/core/ipc';
 import { createNotification, deferredTasks } from '@/frontend/store.svelte';
 
 export type SearchResultWithAddon = SearchResult & {
@@ -42,6 +42,7 @@ export function runTask(
       ...(libraryInfo ? { libraryInfo: structuredClone(libraryInfo) } : {}),
     };
 
+    const addonServer = yield* getAddonServer();
     const response = yield* Effect.tryPromise({
       try: () =>
         addonServer

--- a/application/src/frontend/managers/AppUpdateManager.svelte
+++ b/application/src/frontend/managers/AppUpdateManager.svelte
@@ -6,11 +6,10 @@ import core from '@/frontend/lib/core';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { updatesManager } from '@/frontend/states.svelte';
 import {
-  addonServer,
   fetchAddonsWithConfigure,
+  getAddonServer,
   isAddonEventAvailable,
   queryConnectedAddons,
-  reconnectClientSdk,
 } from '@/frontend/utils';
 import { supportsStorefront } from '@/lib/storefronts';
 
@@ -18,14 +17,13 @@ const logger = createLogger(LOGGER_PREFIXES.frontend);
 
 let updateCheckRunId = 0;
 
-document.addEventListener('addon-runtime-ready', () => {
-  void onAddonRuntimeReady();
+document.addEventListener('addon-manifests-ready', () => {
+  void onAddonManifestsReady();
 });
 
-async function onAddonRuntimeReady() {
+async function onAddonManifestsReady() {
   await runFrontendEffect(
     Effect.gen(function* () {
-      yield* reconnectClientSdk();
       yield* fetchAddonsWithConfigure();
       yield* checkForAppUpdates();
     }).pipe(
@@ -53,6 +51,7 @@ function checkForAppUpdates() {
         }),
     });
     const connectedAddons = yield* queryConnectedAddons();
+    const addonServer = yield* getAddonServer();
     yield* Effect.forEach(
       library,
       (app) =>

--- a/application/src/frontend/views/ClientOptionsView.svelte
+++ b/application/src/frontend/views/ClientOptionsView.svelte
@@ -16,7 +16,6 @@ import ThemePicker from '@/frontend/components/ThemePicker.svelte';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import { createNotification } from '@/frontend/store.svelte';
-import { fetchAddonsWithConfigure, reconnectClientSdk } from '@/frontend/utils';
 
 const logger = createLogger(LOGGER_PREFIXES.frontend);
 
@@ -542,10 +541,7 @@ async function updateAddons() {
 async function restartAddonServer() {
   isRestartingServer = true;
   await runFrontendEffect(
-    Effect.gen(function* () {
-      yield* electronRpc.restartAddonServer();
-      yield* reconnectClientSdk();
-    }).pipe(
+    electronRpc.restartAddonServer().pipe(
       Effect.catchAll((error) =>
         logger.error('Failed to restart addon server:', error)
       ),
@@ -704,26 +700,10 @@ onMount(() => {
     doSteamGridDBReconfigure = true;
     reasonForSteamGridLaunch = (event as CustomEvent).detail || '';
   }
-  async function handleAddonConnected() {
-    await runFrontendEffect(
-      fetchAddonsWithConfigure().pipe(
-        Effect.catchAll((error) =>
-          logger.error('Failed to configure addons after reconnect:', error)
-        ),
-        Effect.ensuring(
-          Effect.sync(() => {
-            isRestartingServer = false;
-          })
-        )
-      )
-    );
-  }
   document.addEventListener('steamgriddb-launch', steamgriddbLaunch);
-  document.addEventListener('addon-connected', handleAddonConnected);
 
   return () => {
     document.removeEventListener('steamgriddb-launch', steamgriddbLaunch);
-    document.removeEventListener('addon-connected', handleAddonConnected);
   };
 });
 </script>

--- a/application/src/frontend/views/CommunityAddonsList.svelte
+++ b/application/src/frontend/views/CommunityAddonsList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
-import { Effect } from 'effect';
 import { fade } from 'svelte/transition';
 import { parseAddonLink } from '@/electron/lib/addon-links';
 import DeleteAddonWarningModal from '@/frontend/components/built/DeleteAddonWarningModal.svelte';
@@ -10,7 +9,6 @@ import HeaderModal from '@/frontend/components/modal/HeaderModal.svelte';
 import Modal from '@/frontend/components/modal/Modal.svelte';
 import TextModal from '@/frontend/components/modal/TextModal.svelte';
 import TitleModal from '@/frontend/components/modal/TitleModal.svelte';
-import { reconnectClientSdk } from '@/frontend/lib/core/ipc';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import {
@@ -45,23 +43,6 @@ async function installAddon(marketplaceURL: string, addon: CommunityAddon) {
       electronRpc.installAddons([addonWithMarketplace])
     ),
   };
-  await runFrontendEffect(
-    reconnectClientSdk().pipe(
-      Effect.catchAll((error) =>
-        Effect.sync(() => {
-          logger.sync.error(
-            'Failed to reconnect after installing addon:',
-            error
-          );
-          createNotification({
-            id: Math.random().toString(36).substring(7),
-            message: `Failed to finish installing ${addon.name}`,
-            type: 'error',
-          });
-        })
-      )
-    )
-  );
 }
 
 function addonConfigMatchesSource(configAddon: string, addonSource: string) {
@@ -103,25 +84,7 @@ async function deleteAddon(addon: CommunityAddon) {
   currentAddons = JSON.parse(
     window.electronAPI.fs.read('./config/option/general.json')
   );
-  await runFrontendEffect(
-    reconnectClientSdk().pipe(
-      Effect.catchAll((error) =>
-        Effect.sync(() => {
-          logger.sync.error('Failed to reconnect after deleting addon:', error);
-          createNotification({
-            id: Math.random().toString(36).substring(7),
-            message: `Deleted ${addon.name}, but failed to reconnect`,
-            type: 'error',
-          });
-        })
-      ),
-      Effect.ensuring(
-        Effect.sync(() => {
-          deleteConfirmationModalAddon = null;
-        })
-      )
-    )
-  );
+  deleteConfirmationModalAddon = null;
 }
 
 async function deleteAddonWarning(addon: CommunityAddon) {

--- a/application/src/frontend/views/ConfigView.svelte
+++ b/application/src/frontend/views/ConfigView.svelte
@@ -29,7 +29,7 @@ import {
   marketplaceSources,
   saveMarketplaceSources,
 } from '@/frontend/store.svelte';
-import { queryConnectedAddons, reconnectClientSdk } from '@/frontend/utils';
+import { queryConnectedAddons } from '@/frontend/utils';
 import CommunityAddonsList from '@/frontend/views/CommunityAddonsList.svelte';
 import FocusedAddonView from '@/frontend/views/FocusedAddonView.svelte';
 
@@ -92,8 +92,6 @@ async function updateAddons() {
     Effect.gen(function* () {
       yield* electronRpc.updateAddons();
       addonUpdates.set([]);
-      yield* electronRpc.restartAddonServer();
-      yield* reconnectClientSdk();
       createNotification({
         id: Math.random().toString(36).substring(7),
         message: 'Addons updated successfully',
@@ -132,7 +130,6 @@ async function addAddon() {
     Effect.gen(function* () {
       yield* electronRpc.installAddons([addonUrl]);
       addonUrl = '';
-      yield* reconnectClientSdk();
     }).pipe(
       Effect.catchAll((error) =>
         Effect.sync(() => {

--- a/application/src/frontend/views/DiscoverView.svelte
+++ b/application/src/frontend/views/DiscoverView.svelte
@@ -6,6 +6,7 @@ import type {
   CatalogSection,
   ConfigurationFile,
   OGIAddonConfiguration,
+  OGIAddonSDKEventListener,
 } from '@ogi-sdk/connect';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { onMount } from 'svelte';
@@ -18,12 +19,13 @@ import {
   selectedView,
   viewOpenedWhenChanged,
 } from '@/frontend/store.svelte';
-import { addonServer, queryConnectedAddons } from '@/frontend/utils';
+import { getAddonServerPromise, queryConnectedAddons } from '@/frontend/utils';
 
 const logger = createLogger(LOGGER_PREFIXES.frontend);
 
 interface ConfigTemplateAndInfo extends OGIAddonConfiguration {
   configTemplate: ConfigurationFile;
+  eventsAvailable: OGIAddonSDKEventListener[];
 }
 
 interface AddonCatalog {
@@ -224,10 +226,11 @@ async function loadCatalogs() {
     addons = await runFrontendEffect(
       queryConnectedAddons<ConfigTemplateAndInfo>()
     );
+    const addonServer = await getAddonServerPromise();
 
     const catalogPromises = addons.map(async (addonInfo) => {
       const addon = addonServer.addon(addonInfo.id);
-      if (!addon.eventsAvailable.includes('catalog')) {
+      if (!addonInfo.eventsAvailable.includes('catalog')) {
         return null;
       }
       try {

--- a/application/src/frontend/views/FocusedAddonView.svelte
+++ b/application/src/frontend/views/FocusedAddonView.svelte
@@ -23,7 +23,7 @@ import TitleModal from '@/frontend/components/modal/TitleModal.svelte';
 import RangeInput from '@/frontend/components/RangeInput.svelte';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
-import { notifications } from '@/frontend/store.svelte';
+import { createNotification, notifications } from '@/frontend/store.svelte';
 import {
   getAddonServerPromise,
   queryConnectedAddons,
@@ -119,7 +119,18 @@ async function updateConfig() {
   });
 
   const addonId = selectedAddon.id;
-  const addonServer = await getAddonServerPromise();
+  const addonServer = await getAddonServerPromise().catch((err) => {
+    logger.sync.error('Failed to get addon server', err);
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message: 'Failed to get addon server',
+      type: 'error',
+    });
+    return null;
+  });
+  if (!addonServer) {
+    return;
+  }
   addonServer
     .addon(addonId)
     // The wire type models config templates, but this endpoint receives values.

--- a/application/src/frontend/views/FocusedAddonView.svelte
+++ b/application/src/frontend/views/FocusedAddonView.svelte
@@ -24,7 +24,11 @@ import RangeInput from '@/frontend/components/RangeInput.svelte';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import { notifications } from '@/frontend/store.svelte';
-import { addonServer, queryConnectedAddons, runTask } from '@/frontend/utils';
+import {
+  getAddonServerPromise,
+  queryConnectedAddons,
+  runTask,
+} from '@/frontend/utils';
 
 const logger = createLogger(LOGGER_PREFIXES.frontend);
 
@@ -81,7 +85,7 @@ onMount(() => {
     });
 });
 
-function updateConfig() {
+async function updateConfig() {
   if (!selectedAddon) return;
   let config: Record<string, string | number | boolean> = {};
   Object.keys(selectedAddon.configTemplate).forEach((key) => {
@@ -115,6 +119,7 @@ function updateConfig() {
   });
 
   const addonId = selectedAddon.id;
+  const addonServer = await getAddonServerPromise();
   addonServer
     .addon(addonId)
     // The wire type models config templates, but this endpoint receives values.

--- a/application/src/lib/electron-rpc.ts
+++ b/application/src/lib/electron-rpc.ts
@@ -469,6 +469,7 @@ export const ElectronRpc = {
     setActive: rpc('powerSave.setActive', [Schema.Boolean], Void),
   },
   installAddons: rpc('installAddons', [StringArray], StringArray),
+  ensureAddonsSpawned: rpc('ensureAddonsSpawned', [], Void),
   restartAddonServer: rpc('restartAddonServer', [], Void),
   deleteInstalledAddon: rpc(
     'deleteInstalledAddon',

--- a/application/tests/addon-client-reconnect.test.ts
+++ b/application/tests/addon-client-reconnect.test.ts
@@ -1,4 +1,5 @@
-import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { LibraryInfo, OGIAddonSDKEventListener } from '@ogi-sdk/connect';
 import { Effect } from 'effect';
 
 mock.module('@/frontend/lib/config/client', () => ({
@@ -6,6 +7,8 @@ mock.module('@/frontend/lib/config/client', () => ({
 }));
 
 let installedAddonUrls: string[] = [];
+let restartAddonServerCalls = 0;
+let onRestartAddonServer = () => {};
 
 mock.module('@/frontend/lib/electron-rpc', () => ({
   electronRpc: {
@@ -14,19 +17,34 @@ mock.module('@/frontend/lib/electron-rpc', () => ({
         installedAddonUrls = addons;
         return addons;
       }),
+    restartAddonServer: () =>
+      Effect.sync(() => {
+        restartAddonServerCalls++;
+        onRestartAddonServer();
+      }),
   },
 }));
 
 type MockResponse = {
   statusError?: string;
-  args: { addons: { id: string }[] };
+  args: { addons: MockAddon[] };
+};
+
+type MockAddon = {
+  id: string;
+  name?: string;
+  eventsAvailable?: OGIAddonSDKEventListener[];
 };
 
 class MockConnection {
   private open = true;
+  public readonly launchCalls: Array<{
+    addonId: string;
+    launchType: 'pre' | 'post';
+  }> = [];
 
   public constructor(
-    private readonly addons: { id: string }[],
+    private readonly addons: MockAddon[],
     private readonly onClose?: () => Promise<void>
   ) {}
 
@@ -41,6 +59,22 @@ class MockConnection {
     return { args: { addons: this.addons } };
   }
 
+  public addon(addonId: string) {
+    return {
+      launchApp: async ({
+        launchType,
+      }: {
+        libraryInfo: LibraryInfo;
+        launchType: 'pre' | 'post';
+      }) => {
+        if (!this.open) {
+          throw new Error('Websocket is not open (readyState: 3)');
+        }
+        this.launchCalls.push({ addonId, launchType });
+      },
+    };
+  }
+
   public async close(): Promise<void> {
     this.open = false;
     await this.onClose?.();
@@ -49,16 +83,26 @@ class MockConnection {
 
 let closeStarted: Promise<void>;
 let releaseClose: () => void;
-let connections: MockConnection[];
+let connections: Array<MockConnection | Error>;
+let connectFailuresRemaining = 0;
 
 mock.module('@ogi-sdk/client-kit', () => ({
   Connection: {
-    make: () => Promise.resolve(connections.shift()!),
+    make: () => {
+      if (connectFailuresRemaining > 0) {
+        connectFailuresRemaining--;
+        return Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1:7654'));
+      }
+      const connection = connections.shift();
+      return connection instanceof Error
+        ? Promise.reject(connection)
+        : Promise.resolve(connection!);
+    },
   },
 }));
 
 let ipc: typeof import('../src/frontend/lib/core/ipc.js');
-let installAddonsAndReconnect: typeof import('../src/frontend/lib/core/addons.js').installAddonsAndReconnect;
+let addons: typeof import('../src/frontend/lib/core/addons.js');
 
 beforeAll(async () => {
   let markCloseStarted: () => void;
@@ -76,9 +120,13 @@ beforeAll(async () => {
     new MockConnection([{ id: 'new' }]),
   ];
   ipc = await import('../src/frontend/lib/core/ipc.js');
-  ({ installAddonsAndReconnect } = await import(
-    '../src/frontend/lib/core/addons.js'
-  ));
+  addons = await import('../src/frontend/lib/core/addons.js');
+});
+
+beforeEach(() => {
+  restartAddonServerCalls = 0;
+  onRestartAddonServer = () => {};
+  connectFailuresRemaining = 0;
 });
 
 describe('addon client reconnect', () => {
@@ -97,10 +145,60 @@ describe('addon client reconnect', () => {
     connections = [new MockConnection([{ id: 'installed' }])];
 
     const connectedAddons = await Effect.runPromise(
-      installAddonsAndReconnect(['https://example.com/installed'])
+      addons.installAddonsAndReconnect(['https://example.com/installed'])
     );
 
     expect(installedAddonUrls).toEqual(['https://example.com/installed']);
     expect(connectedAddons).toEqual([{ id: 'installed' }]);
+  });
+
+  test('play hooks recover from a stale addon connection', async () => {
+    const reconnected = new MockConnection([
+      {
+        id: 'launch-addon',
+        name: 'Launch Addon',
+        eventsAvailable: ['launch-app'],
+      },
+    ]);
+    connections = [
+      new Error('connect ECONNREFUSED 127.0.0.1:7654'),
+      reconnected,
+    ];
+    await ipc.addonServer.close();
+
+    const result = await Effect.runPromise(
+      addons.runLaunchAppAddons({ appID: 1 } as LibraryInfo, 'pre')
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(reconnected.launchCalls).toEqual([
+      { addonId: 'launch-addon', launchType: 'pre' },
+    ]);
+  });
+
+  test('play hooks restart an unhealthy addon runtime', async () => {
+    const restarted = new MockConnection([
+      {
+        id: 'launch-addon',
+        name: 'Launch Addon',
+        eventsAvailable: ['launch-app'],
+      },
+    ]);
+    connections = [restarted];
+    connectFailuresRemaining = Number.POSITIVE_INFINITY;
+    onRestartAddonServer = () => {
+      connectFailuresRemaining = 0;
+    };
+    await ipc.addonServer.close();
+
+    const result = await Effect.runPromise(
+      addons.runLaunchAppAddons({ appID: 1 } as LibraryInfo, 'pre')
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(restartAddonServerCalls).toBe(1);
+    expect(restarted.launchCalls).toEqual([
+      { addonId: 'launch-addon', launchType: 'pre' },
+    ]);
   });
 });

--- a/application/tests/addon-client-reconnect.test.ts
+++ b/application/tests/addon-client-reconnect.test.ts
@@ -4,23 +4,45 @@ import { Effect } from 'effect';
 
 mock.module('@/frontend/lib/config/client', () => ({
   getConfigClientOption: () => null,
+  fetchAddonsWithConfigure: () =>
+    Effect.gen(function* () {
+      const connectedAddons = yield* ipc.queryConnectedAddons<MockAddon>();
+      const server = yield* ipc.getAddonServer();
+      yield* Effect.forEach(
+        connectedAddons,
+        (addon) =>
+          Effect.promise(() => server.addon(addon.id).configUpdate({})),
+        { concurrency: 'unbounded', discard: true }
+      );
+      return connectedAddons;
+    }),
 }));
 
 let installedAddonUrls: string[] = [];
 let restartAddonServerCalls = 0;
 let onRestartAddonServer = () => {};
+let ensureAddonsSpawnedCalls = 0;
+let onEnsureAddonsSpawned = () => {};
+let onInstallAddons = async () => {};
+let connectionMakeCalls = 0;
 
 mock.module('@/frontend/lib/electron-rpc', () => ({
   electronRpc: {
     installAddons: (addons: string[]) =>
-      Effect.sync(() => {
+      Effect.promise(async () => {
         installedAddonUrls = addons;
+        await onInstallAddons();
         return addons;
       }),
     restartAddonServer: () =>
       Effect.sync(() => {
         restartAddonServerCalls++;
         onRestartAddonServer();
+      }),
+    ensureAddonsSpawned: () =>
+      Effect.sync(() => {
+        ensureAddonsSpawnedCalls++;
+        onEnsureAddonsSpawned();
       }),
   },
 }));
@@ -38,6 +60,7 @@ type MockAddon = {
 
 class MockConnection {
   private open = true;
+  public readonly configUpdateCalls: string[] = [];
   public readonly launchCalls: Array<{
     addonId: string;
     launchType: 'pre' | 'post';
@@ -45,7 +68,8 @@ class MockConnection {
 
   public constructor(
     private readonly addons: MockAddon[],
-    private readonly onClose?: () => Promise<void>
+    private readonly onClose?: () => Promise<void>,
+    private configured = true
   ) {}
 
   public on(): Promise<void> {
@@ -59,8 +83,20 @@ class MockConnection {
     return { args: { addons: this.addons } };
   }
 
+  public replaceAddons(addons: MockAddon[], configured: boolean): void {
+    this.addons.splice(0, this.addons.length, ...addons);
+    this.configured = configured;
+  }
+
   public addon(addonId: string) {
     return {
+      configUpdate: async () => {
+        if (!this.open) {
+          throw new Error('Websocket is not open (readyState: 3)');
+        }
+        this.configUpdateCalls.push(addonId);
+        this.configured = true;
+      },
       launchApp: async ({
         launchType,
       }: {
@@ -69,6 +105,9 @@ class MockConnection {
       }) => {
         if (!this.open) {
           throw new Error('Websocket is not open (readyState: 3)');
+        }
+        if (!this.configured) {
+          throw new Error('Addon has not received config-update');
         }
         this.launchCalls.push({ addonId, launchType });
       },
@@ -89,6 +128,7 @@ let connectFailuresRemaining = 0;
 mock.module('@ogi-sdk/client-kit', () => ({
   Connection: {
     make: () => {
+      connectionMakeCalls++;
       if (connectFailuresRemaining > 0) {
         connectFailuresRemaining--;
         return Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1:7654'));
@@ -121,12 +161,17 @@ beforeAll(async () => {
   ];
   ipc = await import('../src/frontend/lib/core/ipc.js');
   addons = await import('../src/frontend/lib/core/addons.js');
+  await Effect.runPromise(ipc.getAddonServer());
 });
 
 beforeEach(() => {
   restartAddonServerCalls = 0;
   onRestartAddonServer = () => {};
+  ensureAddonsSpawnedCalls = 0;
+  onEnsureAddonsSpawned = () => {};
+  onInstallAddons = async () => {};
   connectFailuresRemaining = 0;
+  connectionMakeCalls = 0;
 });
 
 describe('addon client reconnect', () => {
@@ -142,7 +187,14 @@ describe('addon client reconnect', () => {
   });
 
   test('install completion returns addons from the restarted server', async () => {
-    connections = [new MockConnection([{ id: 'installed' }])];
+    const installed = new MockConnection(
+      [{ id: 'installed' }],
+      undefined,
+      false
+    );
+    connections = [installed];
+    onInstallAddons = async () =>
+      (await Effect.runPromise(ipc.getAddonServer())).close();
 
     const connectedAddons = await Effect.runPromise(
       addons.installAddonsAndReconnect(['https://example.com/installed'])
@@ -150,6 +202,23 @@ describe('addon client reconnect', () => {
 
     expect(installedAddonUrls).toEqual(['https://example.com/installed']);
     expect(connectedAddons).toEqual([{ id: 'installed' }]);
+    expect(installed.configUpdateCalls).toEqual(['installed']);
+    expect(connectionMakeCalls).toBe(1);
+  });
+
+  test('concurrent stale queries share one reconnect', async () => {
+    connections = [new MockConnection([{ id: 'shared' }])];
+    await (await Effect.runPromise(ipc.getAddonServer())).close();
+    connectionMakeCalls = 0;
+
+    const [first, second] = await Promise.all([
+      Effect.runPromise(ipc.queryConnectedAddons<{ id: string }>()),
+      Effect.runPromise(ipc.queryConnectedAddons<{ id: string }>()),
+    ]);
+
+    expect(first).toEqual([{ id: 'shared' }]);
+    expect(second).toEqual([{ id: 'shared' }]);
+    expect(connectionMakeCalls).toBe(1);
   });
 
   test('play hooks recover from a stale addon connection', async () => {
@@ -164,7 +233,7 @@ describe('addon client reconnect', () => {
       new Error('connect ECONNREFUSED 127.0.0.1:7654'),
       reconnected,
     ];
-    await ipc.addonServer.close();
+    await (await Effect.runPromise(ipc.getAddonServer())).close();
 
     const result = await Effect.runPromise(
       addons.runLaunchAppAddons({ appID: 1 } as LibraryInfo, 'pre')
@@ -176,20 +245,54 @@ describe('addon client reconnect', () => {
     ]);
   });
 
-  test('play hooks restart an unhealthy addon runtime', async () => {
-    const restarted = new MockConnection([
-      {
-        id: 'launch-addon',
-        name: 'Launch Addon',
-        eventsAvailable: ['launch-app'],
-      },
+  test('play hooks spawn addons before configuration and launch', async () => {
+    const server = await Effect.runPromise(ipc.getAddonServer());
+    server.configUpdateCalls.length = 0;
+    server.launchCalls.length = 0;
+    server.replaceAddons([], true);
+    onEnsureAddonsSpawned = () => {
+      server.replaceAddons(
+        [
+          {
+            id: 'spawned-addon',
+            name: 'Spawned Addon',
+            eventsAvailable: ['launch-app'],
+          },
+        ],
+        false
+      );
+    };
+
+    const result = await Effect.runPromise(
+      addons.runLaunchAppAddons({ appID: 1 } as LibraryInfo, 'pre')
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(ensureAddonsSpawnedCalls).toBe(1);
+    expect(server.configUpdateCalls).toEqual(['spawned-addon']);
+    expect(server.launchCalls).toEqual([
+      { addonId: 'spawned-addon', launchType: 'pre' },
     ]);
+  });
+
+  test('play hooks restart an unhealthy addon runtime', async () => {
+    const restarted = new MockConnection(
+      [
+        {
+          id: 'launch-addon',
+          name: 'Launch Addon',
+          eventsAvailable: ['launch-app'],
+        },
+      ],
+      undefined,
+      false
+    );
     connections = [restarted];
     connectFailuresRemaining = Number.POSITIVE_INFINITY;
     onRestartAddonServer = () => {
       connectFailuresRemaining = 0;
     };
-    await ipc.addonServer.close();
+    await (await Effect.runPromise(ipc.getAddonServer())).close();
 
     const result = await Effect.runPromise(
       addons.runLaunchAppAddons({ appID: 1 } as LibraryInfo, 'pre')
@@ -197,6 +300,7 @@ describe('addon client reconnect', () => {
 
     expect(result).toEqual({ success: true });
     expect(restartAddonServerCalls).toBe(1);
+    expect(restarted.configUpdateCalls).toEqual(['launch-addon']);
     expect(restarted.launchCalls).toEqual([
       { addonId: 'launch-addon', launchType: 'pre' },
     ]);

--- a/application/tests/addon-client-startup.test.ts
+++ b/application/tests/addon-client-startup.test.ts
@@ -1,0 +1,24 @@
+import { expect, mock, test } from 'bun:test';
+import { Effect } from 'effect';
+
+mock.module('@/frontend/lib/config/client', () => ({
+  getConfigClientOption: () => null,
+  fetchAddonsWithConfigure: () => Effect.succeed([]),
+}));
+
+mock.module('@ogi-sdk/client-kit', () => ({
+  Connection: {
+    make: () => new Promise(() => {}),
+  },
+}));
+
+test('frontend IPC initializes while the addon server is unavailable', async () => {
+  const result = await Promise.race([
+    import('../src/frontend/lib/core/ipc.js').then(() => 'initialized'),
+    new Promise<'timed-out'>((resolve) =>
+      setTimeout(() => resolve('timed-out'), 100)
+    ),
+  ]);
+
+  expect(result).toBe('initialized');
+});

--- a/application/tests/addon-configuration-handshake.test.ts
+++ b/application/tests/addon-configuration-handshake.test.ts
@@ -1,0 +1,70 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { Effect } from 'effect';
+
+let configUpdateCalls = 0;
+let configured = false;
+let markConfigUpdateStarted: () => void;
+let releaseConfigUpdate: () => void;
+
+const configUpdateStarted = new Promise<void>((resolve) => {
+  markConfigUpdateStarted = resolve;
+});
+const configUpdateGate = new Promise<void>((resolve) => {
+  releaseConfigUpdate = resolve;
+});
+
+mock.module('@/frontend/lib/core/ipc', () => ({
+  queryConnectedAddons: () =>
+    Effect.succeed([
+      {
+        id: 'configured-addon',
+        configTemplate: {},
+        eventsAvailable: configured ? ['launch-app'] : [],
+      },
+    ]),
+  getAddonServer: () =>
+    Effect.succeed({
+      addon: () => ({
+        configUpdate: async () => {
+          configUpdateCalls++;
+          markConfigUpdateStarted();
+          await configUpdateGate;
+          configured = true;
+        },
+      }),
+    }),
+}));
+
+let fetchAddonsWithConfigure: typeof import('../src/frontend/lib/config/client.js').fetchAddonsWithConfigure;
+
+beforeAll(async () => {
+  Object.assign(globalThis, {
+    window: {
+      electronAPI: {
+        fs: {
+          exists: () => true,
+          read: () => '{}',
+          write: () => {},
+        },
+      },
+    },
+  });
+  ({ fetchAddonsWithConfigure } = await import(
+    '../src/frontend/lib/config/client.js'
+  ));
+});
+
+describe('addon configuration handshake', () => {
+  test('concurrent manifest-ready handlers share one config-update', async () => {
+    const first = Effect.runPromise(fetchAddonsWithConfigure());
+    await configUpdateStarted;
+    const second = Effect.runPromise(fetchAddonsWithConfigure());
+
+    expect(configUpdateCalls).toBe(1);
+    releaseConfigUpdate();
+
+    expect((await first)[0].eventsAvailable).toEqual(['launch-app']);
+    expect((await second)[0].eventsAvailable).toEqual(['launch-app']);
+    expect(configUpdateCalls).toBe(1);
+  });
+});

--- a/application/tests/renderer-event-readiness.test.ts
+++ b/application/tests/renderer-event-readiness.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'bun:test';
+import { RendererEventReadiness } from '../src/electron/lib/renderer-event-readiness';
+
+test('renderer readiness cancels its timeout after the renderer responds', async () => {
+  const readiness = new RendererEventReadiness();
+  let timeoutCalls = 0;
+  const waiting = readiness.wait(10, () => timeoutCalls++);
+
+  readiness.markReady();
+  await waiting;
+  await Bun.sleep(20);
+
+  expect(timeoutCalls).toBe(0);
+  expect(readiness.isReady()).toBe(true);
+});
+
+test('renderer readiness reports a genuine timeout', async () => {
+  const readiness = new RendererEventReadiness();
+  let timeoutCalls = 0;
+
+  await readiness.wait(5, () => timeoutCalls++);
+
+  expect(timeoutCalls).toBe(1);
+  expect(readiness.isReady()).toBe(false);
+});
+
+test('renderer readiness resets for a new document', () => {
+  const readiness = new RendererEventReadiness();
+  readiness.markReady();
+  readiness.reset();
+
+  expect(readiness.isReady()).toBe(false);
+});

--- a/packages/ogi-addon/src/main.ts
+++ b/packages/ogi-addon/src/main.ts
@@ -847,10 +847,6 @@ class OGIAddonWSListener {
                 message: `Invalid addon configuration: ${formatError(cause)}`,
               }),
           });
-          yield* this.respondToMessage(
-            id,
-            result[0] ? { success: true } : { success: false, error: result[1] }
-          );
           if (!this.configConnected) {
             this.configConnected = true;
             const connectEvent = this.makeEventResponse<void>();
@@ -858,6 +854,10 @@ class OGIAddonWSListener {
             this.schedule(this.runDeferredEffect(connectEvent));
             yield* this.addon.sendEventsAvailable();
           }
+          yield* this.respondToMessage(
+            id,
+            result[0] ? { success: true } : { success: false, error: result[1] }
+          );
           return;
         }
         case 'search':


### PR DESCRIPTION
# Description

Fixes intermittent Play failures where the renderer loses access to the add-on runtime and launching only works again after manually restarting the add-on server.

Connected add-on queries now recover stale client sockets through a shared reconnect. If the runtime remains unavailable during a launch hook, OpenGameInstaller restarts it once, reconnects, and retries the hook automatically.

Validated with the complete application test suite (102 passing), application type-checking, and Biome formatting checks.

# Example

```text
Play
  -> reconnect stale add-on client
  -> restart unhealthy add-on runtime when reconnecting fails
  -> reconnect and retry pre-launch hooks
  -> launch game
```

# Next Steps

- Verify repeated launches after add-on updates and runtime restarts.
- Confirm the manual restart workaround is no longer necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved addon startup reliability and readiness detection.
  - Added automatic recovery when addon connections fail or become unhealthy.
  - Prevented stale addon entries from interfering with startup.
  - Improved handling of concurrent addon configuration updates.
  - Reduced unnecessary reconnections and restarts after addon installation, deletion, or updates.
  - Improved reliability for searches, catalogs, downloads, tasks, setup, and application update checks while addons initialize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->