### PR TITLE
feat(application): proton version dropdown from installed compat tools

### DIFF
--- a/application/src/electron/handlers/handler.steam.ts
+++ b/application/src/electron/handlers/handler.steam.ts
@@ -30,7 +30,10 @@ import {
   SteamServiceLive,
   type SteamShortcutLookup,
 } from '@/electron/handlers/helpers.app/steam.js';
-import { SteamRepositoryLive } from '@/electron/lib/steam-installation.js';
+import {
+  listSteamCompatibilityTools,
+  SteamRepositoryLive,
+} from '@/electron/lib/steam-installation.js';
 import {
   getSteamCommandCandidates,
   type SteamInstallationKind,
@@ -438,6 +441,11 @@ export function registerSteamHandlers(mainWindow: BrowserWindow) {
     )
   );
 
+  const getSteamCompatibilityTools = ipcProcedure(
+    ElectronRpc.app.getSteamCompatibilityTools,
+    () => (isLinux() ? listSteamCompatibilityTools() : [])
+  );
+
   const removeFromSteam = ipcProcedure(
     ElectronRpc.app.removeFromSteam,
     ipcBoundary((_, appID: number) => {
@@ -455,6 +463,7 @@ export function registerSteamHandlers(mainWindow: BrowserWindow) {
     launchSteamApp,
     checkPrefixExists,
     addToSteam,
+    getSteamCompatibilityTools,
     removeFromSteam
   );
 }

--- a/application/src/electron/lib/steam-installation.ts
+++ b/application/src/electron/lib/steam-installation.ts
@@ -107,6 +107,8 @@ export function getSteamRootCandidates(
 export interface SteamCompatibilityTool {
   id: string;
   name: string;
+  /** Absolute path to the tool's install directory, usable as umu's PROTONPATH. */
+  installPath: string;
 }
 
 /**
@@ -147,11 +149,15 @@ export function listSteamCompatibilityTools(
 ): SteamCompatibilityTool[] {
   const tools = new Map<string, SteamCompatibilityTool>();
   for (const root of candidates) {
-    for (const directory of listDirectories(
-      path.join(root, 'steamapps', 'common')
-    )) {
+    const commonDir = path.join(root, 'steamapps', 'common');
+    for (const directory of listDirectories(commonDir)) {
       const id = officialProtonToolId(directory);
-      if (id && !tools.has(id)) tools.set(id, { id, name: directory });
+      if (id && !tools.has(id))
+        tools.set(id, {
+          id,
+          name: directory,
+          installPath: path.join(commonDir, directory),
+        });
     }
     const customDir = path.join(root, 'compatibilitytools.d');
     for (const directory of listDirectories(customDir)) {
@@ -174,9 +180,19 @@ export function listSteamCompatibilityTools(
             definition instanceof Map
               ? definition.get('display_name')
               : undefined;
+          const installPath =
+            definition instanceof Map
+              ? definition.get('install_path')
+              : undefined;
           tools.set(id, {
             id,
             name: typeof displayName === 'string' ? displayName : id,
+            // install_path in the manifest is relative to the manifest's directory.
+            installPath: path.resolve(
+              customDir,
+              directory,
+              typeof installPath === 'string' ? installPath : '.'
+            ),
           });
         }
       } catch {

--- a/application/src/electron/lib/steam-installation.ts
+++ b/application/src/electron/lib/steam-installation.ts
@@ -9,9 +9,13 @@ import {
 } from '@ogi-sdk/errors';
 import { Context, Effect, Exit, Layer } from 'effect';
 import { readShortcuts } from '@/electron/lib/steam-shortcuts.js';
-import type { BinaryVdfObject } from '@/electron/lib/steam-vdf.js';
+import type {
+  BinaryVdfObject,
+  TextVdfObject,
+} from '@/electron/lib/steam-vdf.js';
 import {
   parseLoginUsers,
+  parseTextVdf,
   serializeBinaryVdf,
 } from '@/electron/lib/steam-vdf.js';
 
@@ -98,6 +102,91 @@ export function getSteamRootCandidates(
       candidates.filter((candidate): candidate is string => Boolean(candidate))
     ),
   ];
+}
+
+export interface SteamCompatibilityTool {
+  id: string;
+  name: string;
+}
+
+/**
+ * Derive Steam's internal compat tool name from an official Proton install
+ * directory. A ".0" minor version is dropped, matching Steam's naming:
+ * "Proton - Experimental" → proton_experimental, "Proton 9.0 (Beta)" →
+ * proton_9, "Proton 6.3" → proton_63, "Proton 5.13" → proton_513.
+ */
+const officialProtonToolId = (directoryName: string): string | undefined => {
+  const name = directoryName.toLowerCase();
+  if (!name.startsWith('proton')) return undefined;
+  if (name.includes('experimental')) return 'proton_experimental';
+  if (name.includes('hotfix')) return 'proton_hotfix';
+  const version = /(\d+)\.(\d+)/.exec(name);
+  if (!version) return undefined;
+  const [, major, minor] = version;
+  return minor === '0' ? `proton_${major}` : `proton_${major}${minor}`;
+};
+
+const listDirectories = (parent: string): string[] => {
+  try {
+    return fs
+      .readdirSync(parent, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * List the compat tools installed across all Steam roots by reading the
+ * filesystem: official Proton builds under steamapps/common and custom tools
+ * (GE-Proton etc.) registered through compatibilitytools.d manifests.
+ */
+export function listSteamCompatibilityTools(
+  candidates = getSteamRootCandidates()
+): SteamCompatibilityTool[] {
+  const tools = new Map<string, SteamCompatibilityTool>();
+  for (const root of candidates) {
+    for (const directory of listDirectories(
+      path.join(root, 'steamapps', 'common')
+    )) {
+      const id = officialProtonToolId(directory);
+      if (id && !tools.has(id)) tools.set(id, { id, name: directory });
+    }
+    const customDir = path.join(root, 'compatibilitytools.d');
+    for (const directory of listDirectories(customDir)) {
+      const manifestPath = path.join(
+        customDir,
+        directory,
+        'compatibilitytool.vdf'
+      );
+      try {
+        const manifest = parseTextVdf(fs.readFileSync(manifestPath, 'utf8'));
+        const definitions = manifest.get('compatibilitytools');
+        const compatTools =
+          definitions instanceof Map
+            ? definitions.get('compat_tools')
+            : undefined;
+        if (!(compatTools instanceof Map)) continue;
+        for (const [id, definition] of compatTools as TextVdfObject) {
+          if (tools.has(id)) continue;
+          const displayName =
+            definition instanceof Map
+              ? definition.get('display_name')
+              : undefined;
+          tools.set(id, {
+            id,
+            name: typeof displayName === 'string' ? displayName : id,
+          });
+        }
+      } catch {
+        // Skip missing or unparseable manifests rather than failing the listing.
+      }
+    }
+  }
+  return [...tools.values()].sort((left, right) =>
+    left.name.localeCompare(right.name)
+  );
 }
 
 const listSteamUsersSync = (root: string): SteamUser[] => {

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -4,6 +4,7 @@ import type {
   ConfigurationOptionWire,
   LibraryInfo,
 } from '@ogi-sdk/connect';
+import { Effect } from 'effect';
 import {
   ConfigurationBuilder,
   isBooleanOption,
@@ -33,13 +34,45 @@ interface Props {
 
 let { exitPlayPage, gameInfo, onFinish }: Props = $props();
 
+// umu treats this PROTONPATH placeholder as "use its bundled default Proton".
+const UMU_PROTON_DEFAULT = 'umu-proton';
+
 let platform = $state<string>('');
 let showDllOverridesModal = $state(false);
+let protonOptions = $state<{ id: string; name: string }[]>([]);
 
 // Get OS platform
 $effect(() => {
   runFrontendEffect(electronRpc.app.getOS()).then((os) => {
     platform = os;
+  });
+});
+
+// Installed compat tools for the per-game Proton picker. Option ids are the
+// tool install paths, which umu consumes directly through PROTONPATH.
+$effect(() => {
+  if (!canEditDllOverrides) return;
+  runFrontendEffect(
+    electronRpc.app
+      .getSteamCompatibilityTools()
+      .pipe(
+        Effect.catchAll(() =>
+          Effect.succeed(
+            [] as { id: string; name: string; installPath: string }[]
+          )
+        )
+      )
+  ).then((tools) => {
+    const options = [
+      { id: UMU_PROTON_DEFAULT, name: 'UMU Default (Proton-GE)' },
+      ...tools.map((tool) => ({ id: tool.installPath, name: tool.name })),
+    ];
+    // Keep a stored version selectable even if its directory is gone.
+    const stored = gameInfo.umu?.protonVersion;
+    if (stored && !options.some((option) => option.id === stored)) {
+      options.push({ id: stored, name: `${stored} (not installed)` });
+    }
+    protonOptions = options;
   });
 });
 
@@ -90,6 +123,7 @@ $effect(() => {
   });
 
   formData.dllOverrides = [...(gameInfo.umu?.dllOverrides ?? [])];
+  formData.protonVersion = gameInfo.umu?.protonVersion ?? UMU_PROTON_DEFAULT;
 });
 
 function handleInputChange(id: string, value: string | number | boolean) {
@@ -229,6 +263,18 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
         />
         {#if key === 'launchArguments'}
           {#if platform === 'linux' || platform === 'darwin'}
+            {#if canEditDllOverrides && protonOptions.length > 0}
+              <InputModal
+                id="protonVersion"
+                label="Proton Version"
+                description="The Proton build umu launches this game with."
+                type="select"
+                value={formData.protonVersion}
+                options={protonOptions}
+                class="mb-4"
+                onchange={handleInputChange}
+              />
+            {/if}
             <ButtonModal
               text={dllOverridesCount > 0
                 ? `DLL Overrides (${dllOverridesCount})`

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -226,11 +226,18 @@ function onFinish(data: any) {
   libraryInfo.cwd = data.cwd;
   libraryInfo.launchExecutable = data.launchExecutable;
   libraryInfo.launchArguments = data.launchArguments;
-  if (libraryInfo.umu && Array.isArray(data.dllOverrides)) {
+  if (libraryInfo.umu) {
     libraryInfo.umu = {
       ...libraryInfo.umu,
-      dllOverrides:
-        data.dllOverrides.length > 0 ? data.dllOverrides : undefined,
+      ...(Array.isArray(data.dllOverrides) && {
+        dllOverrides:
+          data.dllOverrides.length > 0 ? data.dllOverrides : undefined,
+      }),
+      ...(typeof data.protonVersion === 'string' && {
+        // 'umu-proton' is umu's default; storing it explicitly is redundant.
+        protonVersion:
+          data.protonVersion === 'umu-proton' ? undefined : data.protonVersion,
+      }),
     };
   }
   window.electronAPI.fs.write(

--- a/application/src/frontend/views/ClientOptionsView.svelte
+++ b/application/src/frontend/views/ClientOptionsView.svelte
@@ -122,9 +122,10 @@ let options: OptionsCategory[] = [
       steamCompatibilityTool: {
         displayName: 'Steam Compatibility Tool',
         description:
-          "Steam's internal compatibility tool name, such as proton_experimental or a GE-Proton identifier. Leave blank to clear the forced tool when updating a shortcut.",
+          'The Proton version Steam uses for shortcuts, read from your installed compatibility tools.',
         defaultValue: 'proton_experimental',
         value: 'proton_experimental',
+        choice: [],
         type: 'string',
         condition: async () =>
           (await runFrontendEffect(electronRpc.app.getOS())) === 'linux',
@@ -383,6 +384,8 @@ function updateConfig() {
           config[key] = selectedTorrentClientId;
         } else if (key === 'theme') {
           config[key] = selectedTheme;
+        } else if (key === 'steamCompatibilityTool') {
+          config[key] = selectedCompatibilityTool;
         } else {
           config[key] = element.value;
         }
@@ -576,6 +579,8 @@ async function saveSteamGridDbKey(): Promise<void> {
 }
 let selectedTorrentClientId: string = $state('webtorrent'); // Track selection reactively
 let selectedTheme: string = $state('light');
+let selectedCompatibilityTool: string = $state('proton_experimental');
+let compatibilityTools: { id: string; name: string }[] = $state([]);
 
 // Loading states for addon management buttons
 let isInstallingAddons = $state(false);
@@ -659,6 +664,36 @@ function handleThemeChange(detail: { selectedId: string }) {
   document.documentElement.setAttribute('data-theme', detail.selectedId);
 }
 
+function handleCompatibilityToolChange(detail: { selectedId: string }) {
+  selectedCompatibilityTool = detail.selectedId;
+  updateConfig();
+}
+
+async function loadCompatibilityTools() {
+  const tools = await runFrontendEffect(
+    electronRpc.app
+      .getSteamCompatibilityTools()
+      .pipe(
+        Effect.catchAll((error) =>
+          logger
+            .error('Failed to list Steam compatibility tools:', error)
+            .pipe(Effect.as([] as { id: string; name: string }[]))
+        )
+      )
+  );
+  // Keep a stored tool selectable even if its directory is gone.
+  if (
+    selectedCompatibilityTool &&
+    !tools.some((tool) => tool.id === selectedCompatibilityTool)
+  ) {
+    tools.push({
+      id: selectedCompatibilityTool,
+      name: `${selectedCompatibilityTool} (not installed)`,
+    });
+  }
+  compatibilityTools = tools;
+}
+
 $effect(() => {
   if (mainContent && selectedOption) {
     mainContent.scrollTo({ top: 0, behavior: 'smooth' });
@@ -677,6 +712,12 @@ $effect(() => {
     if (storedTheme && storedTheme !== selectedTheme) {
       selectedTheme = storedTheme as string;
     }
+
+    const storedTool = getStoredOrDefaultValue('steamCompatibilityTool');
+    if (storedTool && storedTool !== selectedCompatibilityTool) {
+      selectedCompatibilityTool = storedTool as string;
+    }
+    loadCompatibilityTools();
   }
 });
 
@@ -1062,6 +1103,20 @@ onMount(() => {
                                 selectedId={selectedTheme}
                                 onchange={handleThemeChange}
                               />
+                            {:else if key === 'steamCompatibilityTool'}
+                              {#if compatibilityTools.length > 0}
+                                <CustomDropdown
+                                  id={key}
+                                  options={compatibilityTools}
+                                  selectedId={selectedCompatibilityTool}
+                                  onchange={handleCompatibilityToolChange}
+                                />
+                              {:else}
+                                <p class="option-description mb-0!">
+                                  No Steam compatibility tools were found.
+                                  Install Proton through Steam first.
+                                </p>
+                              {/if}
                             {:else}
                               <!-- Regular select for other options -->
                               <select

--- a/application/src/frontend/views/ClientOptionsView.svelte
+++ b/application/src/frontend/views/ClientOptionsView.svelte
@@ -670,14 +670,14 @@ function handleCompatibilityToolChange(detail: { selectedId: string }) {
 }
 
 async function loadCompatibilityTools() {
-  const tools = await runFrontendEffect(
+  const tools: { id: string; name: string }[] = await runFrontendEffect(
     electronRpc.app
       .getSteamCompatibilityTools()
       .pipe(
         Effect.catchAll((error) =>
           logger
             .error('Failed to list Steam compatibility tools:', error)
-            .pipe(Effect.as([] as { id: string; name: string }[]))
+            .pipe(Effect.as([]))
         )
       )
   );

--- a/application/src/frontend/views/ClientOptionsView.svelte
+++ b/application/src/frontend/views/ClientOptionsView.svelte
@@ -466,16 +466,17 @@ function updateConfig() {
   );
 }
 
+// Returns the persisted value only, undefined when nothing was saved yet.
+function getStoredValue(key: string) {
+  if (!selectedOption) return undefined;
+  const configPath = './config/option/' + selectedOption.id + '.json';
+  if (!fs.exists(configPath)) return undefined;
+  return JSON.parse(fs.read(configPath))[key];
+}
+
 function getStoredOrDefaultValue(key: string) {
   if (!selectedOption) return;
-  if (!fs.exists('./config/option/' + selectedOption.id + '.json')) {
-    return selectedOption.options[key].defaultValue;
-  } else {
-    const storedConfig = JSON.parse(
-      fs.read('./config/option/' + selectedOption.id + '.json')
-    );
-    return storedConfig[key] ?? selectedOption.options[key].defaultValue;
-  }
+  return getStoredValue(key) ?? selectedOption.options[key].defaultValue;
 }
 
 function browseForFolder(event: MouseEvent) {
@@ -681,15 +682,15 @@ async function loadCompatibilityTools() {
         )
       )
   );
-  // Keep a stored tool selectable even if its directory is gone.
+  // Keep an explicitly saved tool selectable even if its directory is gone.
+  // The unsaved default is skipped so an empty scan shows the no-tools hint.
+  const storedTool = getStoredValue('steamCompatibilityTool');
   if (
-    selectedCompatibilityTool &&
-    !tools.some((tool) => tool.id === selectedCompatibilityTool)
+    typeof storedTool === 'string' &&
+    storedTool &&
+    !tools.some((tool) => tool.id === storedTool)
   ) {
-    tools.push({
-      id: selectedCompatibilityTool,
-      name: `${selectedCompatibilityTool} (not installed)`,
-    });
+    tools.push({ id: storedTool, name: `${storedTool} (not installed)` });
   }
   compatibilityTools = tools;
 }

--- a/application/src/lib/electron-rpc.ts
+++ b/application/src/lib/electron-rpc.ts
@@ -267,7 +267,13 @@ export const ElectronRpc = {
       'app.getSteamCompatibilityTools',
       [],
       Schema.mutable(
-        Schema.Array(Schema.Struct({ id: Schema.String, name: Schema.String }))
+        Schema.Array(
+          Schema.Struct({
+            id: Schema.String,
+            name: Schema.String,
+            installPath: Schema.String,
+          })
+        )
       )
     ),
     removeFromSteam: rpc(

--- a/application/src/lib/electron-rpc.ts
+++ b/application/src/lib/electron-rpc.ts
@@ -263,6 +263,13 @@ export const ElectronRpc = {
         | { status: 'error'; error: string }
       >()
     ),
+    getSteamCompatibilityTools: rpc(
+      'app.getSteamCompatibilityTools',
+      [],
+      Schema.mutable(
+        Schema.Array(Schema.Struct({ id: Schema.String, name: Schema.String }))
+      )
+    ),
     removeFromSteam: rpc(
       'app.removeFromSteam',
       [Schema.Number],


### PR DESCRIPTION
# Description

The Steam Compatibility Tool client option is now a dropdown populated from the filesystem instead of a free-text field, and game configuration gains a per-game Proton picker backed by the same scan. A new `app.getSteamCompatibilityTools` RPC scans every Steam root candidate for:

- official Proton builds under `steamapps/common`, mapping directory names to Steam's internal tool IDs (`Proton - Experimental` → `proton_experimental`, `Proton 9.0 (Beta)` → `proton_9`, `Proton 6.3` → `proton_63`)
- custom tools (GE-Proton etc.) by parsing `compatibilitytools.d/*/compatibilitytool.vdf` manifests with the existing `parseTextVdf`

Each tool now also carries its absolute `installPath`. The client option dropdown stores the Steam internal ID (for shortcuts), while the per-game picker in GameConfiguration stores the install path into `umu.protonVersion` — which umu consumes directly as `PROTONPATH` — with a "UMU Default (Proton-GE)" entry mapping to the existing `umu-proton` placeholder. Both keep a stored-but-uninstalled selection visible as "(not installed)".

# Example

Fake Steam layout with Proton Experimental / 9.0 Beta / GE-Proton10-4 plus a non-Proton game directory:

```json
[
  { "id": "GE-Proton10-4", "name": "GE-Proton10-4", "installPath": ".../compatibilitytools.d/GE-Proton10-4" },
  { "id": "proton_experimental", "name": "Proton - Experimental", "installPath": ".../steamapps/common/Proton - Experimental" },
  { "id": "proton_9", "name": "Proton 9.0 (Beta)", "installPath": ".../steamapps/common/Proton 9.0 (Beta)" }
]
```

# Next Steps

- focused test for the directory-name → tool-ID mapping


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic discovery of installed Steam compatibility tools, including Proton versions and custom tools.
  - Added Steam compatibility-tool selection in client settings, with clear messaging when none are available.
  - Added per-game Proton selection for UMU launches, including support for unavailable previously saved versions.
  - Game launch settings now save the selected Proton version alongside DLL overrides.

- **Bug Fixes**
  - Improved handling of invalid, inaccessible, or duplicate compatibility-tool entries.
  - Preserved existing selections when compatibility tools are temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->