### PR TITLE
fix(ogi-addon): fall back to unar when unrar is missing

### DIFF
--- a/packages/ogi-addon/src/extraction-progress.ts
+++ b/packages/ogi-addon/src/extraction-progress.ts
@@ -1,4 +1,4 @@
-export type UnrarType = 'unrar-free' | 'unrar-nonfree' | 'unknown';
+export type UnrarType = 'unrar-free' | 'unrar-nonfree' | 'unar' | 'unknown';
 
 export const isSupportedArchivePath = (
   platform: NodeJS.Platform,
@@ -29,6 +29,10 @@ export const detectUnrarTypeFromOutput = (output: string): UnrarType => {
     : 'unknown';
 };
 
+// unar -version prints either "unar v1.10.8, ..." or a bare "v1.10.8".
+export const detectUnarFromVersionOutput = (output: string): boolean =>
+  /\bunar\b/i.test(output) || /^v?\d+(\.\d+)+\s*$/.test(output.trim());
+
 export const parseSevenZipTotal = (output: string): number | undefined =>
   safeTotal(
     [...output.matchAll(/^Size = (\d+)\s*$/gm)].map((match) => match[1])
@@ -48,4 +52,10 @@ export const parseUnrarFreeTotal = (output: string): number | undefined => {
 export const parseUnrarNonFreeTotal = (output: string): number | undefined =>
   safeTotal(
     [...output.matchAll(/^\s*Size:\s*(\d+)\s*$/gm)].map((match) => match[1])
+  );
+
+// lsar -l lines look like: "  0. -----         500   0.0%  None  2026-08-22 06:20  a.txt"
+export const parseLsarTotal = (output: string): number | undefined =>
+  safeTotal(
+    [...output.matchAll(/^\s*\d+\.\s+\S+\s+(\d+)\s/gm)].map((match) => match[1])
   );

--- a/packages/ogi-addon/src/extraction.ts
+++ b/packages/ogi-addon/src/extraction.ts
@@ -4,8 +4,10 @@ import { join } from 'node:path';
 import { FileSystemError, PlatformError } from '@ogi-sdk/errors';
 import { Effect } from 'effect';
 import {
+  detectUnarFromVersionOutput,
   detectUnrarTypeFromOutput,
   isSupportedArchivePath,
+  parseLsarTotal,
   parseSevenZipTotal,
   parseUnrarFreeTotal,
   parseUnrarNonFreeTotal,
@@ -113,7 +115,19 @@ const collectProcessOutput = (
 const detectUnrarType = (): Effect.Effect<UnrarType, FileSystemError> =>
   collectProcessOutput('unrar', [], undefined, true).pipe(
     Effect.catchAll(() => Effect.succeed('')),
-    Effect.map(detectUnrarTypeFromOutput)
+    Effect.map(detectUnrarTypeFromOutput),
+    Effect.flatMap((unrarType) => {
+      if (unrarType !== 'unknown') return Effect.succeed(unrarType);
+      // No unrar on PATH: fall back to unar (The Unarchiver), which also
+      // extracts RAR archives and is packaged on most distributions.
+      return collectProcessOutput('unar', ['-version'], undefined, true).pipe(
+        Effect.catchAll(() => Effect.succeed('')),
+        Effect.map(
+          (output): UnrarType =>
+            detectUnarFromVersionOutput(output) ? 'unar' : 'unknown'
+        )
+      );
+    })
   );
 
 const getArchiveSize = (
@@ -150,6 +164,15 @@ const getArchiveSize = (
       env: { ...process.env, LC_ALL: 'C' },
     }).pipe(
       Effect.map(parseUnrarNonFreeTotal),
+      Effect.catchAll(() => Effect.succeed(undefined))
+    );
+  }
+
+  if (unrarType === 'unar') {
+    return collectProcessOutput('lsar', ['-l', filePath], {
+      env: { ...process.env, LC_ALL: 'C' },
+    }).pipe(
+      Effect.map(parseLsarTotal),
       Effect.catchAll(() => Effect.succeed(undefined))
     );
   }
@@ -247,7 +270,8 @@ export const extraction = (
     ) {
       return yield* Effect.fail(
         new FileSystemError({
-          message: 'Unknown unrar implementation',
+          message:
+            'No RAR extractor found in PATH. Install unrar (unrar-nonfree) or unar with your package manager.',
           path: filePath,
         })
       );
@@ -299,6 +323,13 @@ export const extraction = (
           }
         );
         failureMessage = 'Failed to unzip file';
+      } else if (unrarType === 'unar') {
+        child = yield* spawnProcess(
+          'unar',
+          ['-f', '-D', '-o', stagingDir, filePath],
+          { stdio: 'ignore' }
+        );
+        failureMessage = 'Failed to unar file';
       } else {
         const args =
           unrarType === 'unrar-free'

--- a/packages/ogi-addon/tests/extraction-progress.test.ts
+++ b/packages/ogi-addon/tests/extraction-progress.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  detectUnarFromVersionOutput,
   detectUnrarTypeFromOutput,
   isSupportedArchivePath,
+  parseLsarTotal,
   parseSevenZipTotal,
   parseUnrarFreeTotal,
   parseUnrarNonFreeTotal,
@@ -27,6 +29,15 @@ describe('archive extraction progress parsing', () => {
     expect(detectUnrarTypeFromOutput('command unavailable')).toBe('unknown');
   });
 
+  test('detects unar from both -version output shapes', () => {
+    expect(detectUnarFromVersionOutput('unar v1.10.8, use unar --help')).toBe(
+      true
+    );
+    expect(detectUnarFromVersionOutput('v1.10.8\n')).toBe(true);
+    expect(detectUnarFromVersionOutput('')).toBe(false);
+    expect(detectUnarFromVersionOutput('command not found')).toBe(false);
+  });
+
   test('sums 7-Zip file sizes without counting physical archive size', () => {
     const output = `Physical Size = 120\n----------\nSize = 0\nSize = 12\nSize = 30\n`;
     expect(parseSevenZipTotal(output)).toBe(42);
@@ -49,6 +60,19 @@ describe('archive extraction progress parsing', () => {
     expect(
       parseUnrarNonFreeTotal('Name: a\nSize: 12\nName: b\nSize: 30\n')
     ).toBe(42);
+  });
+
+  test('sums lsar listing sizes', () => {
+    const output = [
+      't.rar: RAR',
+      '     Flags  File size   Ratio  Mode  Date       Time   Name',
+      '     =====  ==========  =====  ====  ========== =====  ====',
+      '  0. -----         500   0.0%  None  2026-08-22 06:20  a.txt',
+      '  1. -----          42   0.0%  None  2026-08-22 06:20  b.txt',
+      '(Flags: D=Directory, R=Resource fork, L=Link, E=Encrypted, @=Extended attributes)',
+    ].join('\n');
+    expect(parseLsarTotal(output)).toBe(542);
+    expect(parseLsarTotal('no listing')).toBeUndefined();
   });
 
   test('rejects missing and unsafe totals', () => {


### PR DESCRIPTION
# Description

On Linux systems where `unrar` is not installed but `unar` (The Unarchiver) is — e.g. distros packaging `unar` instead of `unrar-nonfree` — RAR extraction fails with a spawn "not found in PATH" error even though a capable extractor exists.

`detectUnrarType` now probes `unar -version` when the `unrar` probe comes back unknown, and the extractor spawns `unar -f -D -o <stagingDir> <archive>` in that case. Archive sizing for progress uses `lsar -l` (ships with unar), so byte-based progress reporting keeps working. When neither tool exists, the failure message now says which packages to install instead of "Unknown unrar implementation".

# Example

Verified on a machine with `unar` but no `unrar`:

```
$ bun -e 'import { extraction } from "./src/extraction"; ...'
progress 0
progress 1
rar-branch extraction via unar ok
```

`bun test` (8 pass), `tsc --noEmit`, and `biome check` all clean in `packages/ogi-addon`.

# Next Steps

- Consider mentioning `unar` alongside `unrar-nonfree` in the OOBE tools note in `OutOfBoxExperience.svelte`
- Publish an ogi-addon release so downstream addons pick up the fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for extracting RAR archives with `unar` when `unrar` is unavailable.
  - Improved archive-size estimation for `unar`-supported workflows.
- **Bug Fixes**
  - RAR extraction now provides clearer guidance when no supported extractor is installed.
  - Improved handling of extractor detection and archive listings across supported command-line tools.
- **Tests**
  - Added coverage for `unar` version detection and archive size parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->