### PR TITLE
feat(application/electron): tag windows with STEAM_GAME for gamescope visibility

### DIFF
--- a/application/src/electron/lib/gamescope.ts
+++ b/application/src/electron/lib/gamescope.ts
@@ -1,0 +1,78 @@
+import { execFile } from 'node:child_process';
+import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
+import type { BrowserWindow } from 'electron';
+
+const logger = createLogger(LOGGER_PREFIXES.electron);
+
+/** True inside an embedded gamescope session (Steam Deck Game Mode). */
+export function isGamescopeSession(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return (
+    env.XDG_CURRENT_DESKTOP === 'gamescope' ||
+    env.GAMESCOPE_WAYLAND_DISPLAY !== undefined
+  );
+}
+
+/**
+ * Resolve the 32-bit appid gamescope associates with this launch session.
+ * Steam exports SteamGameId as the 64-bit gameid; for non-Steam shortcuts the
+ * shortcut appid lives in its upper 32 bits, so shift it back down.
+ */
+export function getGamescopeAppId(
+  env: NodeJS.ProcessEnv = process.env
+): number | null {
+  for (const value of [env.SteamGameId, env.SteamAppId]) {
+    if (!value || !/^\d+$/.test(value)) continue;
+    const gameId = BigInt(value);
+    const appId = gameId > 0xffffffffn ? gameId >> 32n : gameId;
+    if (appId > 0n && appId <= 0xffffffffn) return Number(appId);
+  }
+  return null;
+}
+
+function xprop(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile('xprop', args, (cause) => (cause ? reject(cause) : resolve()));
+  });
+}
+
+/**
+ * Tag the window with STEAM_GAME so embedded gamescope will display it.
+ * Steam only sets this property on Xlib clients (via gameoverlayrenderer.so);
+ * Chromium talks XCB directly, so without the tag Game Mode leaves the window
+ * as an unfocusable black layer. Best-effort: failure is logged, never fatal.
+ */
+export async function tagWindowForGamescope(
+  window: BrowserWindow
+): Promise<void> {
+  if (!isGamescopeSession()) return;
+  const appId = getGamescopeAppId();
+  if (appId === null) {
+    logger.sync.warn(
+      '[gamescope] No SteamGameId/SteamAppId in environment, cannot tag window'
+    );
+    return;
+  }
+  const windowId = `0x${window.getNativeWindowHandle().readUInt32LE(0).toString(16)}`;
+  try {
+    await xprop([
+      '-id',
+      windowId,
+      '-f',
+      'STEAM_GAME',
+      '32c',
+      '-set',
+      'STEAM_GAME',
+      String(appId),
+    ]);
+    logger.sync.info(
+      `[gamescope] Tagged window ${windowId} with STEAM_GAME=${appId}`
+    );
+  } catch (cause) {
+    logger.sync.error(
+      `[gamescope] Failed to tag window ${windowId} with STEAM_GAME=${appId}:`,
+      cause
+    );
+  }
+}

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -12,6 +12,10 @@ import {
   launchGameFromLibrary,
 } from '@/electron/handlers/handler.library.js';
 import { loadLibraryInfo } from '@/electron/handlers/helpers.app/library.js';
+import {
+  isGamescopeSession,
+  tagWindowForGamescope,
+} from '@/electron/lib/gamescope.js';
 import { releasePowerSaveBlock } from '@/electron/lib/power-save.js';
 import { RendererEventReadiness } from '@/electron/lib/renderer-event-readiness.js';
 import {
@@ -143,6 +147,12 @@ async function launchGameById(gameId: number, wrapperCommand?: string | null) {
 }
 
 export const VERSION = app.getVersion();
+
+// Embedded gamescope only shows XWayland windows it can classify, so pin
+// Chromium to X11 there; must run before app 'ready' to take effect.
+if (isGamescopeSession()) {
+  app.commandLine.appendSwitch('ozone-platform-hint', 'x11');
+}
 
 // check if NixOS using command -v nixos-rebuild
 logger.sync.info('continuing launch...');
@@ -443,6 +453,9 @@ function createWindow(options: { gameLaunchMode?: boolean } = {}) {
       mainWindow.setFullScreen(true);
     }
     mainWindow?.show();
+    // Game Mode won't display an untagged Chromium window; tag after show so
+    // the X11 window exists.
+    if (mainWindow) void tagWindowForGamescope(mainWindow);
   });
 }
 

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -150,8 +150,9 @@ export const VERSION = app.getVersion();
 
 // Embedded gamescope only shows XWayland windows it can classify, so pin
 // Chromium to X11 there; must run before app 'ready' to take effect.
+// (ozone-platform-hint was removed in Electron 40 — use ozone-platform.)
 if (isGamescopeSession()) {
-  app.commandLine.appendSwitch('ozone-platform-hint', 'x11');
+  app.commandLine.appendSwitch('ozone-platform', 'x11');
 }
 
 // check if NixOS using command -v nixos-rebuild


### PR DESCRIPTION
# Description

Embedded gamescope (Steam Deck Game Mode) only displays XWayland windows it can classify via the \`STEAM_GAME\` X11 property. Steam sets that property by LD_PRELOAD-ing \`gameoverlayrenderer.so\`, which hooks Xlib window creation — Wine windows get tagged, but Chromium talks XCB directly so the OGI window is left as an invisible/black layer. This is why the pre/post-launch save-sync UI only worked under Wine.

This change makes the OGI window visible in Game Mode:

- new \`lib/gamescope.ts\`: detects an embedded gamescope session, resolves the session appid from \`SteamGameId\`/\`SteamAppId\` (non-Steam shortcuts store the appid in the upper 32 bits of the 64-bit gameid), and tags the window via \`xprop -set STEAM_GAME <appid>\` (best-effort, never fatal)
- \`main.ts\`: pins Chromium to X11 (\`ozone-platform-hint=x11\`) when under gamescope so the window is a taggable XWayland client, and tags the window after first \`ready-to-show\` in \`createWindow\` — covering normal, hook-only, and wrapper launch paths

# Example

```bash
# what the tagging performs on the Deck, effectively:
xprop -id 0x<ogi-window-xid> -f STEAM_GAME 32c -set STEAM_GAME <appid>
```

On-Deck verification: launch an OGI-managed game from Game Mode; the launch/sync UI should now render instead of a black screen. If it doesn't, the log line \`[gamescope] Tagged window ...\` plus \`DISPLAY=:1 xprop -id <xid> STEAM_GAME\` will show whether gamescope expects the raw 64-bit gameid instead of the shifted appid (one-line tweak in \`getGamescopeAppId\`).

# Next Steps

- test on real Steam Deck hardware in Game Mode
- add \`GAMESCOPECTRL_BASELAYER_APPID\` root-window fallback if focus issues remain
- fix single-instance forwarding so hook UI isn't sent to a desktop-session OGI instance while the game runs in gamescope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running the application in Gamescope sessions.
  * Automatically configures the appropriate display mode and identifies the associated game session.
  * Improves compatibility with Gamescope-managed windows during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->