### PR TITLE
fix(application): detect NixOS before Bun setup

### DIFF
--- a/application/src/electron/handlers/handler.oobe.ts
+++ b/application/src/electron/handlers/handler.oobe.ts
@@ -196,8 +196,9 @@ const downloadTools = (): Effect.Effect<readonly [boolean, boolean]> =>
       yield* attempt(
         Effect.fail(
           new PlatformError({
-            message:
-              'Bun is not installed, and OpenGameInstaller cannot install it automatically on this platform. Install Bun manually, then try again.',
+            message: IS_NIXOS
+              ? 'Bun is not installed. Automatic installation is disabled on NixOS. Install Bun with your system package manager, then try again.'
+              : 'Bun is not installed, and OpenGameInstaller cannot install it automatically on this platform. Install Bun manually, then try again.',
             platform: process.platform,
           })
         )

--- a/application/src/electron/lib/nix-detection.ts
+++ b/application/src/electron/lib/nix-detection.ts
@@ -1,0 +1,6 @@
+export function isNixOSCommandResult(
+  error: Error | null,
+  stdout: string
+): boolean {
+  return error === null && stdout.trim().length > 0;
+}

--- a/application/src/electron/startup.ts
+++ b/application/src/electron/startup.ts
@@ -21,6 +21,7 @@ import {
   normalizeAddonLink,
   parseAddonLink,
 } from '@/electron/lib/addon-links.js';
+import { isNixOSCommandResult } from '@/electron/lib/nix-detection.js';
 import { sendNotification } from '@/electron/main.js';
 import { Addon } from '@/electron/manager/manager.addon.js';
 import { __dirname } from '@/electron/manager/manager.paths.js';
@@ -305,12 +306,8 @@ export let IS_NIXOS = false;
 function detectNixOS(): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     try {
-      exec('command -v nixos-rebuild', (error, _stdout, stderr) => {
-        if (error) {
-          resolve(false);
-          return;
-        }
-        resolve(stderr.includes('nixos-rebuild'));
+      exec('command -v nixos-rebuild', (error, stdout) => {
+        resolve(isNixOSCommandResult(error, stdout));
       });
     } catch {
       resolve(false);

--- a/application/tests/bun-setup.test.ts
+++ b/application/tests/bun-setup.test.ts
@@ -18,4 +18,15 @@ describe('Bun setup', () => {
       ],
     });
   });
+
+  test('does not run the generic installer on NixOS', () => {
+    expect(
+      getBunSetupAction({
+        installed: false,
+        isNixOS: true,
+        platform: 'linux',
+        username: 'test-user',
+      })
+    ).toEqual({ type: 'unsupported' });
+  });
 });

--- a/application/tests/nix-detection.test.ts
+++ b/application/tests/nix-detection.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { isNixOSCommandResult } from '../src/electron/lib/nix-detection';
+
+describe('NixOS detection', () => {
+  test('recognizes a successful nixos-rebuild lookup from stdout', () => {
+    expect(
+      isNixOSCommandResult(null, '/run/current-system/sw/bin/nixos-rebuild\n')
+    ).toBe(true);
+  });
+
+  test('rejects failed lookups and empty stdout', () => {
+    expect(isNixOSCommandResult(new Error('command not found'), '')).toBe(
+      false
+    );
+    expect(isNixOSCommandResult(null, '')).toBe(false);
+  });
+});


### PR DESCRIPTION
# Description

Fix NixOS detection during OOBE Bun setup. `command -v nixos-rebuild` writes its path to stdout, but the detector was checking stderr, so NixOS could be treated as generic Linux and invoke the curl installer or `bun upgrade`. The OOBE now gives NixOS-specific package-manager guidance when Bun is unavailable.

# Example

On NixOS, a missing Bun installation now follows the unsupported/system-package-manager path instead of running the generic Bun installer.

# Next Steps

- Review the NixOS detection and OOBE messaging.
- Validate OOBE behavior on a NixOS host.

## Validation

- `bun test application/tests/nix-detection.test.ts application/tests/bun-setup.test.ts`
- `bun run --cwd application typecheck`
- `bun run --cwd application build`

Typecheck reports 0 errors; the repository retains its existing warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unsupported Bun installation guidance on NixOS.
  * NixOS users are directed to install Bun through their system package manager instead of the generic installer.
  * Improved NixOS detection for command errors and empty output.

* **Tests**
  * Added coverage for NixOS detection and Bun setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->