### PR TITLE
feat(application): library management improvements and promise-only addon SDK

### DIFF
--- a/application/src/electron/handlers/handler.fs.ts
+++ b/application/src/electron/handlers/handler.fs.ts
@@ -71,15 +71,17 @@ const extractArchive = (arg: {
         ],
       });
     }
-    yield* extraction(archivePath, arg.outputDir, (progress) => {
-      if (arg.downloadId) {
-        sendIPCMessage('processing:progress', {
-          id: arg.downloadId,
-          phase: 'Extracting archive',
-          progress,
-        });
-      }
-    }).pipe(
+    yield* fsTryPromise(arg.outputDir, () =>
+      extraction(archivePath, arg.outputDir, (progress) => {
+        if (arg.downloadId) {
+          sendIPCMessage('processing:progress', {
+            id: arg.downloadId,
+            phase: 'Extracting archive',
+            progress,
+          });
+        }
+      })
+    ).pipe(
       Effect.tapError((error) =>
         Effect.sync(() => {
           if (arg.downloadId) {

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -18,7 +18,7 @@ import { Effect } from 'effect';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import { homedir } from 'os';
-import { parse, resolve, sep } from 'path';
+import { join, parse, resolve, sep } from 'path';
 import { parse as shellQuoteParse } from 'shell-quote';
 import {
   addDeckGameToSteam,
@@ -56,30 +56,58 @@ import { ElectronRpc } from '@/lib/electron-rpc.js';
 
 const logger = createLogger(LOGGER_PREFIXES.electron);
 
+/** Realpath + case-normalize (win32) so symlinks and drive casing can't bypass guards. */
+const normalizeDeletePath = (value: string): string => {
+  let normalized: string;
+  try {
+    normalized = fs.realpathSync(value);
+  } catch {
+    normalized = resolve(value);
+  }
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+};
+
 /**
  * Paths we will never recursively delete when removing a game, so a
- * mistyped/misconfigured cwd cannot nuke unrelated data. Uses realpath +
- * case normalization (win32) and subtree containment so symlinks, drive
- * letter casing, and app-owned subdirectories cannot bypass the guard.
+ * mistyped/misconfigured cwd cannot nuke unrelated data. Subtree containment
+ * protects app-owned metadata; note that `__dirname/downloads` stays deletable
+ * since that is where game installs live by default.
  */
 const isProtectedDeletePath = (target: string): boolean => {
-  const normalize = (value: string): string => {
-    let normalized: string;
-    try {
-      normalized = fs.realpathSync(value);
-    } catch {
-      normalized = resolve(value);
-    }
-    return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
-  };
-
-  const resolved = normalize(target);
-  const protectedRoots = [parse(homedir()).root, homedir(), __dirname].map(
-    normalize
-  );
-  return protectedRoots.some(
+  const resolved = normalizeDeletePath(target);
+  const protectedPaths = [
+    parse(homedir()).root,
+    homedir(),
+    __dirname,
+    join(__dirname, 'config'),
+    join(__dirname, 'internals'),
+    join(__dirname, 'addons'),
+    join(__dirname, 'library'),
+  ].map(normalizeDeletePath);
+  return protectedPaths.some(
     (base) => resolved === base || resolved.startsWith(base + sep)
   );
+};
+
+/**
+ * Refuse deletion when the target directory overlaps another game's install
+ * directory (either one containing the other), so removing one game cannot
+ * wipe a sibling's files in a shared folder.
+ */
+const sharesDirectoryWithOtherGames = (
+  appID: number,
+  target: string
+): boolean => {
+  const resolvedTarget = normalizeDeletePath(target);
+  return getAllLibraryFiles().some((other) => {
+    if (other.appID === appID || !other.cwd) return false;
+    const otherCwd = normalizeDeletePath(other.cwd);
+    return (
+      resolvedTarget === otherCwd ||
+      resolvedTarget.startsWith(otherCwd + sep) ||
+      otherCwd.startsWith(resolvedTarget + sep)
+    );
+  });
 };
 
 /**
@@ -595,6 +623,9 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                 if (isProtectedDeletePath(appInfo.cwd)) {
                   fileWarning =
                     'The game was removed from the library, but its files were not deleted because the path is a protected directory.';
+                } else if (sharesDirectoryWithOtherGames(appid, appInfo.cwd)) {
+                  fileWarning =
+                    'The game was removed from the library, but its files were not deleted because the directory contains other games.';
                 } else if (fs.existsSync(appInfo.cwd)) {
                   const deletion = yield* Effect.either(
                     Effect.tryPromise({

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -16,6 +16,9 @@ import {
 } from 'child_process';
 import { Effect } from 'effect';
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import { homedir } from 'os';
+import { parse, resolve } from 'path';
 import { parse as shellQuoteParse } from 'shell-quote';
 import {
   addDeckGameToSteam,
@@ -52,6 +55,17 @@ import { sendNotification } from '@/electron/main.js';
 import { ElectronRpc } from '@/lib/electron-rpc.js';
 
 const logger = createLogger(LOGGER_PREFIXES.electron);
+
+/**
+ * Paths we will never recursively delete when removing a game, so a
+ * mistyped/misconfigured cwd cannot nuke unrelated data.
+ */
+const isProtectedDeletePath = (target: string): boolean => {
+  const resolved = resolve(target);
+  return [parse(homedir()).root, homedir(), __dirname].some(
+    (protectedPath) => resolve(protectedPath) === resolved
+  );
+};
 
 /**
  * Determine if a game should use UMU mode
@@ -557,19 +571,28 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
 
               yield* Effect.sync(removal.commit);
 
-              // Delete the game files from disk; a failed deletion is a warning,
-              // not a failed removal (the library entry is already gone).
+              // Delete the game files from disk; a failed, skipped, or
+              // refused deletion is a warning, not a failed removal (the
+              // library entry is already gone).
               let fileWarning: string | undefined;
-              if (appInfo.cwd && fs.existsSync(appInfo.cwd)) {
-                const deletion = yield* Effect.either(
-                  Effect.try({
-                    try: () =>
-                      fs.rmSync(appInfo.cwd, { recursive: true, force: true }),
-                    catch: (cause: unknown) => String(cause),
-                  })
-                );
-                if (deletion._tag === 'Left') {
-                  fileWarning = `The game was removed from the library, but its files could not be deleted: ${deletion.left}`;
+              let filesDeleted = false;
+              if (appInfo.cwd) {
+                if (isProtectedDeletePath(appInfo.cwd)) {
+                  fileWarning =
+                    'The game was removed from the library, but its files were not deleted because the path is a protected directory.';
+                } else if (fs.existsSync(appInfo.cwd)) {
+                  const deletion = yield* Effect.either(
+                    Effect.tryPromise({
+                      try: () =>
+                        fsp.rm(appInfo.cwd, { recursive: true, force: true }),
+                      catch: (cause: unknown) => String(cause),
+                    })
+                  );
+                  if (deletion._tag === 'Left') {
+                    fileWarning = `The game was removed from the library, but its files could not be deleted: ${deletion.left}`;
+                  } else {
+                    filesDeleted = true;
+                  }
                 }
               }
 
@@ -577,6 +600,7 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                 status: 'success' as const,
                 warning:
                   [warning, fileWarning].filter(Boolean).join(' ') || undefined,
+                filesDeleted,
               };
             }),
           (removal) =>

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -55,6 +55,7 @@ import {
   filesystemRoot,
   isProtectedDeletePath,
   sharesDirectoryWithOtherGames,
+  systemSubtrees,
 } from '@/electron/lib/delete-guards.js';
 import { resolveSpawnInvocation } from '@/electron/lib/spawn-shell.js';
 import { sendNotification } from '@/electron/main.js';
@@ -65,9 +66,28 @@ const logger = createLogger(LOGGER_PREFIXES.electron);
 /** Library appIDs with a game process currently launched by OGI. */
 const runningGames = new Set<number>();
 
+/** Per-game serial queues so launches and removals cannot interleave mid-flight. */
+const gameOperationQueues = new Map<number, Promise<unknown>>();
+
+function enqueueGameOperation<T>(
+  appID: number,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = gameOperationQueues.get(appID) ?? Promise.resolve();
+  const result = previous.then(operation, operation);
+  gameOperationQueues.set(
+    appID,
+    result.then(
+      () => undefined,
+      () => undefined
+    )
+  );
+  return result;
+}
+
 const deleteGuardRoots = (): DeleteGuardRoots => ({
   exact: [filesystemRoot(), homedir(), __dirname],
-  subtrees: appMetadataSubtrees(__dirname),
+  subtrees: [...appMetadataSubtrees(__dirname), ...systemSubtrees()],
 });
 
 /**
@@ -199,7 +219,8 @@ export function launchGameFromLibrary(
         };
       }
 
-      runningGames.add(appInfo.appID);
+      // Already tracked by the pre-await add above; do not re-add here or a
+      // fast crash's onExit delete would be resurrected.
       mainWindow?.webContents.send('game:launch', { id: appInfo.appID });
       return { success: true };
     }
@@ -233,6 +254,8 @@ export function launchGameFromLibrary(
         ...effectiveLaunchEnv,
       },
     };
+    // Register before spawning so no launch can begin untracked
+    runningGames.add(appInfo.appID);
     const spawnedItem: ChildProcess = spawnInvocation.args
       ? spawn(spawnInvocation.command, spawnInvocation.args, spawnOptions)
       : spawn(spawnInvocation.command, spawnOptions);
@@ -263,7 +286,6 @@ export function launchGameFromLibrary(
       mainWindow?.webContents.send('game:exit', { id: appInfo.appID });
     });
 
-    runningGames.add(appInfo.appID);
     mainWindow?.webContents.send('game:launch', { id: appInfo.appID });
     return { success: true };
   });
@@ -611,16 +633,18 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                 } else if (fs.existsSync(appInfo.cwd)) {
                   const deletion = yield* Effect.either(
                     Effect.tryPromise({
-                      try: async () => {
-                        // Re-check at rm time to close the launch race window
-                        if (runningGames.has(appid)) {
-                          throw new Error('the game is currently running');
-                        }
-                        await fsp.rm(appInfo.cwd, {
-                          recursive: true,
-                          force: true,
-                        });
-                      },
+                      try: () =>
+                        // Serialize against other per-game operations so a
+                        // launch cannot interleave with the recursive rm
+                        enqueueGameOperation(appid, async () => {
+                          if (runningGames.has(appid)) {
+                            throw new Error('the game is currently running');
+                          }
+                          await fsp.rm(appInfo.cwd, {
+                            recursive: true,
+                            force: true,
+                          });
+                        }),
                       catch: (cause: unknown) => String(cause),
                     })
                   );

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -667,7 +667,8 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                             force: true,
                           });
                         }),
-                      catch: (cause: unknown) => String(cause),
+                      catch: (cause) =>
+                        cause instanceof Error ? cause.message : String(cause),
                     })
                   );
                   if (deletion._tag === 'Left') {

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -556,7 +556,28 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
               }
 
               yield* Effect.sync(removal.commit);
-              return { status: 'success' as const, warning };
+
+              // Delete the game files from disk; a failed deletion is a warning,
+              // not a failed removal (the library entry is already gone).
+              let fileWarning: string | undefined;
+              if (appInfo.cwd && fs.existsSync(appInfo.cwd)) {
+                const deletion = yield* Effect.either(
+                  Effect.try({
+                    try: () =>
+                      fs.rmSync(appInfo.cwd, { recursive: true, force: true }),
+                    catch: (cause: unknown) => String(cause),
+                  })
+                );
+                if (deletion._tag === 'Left') {
+                  fileWarning = `The game was removed from the library, but its files could not be deleted: ${deletion.left}`;
+                }
+              }
+
+              return {
+                status: 'success' as const,
+                warning:
+                  [warning, fileWarning].filter(Boolean).join(' ') || undefined,
+              };
             }),
           (removal) =>
             Effect.try({
@@ -733,7 +754,13 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                 }
               }
               if (redistributableFailed) {
-                return 'setup-redistributables-failed';
+                // A failed redistributable should not fail the whole setup;
+                // the game is installed either way.
+                sendNotification({
+                  message: `Some redistributables failed to install for ${data.name}. The game was still added.`,
+                  id: generateNotificationId(),
+                  type: 'warning',
+                });
               }
             }
           }

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -167,6 +167,8 @@ export function launchGameFromLibrary(
       logger.sync.info(`[launch] Using UMU mode for ${appInfo.name}`);
 
       const appID = appInfo.appID;
+      // Track before awaiting so a fast crash cannot out-race the add
+      runningGames.add(appInfo.appID);
       const result = yield* Effect.tryPromise({
         try: () =>
           launchWithUmu(appInfo, {
@@ -183,6 +185,7 @@ export function launchGameFromLibrary(
       });
 
       if (!result.success) {
+        runningGames.delete(appInfo.appID);
         logger.sync.error('[launch] UMU launch failed:', result.error);
         sendNotification({
           message: `Failed to launch game: ${result.error}`,
@@ -608,8 +611,16 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                 } else if (fs.existsSync(appInfo.cwd)) {
                   const deletion = yield* Effect.either(
                     Effect.tryPromise({
-                      try: () =>
-                        fsp.rm(appInfo.cwd, { recursive: true, force: true }),
+                      try: async () => {
+                        // Re-check at rm time to close the launch race window
+                        if (runningGames.has(appid)) {
+                          throw new Error('the game is currently running');
+                        }
+                        await fsp.rm(appInfo.cwd, {
+                          recursive: true,
+                          force: true,
+                        });
+                      },
                       catch: (cause: unknown) => String(cause),
                     })
                   );

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -18,7 +18,6 @@ import { Effect } from 'effect';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import { homedir } from 'os';
-import { join, parse, resolve, sep } from 'path';
 import { parse as shellQuoteParse } from 'shell-quote';
 import {
   addDeckGameToSteam,
@@ -50,65 +49,26 @@ import {
 } from '@/electron/handlers/helpers.app/library.js';
 import { generateNotificationId } from '@/electron/handlers/helpers.app/notifications.js';
 import { isLinux } from '@/electron/handlers/helpers.app/platform.js';
+import {
+  appMetadataSubtrees,
+  type DeleteGuardRoots,
+  filesystemRoot,
+  isProtectedDeletePath,
+  sharesDirectoryWithOtherGames,
+} from '@/electron/lib/delete-guards.js';
 import { resolveSpawnInvocation } from '@/electron/lib/spawn-shell.js';
 import { sendNotification } from '@/electron/main.js';
 import { ElectronRpc } from '@/lib/electron-rpc.js';
 
 const logger = createLogger(LOGGER_PREFIXES.electron);
 
-/** Realpath + case-normalize (win32) so symlinks and drive casing can't bypass guards. */
-const normalizeDeletePath = (value: string): string => {
-  let normalized: string;
-  try {
-    normalized = fs.realpathSync(value);
-  } catch {
-    normalized = resolve(value);
-  }
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
-};
+/** Library appIDs with a game process currently launched by OGI. */
+const runningGames = new Set<number>();
 
-/**
- * Paths we will never recursively delete when removing a game, so a
- * mistyped/misconfigured cwd cannot nuke unrelated data. Subtree containment
- * protects app-owned metadata; note that `__dirname/downloads` stays deletable
- * since that is where game installs live by default.
- */
-const isProtectedDeletePath = (target: string): boolean => {
-  const resolved = normalizeDeletePath(target);
-  const protectedPaths = [
-    parse(homedir()).root,
-    homedir(),
-    __dirname,
-    join(__dirname, 'config'),
-    join(__dirname, 'internals'),
-    join(__dirname, 'addons'),
-    join(__dirname, 'library'),
-  ].map(normalizeDeletePath);
-  return protectedPaths.some(
-    (base) => resolved === base || resolved.startsWith(base + sep)
-  );
-};
-
-/**
- * Refuse deletion when the target directory overlaps another game's install
- * directory (either one containing the other), so removing one game cannot
- * wipe a sibling's files in a shared folder.
- */
-const sharesDirectoryWithOtherGames = (
-  appID: number,
-  target: string
-): boolean => {
-  const resolvedTarget = normalizeDeletePath(target);
-  return getAllLibraryFiles().some((other) => {
-    if (other.appID === appID || !other.cwd) return false;
-    const otherCwd = normalizeDeletePath(other.cwd);
-    return (
-      resolvedTarget === otherCwd ||
-      resolvedTarget.startsWith(otherCwd + sep) ||
-      otherCwd.startsWith(resolvedTarget + sep)
-    );
-  });
-};
+const deleteGuardRoots = (): DeleteGuardRoots => ({
+  exact: [filesystemRoot(), homedir(), __dirname],
+  subtrees: appMetadataSubtrees(__dirname),
+});
 
 /**
  * Determine if a game should use UMU mode
@@ -211,6 +171,7 @@ export function launchGameFromLibrary(
         try: () =>
           launchWithUmu(appInfo, {
             onExit: () => {
+              runningGames.delete(appID);
               mainWindow?.webContents.send('game:exit', { id: appID });
             },
           }),
@@ -235,6 +196,7 @@ export function launchGameFromLibrary(
         };
       }
 
+      runningGames.add(appInfo.appID);
       mainWindow?.webContents.send('game:launch', { id: appInfo.appID });
       return { success: true };
     }
@@ -273,6 +235,7 @@ export function launchGameFromLibrary(
       : spawn(spawnInvocation.command, spawnOptions);
     spawnedItem.on('error', (error) => {
       logger.sync.error(error);
+      runningGames.delete(appInfo.appID);
       sendNotification({
         message: 'Failed to launch game',
         id: generateNotificationId(),
@@ -281,6 +244,7 @@ export function launchGameFromLibrary(
       mainWindow?.webContents.send('game:exit', { id: appInfo.appID });
     });
     spawnedItem.on('exit', (exitCode, signal) => {
+      runningGames.delete(appInfo.appID);
       logger.sync.info(
         'Game exited with code: ' +
           exitCode +
@@ -296,6 +260,7 @@ export function launchGameFromLibrary(
       mainWindow?.webContents.send('game:exit', { id: appInfo.appID });
     });
 
+    runningGames.add(appInfo.appID);
     mainWindow?.webContents.send('game:launch', { id: appInfo.appID });
     return { success: true };
   });
@@ -483,6 +448,7 @@ function executeWrapperCommandForAppSteam(
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
+      runningGames.add(appid);
 
       wrappedChild.stdout?.on('data', (data) => {
         logger.sync.info(`[wrapper stdout] ${data}`);
@@ -497,10 +463,12 @@ function executeWrapperCommandForAppSteam(
           '[wrapper] Failed to execute wrapper command:',
           error
         );
+        runningGames.delete(appid);
         resume(Effect.succeed({ success: false, error: error.message }));
       });
 
       wrappedChild.on('close', (code, signal) => {
+        runningGames.delete(appid);
         if (code === 0) {
           resume(Effect.succeed({ success: true, exitCode: 0 }));
           return;
@@ -620,10 +588,21 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
               let fileWarning: string | undefined;
               let filesDeleted = false;
               if (appInfo.cwd) {
-                if (isProtectedDeletePath(appInfo.cwd)) {
+                if (runningGames.has(appid)) {
+                  fileWarning =
+                    'The game was removed from the library, but its files were not deleted because the game is currently running.';
+                } else if (
+                  isProtectedDeletePath(appInfo.cwd, deleteGuardRoots())
+                ) {
                   fileWarning =
                     'The game was removed from the library, but its files were not deleted because the path is a protected directory.';
-                } else if (sharesDirectoryWithOtherGames(appid, appInfo.cwd)) {
+                } else if (
+                  sharesDirectoryWithOtherGames(
+                    appid,
+                    appInfo.cwd,
+                    getAllLibraryFiles()
+                  )
+                ) {
                   fileWarning =
                     'The game was removed from the library, but its files were not deleted because the directory contains other games.';
                 } else if (fs.existsSync(appInfo.cwd)) {

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -18,7 +18,7 @@ import { Effect } from 'effect';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import { homedir } from 'os';
-import { parse, resolve } from 'path';
+import { parse, resolve, sep } from 'path';
 import { parse as shellQuoteParse } from 'shell-quote';
 import {
   addDeckGameToSteam,
@@ -58,12 +58,27 @@ const logger = createLogger(LOGGER_PREFIXES.electron);
 
 /**
  * Paths we will never recursively delete when removing a game, so a
- * mistyped/misconfigured cwd cannot nuke unrelated data.
+ * mistyped/misconfigured cwd cannot nuke unrelated data. Uses realpath +
+ * case normalization (win32) and subtree containment so symlinks, drive
+ * letter casing, and app-owned subdirectories cannot bypass the guard.
  */
 const isProtectedDeletePath = (target: string): boolean => {
-  const resolved = resolve(target);
-  return [parse(homedir()).root, homedir(), __dirname].some(
-    (protectedPath) => resolve(protectedPath) === resolved
+  const normalize = (value: string): string => {
+    let normalized: string;
+    try {
+      normalized = fs.realpathSync(value);
+    } catch {
+      normalized = resolve(value);
+    }
+    return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+  };
+
+  const resolved = normalize(target);
+  const protectedRoots = [parse(homedir()).root, homedir(), __dirname].map(
+    normalize
+  );
+  return protectedRoots.some(
+    (base) => resolved === base || resolved.startsWith(base + sep)
   );
 };
 

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -59,6 +59,7 @@ import {
 } from '@/electron/lib/delete-guards.js';
 import { resolveSpawnInvocation } from '@/electron/lib/spawn-shell.js';
 import { sendNotification } from '@/electron/main.js';
+import { __dirname } from '@/electron/manager/manager.paths.js';
 import { ElectronRpc } from '@/lib/electron-rpc.js';
 
 const logger = createLogger(LOGGER_PREFIXES.electron);
@@ -190,16 +191,18 @@ export function launchGameFromLibrary(
       logger.sync.info(`[launch] Using UMU mode for ${appInfo.name}`);
 
       const appID = appInfo.appID;
-      // Track before awaiting so a fast crash cannot out-race the add;
+      // Register inside the queue so a concurrent removal cannot interleave;
       // onError cleans up if the launch promise itself rejects.
-      runningGames.add(appInfo.appID);
       const result = yield* Effect.tryPromise({
         try: () =>
-          launchWithUmu(appInfo, {
-            onExit: () => {
-              runningGames.delete(appID);
-              mainWindow?.webContents.send('game:exit', { id: appID });
-            },
+          enqueueGameOperation(parsedAppId, async () => {
+            runningGames.add(appInfo.appID);
+            return launchWithUmu(appInfo, {
+              onExit: () => {
+                runningGames.delete(appID);
+                mainWindow?.webContents.send('game:exit', { id: appID });
+              },
+            });
           }),
         catch: (cause) =>
           new LibraryError({
@@ -262,17 +265,22 @@ export function launchGameFromLibrary(
         ...effectiveLaunchEnv,
       },
     };
-    // Register before spawning so no launch can begin untracked
-    runningGames.add(appInfo.appID);
-    let spawnedItem: ChildProcess;
-    try {
-      spawnedItem = spawnInvocation.args
-        ? spawn(spawnInvocation.command, spawnInvocation.args, spawnOptions)
-        : spawn(spawnInvocation.command, spawnOptions);
-    } catch (cause) {
-      runningGames.delete(appInfo.appID);
-      throw cause;
-    }
+    // Register + spawn inside the queue so a concurrent removal cannot
+    // interleave with the launch.
+    const spawnedItem: ChildProcess = yield* Effect.tryPromise({
+      try: () =>
+        enqueueGameOperation(parsedAppId, async () => {
+          runningGames.add(appInfo.appID);
+          return spawnInvocation.args
+            ? spawn(spawnInvocation.command, spawnInvocation.args, spawnOptions)
+            : spawn(spawnInvocation.command, spawnOptions);
+        }),
+      catch: (cause) =>
+        new LibraryError({
+          message: `Failed to launch game: ${String(cause)}`,
+          gameId: parsedAppId,
+        }),
+    });
     spawnedItem.on('error', (error) => {
       logger.sync.error(error);
       runningGames.delete(appInfo.appID);

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -75,13 +75,16 @@ function enqueueGameOperation<T>(
 ): Promise<T> {
   const previous = gameOperationQueues.get(appID) ?? Promise.resolve();
   const result = previous.then(operation, operation);
-  gameOperationQueues.set(
-    appID,
-    result.then(
-      () => undefined,
-      () => undefined
-    )
+  const settled = result.then(
+    () => undefined,
+    () => undefined
   );
+  gameOperationQueues.set(appID, settled);
+  void settled.then(() => {
+    if (gameOperationQueues.get(appID) === settled) {
+      gameOperationQueues.delete(appID);
+    }
+  });
   return result;
 }
 
@@ -187,7 +190,8 @@ export function launchGameFromLibrary(
       logger.sync.info(`[launch] Using UMU mode for ${appInfo.name}`);
 
       const appID = appInfo.appID;
-      // Track before awaiting so a fast crash cannot out-race the add
+      // Track before awaiting so a fast crash cannot out-race the add;
+      // onError cleans up if the launch promise itself rejects.
       runningGames.add(appInfo.appID);
       const result = yield* Effect.tryPromise({
         try: () =>
@@ -202,7 +206,11 @@ export function launchGameFromLibrary(
             message: `Failed to launch game with UMU: ${String(cause)}`,
             gameId: parsedAppId,
           }),
-      });
+      }).pipe(
+        Effect.onError(() =>
+          Effect.sync(() => runningGames.delete(appInfo.appID))
+        )
+      );
 
       if (!result.success) {
         runningGames.delete(appInfo.appID);
@@ -256,9 +264,15 @@ export function launchGameFromLibrary(
     };
     // Register before spawning so no launch can begin untracked
     runningGames.add(appInfo.appID);
-    const spawnedItem: ChildProcess = spawnInvocation.args
-      ? spawn(spawnInvocation.command, spawnInvocation.args, spawnOptions)
-      : spawn(spawnInvocation.command, spawnOptions);
+    let spawnedItem: ChildProcess;
+    try {
+      spawnedItem = spawnInvocation.args
+        ? spawn(spawnInvocation.command, spawnInvocation.args, spawnOptions)
+        : spawn(spawnInvocation.command, spawnOptions);
+    } catch (cause) {
+      runningGames.delete(appInfo.appID);
+      throw cause;
+    }
     spawnedItem.on('error', (error) => {
       logger.sync.error(error);
       runningGames.delete(appInfo.appID);

--- a/application/src/electron/handlers/handler.redists.ts
+++ b/application/src/electron/handlers/handler.redists.ts
@@ -113,7 +113,15 @@ const installRedistributables = (
     });
 
     yield* Effect.forkDaemon(addDeckGameToSteam(mainWindow, appID));
-    return result;
+
+    // Redistributable failures are non-fatal: each failure already emitted
+    // progress + a warning notification, and the game itself is installed.
+    if (result === 'not-found') {
+      return yield* Effect.fail(
+        new LibraryError({ message: 'Game not found', gameId: appID })
+      );
+    }
+    return 'success' as const;
   });
 
 export function registerRedistributableHandlers(mainWindow: BrowserWindow) {

--- a/application/src/electron/handlers/handler.redists.ts
+++ b/application/src/electron/handlers/handler.redists.ts
@@ -121,7 +121,7 @@ const installRedistributables = (
         new LibraryError({ message: 'Game not found', gameId: appID })
       );
     }
-    return 'success' as const;
+    return result;
   });
 
 export function registerRedistributableHandlers(mainWindow: BrowserWindow) {

--- a/application/src/electron/handlers/handler.umu.ts
+++ b/application/src/electron/handlers/handler.umu.ts
@@ -610,7 +610,7 @@ export async function launchWithUmu(
 export async function installRedistributablesWithUmu(
   appID: number,
   reportProgress?: RedistributableProgressReporter
-): Promise<'success' | 'failed' | 'not-found'> {
+): Promise<'success' | 'partial' | 'failed' | 'not-found'> {
   if (!isLinux()) {
     reportProgress?.({
       kind: 'done',
@@ -914,7 +914,10 @@ export async function installRedistributablesWithUmu(
     result: anyFailed ? 'failed' : 'success',
   });
 
-  return anyFailed ? 'failed' : 'success';
+  // Partial failure is distinct from total failure so the UI can warn without
+  // treating the whole setup as broken.
+  if (!anyFailed) return 'success';
+  return completedCount > 0 ? 'partial' : 'failed';
 }
 async function initializePrefixWithUmuRun(
   libraryInfo: LibraryInfo,

--- a/application/src/electron/handlers/handler.umu.ts
+++ b/application/src/electron/handlers/handler.umu.ts
@@ -297,7 +297,7 @@ export type RedistributableInstallProgress = {
   redistributablePath?: string;
   index?: number;
   status?: 'installing' | 'completed' | 'failed';
-  result?: 'success' | 'failed' | 'not-found';
+  result?: 'success' | 'partial' | 'failed' | 'not-found';
   error?: string;
 };
 
@@ -911,7 +911,7 @@ export async function installRedistributablesWithUmu(
     completedCount,
     failedCount: anyFailed ? failedCount + unresolvedCount : failedCount,
     overallProgress: 100,
-    result: anyFailed ? 'failed' : 'success',
+    result: !anyFailed ? 'success' : completedCount > 0 ? 'partial' : 'failed',
   });
 
   // Partial failure is distinct from total failure so the UI can warn without

--- a/application/src/electron/lib/delete-guards.test.ts
+++ b/application/src/electron/lib/delete-guards.test.ts
@@ -21,6 +21,11 @@ describe('isProtectedDeletePath', () => {
     expect(isProtectedDeletePath('/', roots())).toBe(true);
     expect(isProtectedDeletePath('/etc', roots())).toBe(true);
     expect(isProtectedDeletePath('/usr/share', roots())).toBe(true);
+    // Root containment must not silently match everything via an empty prefix
+    expect(
+      isProtectedDeletePath('/games/MyGame', { exact: [], subtrees: ['/'] })
+    ).toBe(true);
+    expect(isProtectedDeletePath('/etc', roots())).toBe(true);
   });
 
   test('protects the home directory itself but not its children', () => {

--- a/application/src/electron/lib/delete-guards.test.ts
+++ b/application/src/electron/lib/delete-guards.test.ts
@@ -25,7 +25,6 @@ describe('isProtectedDeletePath', () => {
     expect(
       isProtectedDeletePath('/games/MyGame', { exact: [], subtrees: ['/'] })
     ).toBe(true);
-    expect(isProtectedDeletePath('/etc', roots())).toBe(true);
   });
 
   test('protects the home directory itself but not its children', () => {

--- a/application/src/electron/lib/delete-guards.test.ts
+++ b/application/src/electron/lib/delete-guards.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { homedir } from 'os';
+import { join, sep } from 'path';
+import {
+  appMetadataSubtrees,
+  type DeleteGuardRoots,
+  filesystemRoot,
+  isProtectedDeletePath,
+  sharesDirectoryWithOtherGames,
+  systemSubtrees,
+} from './delete-guards';
+
+const dataDir = '/data/ogi';
+const roots = (): DeleteGuardRoots => ({
+  exact: [filesystemRoot(), homedir(), dataDir],
+  subtrees: [...appMetadataSubtrees(dataDir), ...systemSubtrees()],
+});
+
+describe('isProtectedDeletePath', () => {
+  test('protects the filesystem root exactly and system subtrees by containment', () => {
+    expect(isProtectedDeletePath('/', roots())).toBe(true);
+    expect(isProtectedDeletePath('/etc', roots())).toBe(true);
+    expect(isProtectedDeletePath('/usr/share', roots())).toBe(true);
+  });
+
+  test('protects the home directory itself but not its children', () => {
+    expect(isProtectedDeletePath(homedir(), roots())).toBe(true);
+    expect(
+      isProtectedDeletePath(join(homedir(), 'Games', 'MyGame'), roots())
+    ).toBe(false);
+  });
+
+  test('protects the data dir itself but keeps game installs deletable', () => {
+    expect(isProtectedDeletePath(dataDir, roots())).toBe(true);
+    expect(isProtectedDeletePath(join(dataDir, 'downloads'), roots())).toBe(
+      false
+    );
+    expect(
+      isProtectedDeletePath(join(dataDir, 'downloads', 'MyGame'), roots())
+    ).toBe(false);
+  });
+
+  test('protects metadata subtrees by containment', () => {
+    for (const subtree of appMetadataSubtrees(dataDir)) {
+      expect(isProtectedDeletePath(subtree, roots())).toBe(true);
+      expect(isProtectedDeletePath(join(subtree, 'file.json'), roots())).toBe(
+        true
+      );
+    }
+  });
+});
+
+describe('sharesDirectoryWithOtherGames', () => {
+  const others = [
+    { appID: 1, cwd: '/games/alpha' },
+    { appID: 2, cwd: '/games/beta/nested' },
+    { appID: 3 },
+  ];
+
+  test('detects exact, parent, and child overlaps with other games', () => {
+    expect(sharesDirectoryWithOtherGames(9, '/games/alpha', others)).toBe(true);
+    expect(sharesDirectoryWithOtherGames(9, '/games', others)).toBe(true);
+    expect(
+      sharesDirectoryWithOtherGames(9, '/games/beta/nested/child', others)
+    ).toBe(true);
+  });
+
+  test('allows unrelated directories and ignores the removed game itself', () => {
+    expect(sharesDirectoryWithOtherGames(9, '/games/gamma', others)).toBe(
+      false
+    );
+    // Removing game 1 from its own directory is not an overlap with itself
+    expect(
+      sharesDirectoryWithOtherGames(1, join('/games/alpha' + sep, 'sub'), [
+        { appID: 1, cwd: '/games/alpha' },
+      ])
+    ).toBe(false);
+  });
+
+  test('ignores other games without a cwd', () => {
+    expect(sharesDirectoryWithOtherGames(9, '/somewhere', [{ appID: 3 }])).toBe(
+      false
+    );
+  });
+});

--- a/application/src/electron/lib/delete-guards.ts
+++ b/application/src/electron/lib/delete-guards.ts
@@ -18,10 +18,15 @@ const withTrailingSep = (base: string): string =>
 
 /** Containment match that also handles filesystem roots (`/`, `C:\`). */
 const containsOrEquals = (base: string, target: string): boolean => {
-  const normalizedBase = base.replace(/[\\/]$/, '');
+  // A filesystem root must never collapse to an empty prefix (which would
+  // match every path via startsWith).
+  if (base === sep || /^[a-zA-Z]:\\?$/.test(base)) {
+    const trimmed = base.endsWith(sep) ? base.slice(0, -1) : base;
+    return target === trimmed || target.startsWith(withTrailingSep(trimmed));
+  }
+  const normalizedBase = base.replace(/[\\/]+$/, '');
   return (
     target === normalizedBase ||
-    target === base ||
     target.startsWith(withTrailingSep(normalizedBase))
   );
 };

--- a/application/src/electron/lib/delete-guards.ts
+++ b/application/src/electron/lib/delete-guards.ts
@@ -10,7 +10,8 @@ export const normalizeDeletePath = (value: string): string => {
   } catch {
     normalized = resolve(value);
   }
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+  // win32 and macOS default to case-insensitive filesystems
+  return process.platform !== 'linux' ? normalized.toLowerCase() : normalized;
 };
 
 const withTrailingSep = (base: string): string =>

--- a/application/src/electron/lib/delete-guards.ts
+++ b/application/src/electron/lib/delete-guards.ts
@@ -102,6 +102,9 @@ export const systemSubtrees = (): string[] => {
       process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
     ];
   }
+  if (process.platform === 'darwin') {
+    return ['/Applications', '/Library', '/System', '/Volumes', '/private'];
+  }
   return [
     '/etc',
     '/usr',

--- a/application/src/electron/lib/delete-guards.ts
+++ b/application/src/electron/lib/delete-guards.ts
@@ -1,0 +1,114 @@
+import { realpathSync } from 'fs';
+import { homedir } from 'os';
+import { join, parse, resolve, sep } from 'path';
+
+/** Realpath + case-normalize (win32) so symlinks and drive casing can't bypass guards. */
+export const normalizeDeletePath = (value: string): string => {
+  let normalized: string;
+  try {
+    normalized = realpathSync(value);
+  } catch {
+    normalized = resolve(value);
+  }
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+};
+
+const withTrailingSep = (base: string): string =>
+  base.endsWith(sep) || base === '' ? base : base + sep;
+
+/** Containment match that also handles filesystem roots (`/`, `C:\`). */
+const containsOrEquals = (base: string, target: string): boolean => {
+  const normalizedBase = base.replace(/[\\/]$/, '');
+  return (
+    target === normalizedBase ||
+    target === base ||
+    target.startsWith(withTrailingSep(normalizedBase))
+  );
+};
+
+/**
+ * Targets we will never recursively delete when removing a game. Exact-match
+ * entries protect the paths themselves; containment entries protect whole
+ * subtrees (used only for OGI's metadata directories, never for home or the
+ * data dir, so game installs under either stay deletable).
+ */
+export type DeleteGuardRoots = {
+  /** Exact-match only. */
+  readonly exact: string[];
+  /** Exact match plus everything beneath them. */
+  readonly subtrees: string[];
+};
+
+/**
+ * Whether `target` is protected from deletion: an exact protected path, or a
+ * path inside one of the protected subtrees.
+ */
+export const isProtectedDeletePath = (
+  target: string,
+  roots: DeleteGuardRoots
+): boolean => {
+  const resolved = normalizeDeletePath(target);
+  const matches = (paths: string[], containment: boolean): boolean =>
+    paths.some((path) => {
+      const base = normalizeDeletePath(path);
+      if (!containment) return resolved === base;
+      return containsOrEquals(base, resolved);
+    });
+  return matches(roots.exact, false) || matches(roots.subtrees, true);
+};
+
+/** Refuse deletion when the directory overlaps another game's install directory. */
+export const sharesDirectoryWithOtherGames = (
+  appID: number,
+  target: string,
+  otherGames: ReadonlyArray<{ appID: number; cwd?: string }>
+): boolean => {
+  const resolvedTarget = normalizeDeletePath(target);
+  return otherGames.some((other) => {
+    if (other.appID === appID || !other.cwd) return false;
+    const otherCwd = normalizeDeletePath(other.cwd);
+    return (
+      resolvedTarget === otherCwd ||
+      resolvedTarget.startsWith(withTrailingSep(otherCwd)) ||
+      otherCwd.startsWith(withTrailingSep(resolvedTarget))
+    );
+  });
+};
+
+/** App-owned directories that must never be wiped by a game removal. */
+export const appMetadataSubtrees = (dataDir: string): string[] => [
+  join(dataDir, 'config'),
+  join(dataDir, 'internals'),
+  join(dataDir, 'addons'),
+  join(dataDir, 'library'),
+];
+
+/**
+ * System directories no game install should ever live in. Kept separate from
+ * the filesystem root so legitimate install locations on the same drive stay
+ * deletable.
+ */
+export const systemSubtrees = (): string[] => {
+  if (process.platform === 'win32') {
+    return [
+      process.env.SystemRoot ?? 'C:\\Windows',
+      process.env.ProgramFiles ?? 'C:\\Program Files',
+      process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
+    ];
+  }
+  return [
+    '/etc',
+    '/usr',
+    '/var',
+    '/boot',
+    '/bin',
+    '/sbin',
+    '/lib',
+    '/lib64',
+    '/proc',
+    '/sys',
+    '/dev',
+  ];
+};
+
+export const filesystemRoot = (): string => parse(homedir()).root;

--- a/application/src/electron/lib/single-instance-launch.ts
+++ b/application/src/electron/lib/single-instance-launch.ts
@@ -66,6 +66,11 @@ export function parseGameIdArg(
   return null;
 }
 
+/** Whether this session was launched for a specific game (Steam shortcut). */
+export function isGameSpecificLaunch(): boolean {
+  return parseGameIdArg() !== null;
+}
+
 /** Parse the pre/post hook flags used by Steam shortcut launches. */
 export function parseLaunchHookArgs(argv: readonly string[] = process.argv): {
   noLaunch: boolean;

--- a/application/src/electron/manager/manager.addon.ts
+++ b/application/src/electron/manager/manager.addon.ts
@@ -44,6 +44,10 @@ export class Addon extends ExecutorAddon {
         Effect.mapError((cause) => new AddonLoadError({ addonName, cause }))
       );
       const secret = addonServer.getSecret();
+      // gameLaunch describes the session type, not individual launches: a
+      // dedicated Steam-shortcut session spawns addons with the flag set,
+      // while forwarded launches into a running full-app session correctly
+      // report false (the addon learns per-launch detail from launch-app).
       return new Addon({
         port,
         secret,

--- a/application/src/electron/manager/manager.addon.ts
+++ b/application/src/electron/manager/manager.addon.ts
@@ -54,7 +54,7 @@ export class Addon extends ExecutorAddon {
         path: addonPath,
         name: addonName,
         scripts: parsed.scripts,
-        gameLaunch: isGameSpecificLaunch(),
+        gameSpecificLaunch: isGameSpecificLaunch(),
       });
     }).pipe(
       Effect.tapError((error) =>

--- a/application/src/electron/manager/manager.addon.ts
+++ b/application/src/electron/manager/manager.addon.ts
@@ -13,6 +13,7 @@ import {
 } from '@ogi-sdk/executor';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect, Schema } from 'effect';
+import { isGameSpecificLaunch } from '@/electron/lib/single-instance-launch.js';
 import { sendNotification } from '@/electron/main.js';
 import { addonServer, port } from '@/electron/server/addon-server.js';
 
@@ -49,6 +50,7 @@ export class Addon extends ExecutorAddon {
         path: addonPath,
         name: addonName,
         scripts: parsed.scripts,
+        gameLaunch: isGameSpecificLaunch(),
       });
     }).pipe(
       Effect.tapError((error) =>

--- a/application/src/electron/tsconfig.json
+++ b/application/src/electron/tsconfig.json
@@ -34,5 +34,6 @@
     "isolatedModules": true,
     "skipLibCheck": true
   },
-  "include": [".", "../typings"]
+  "include": [".", "../typings"],
+  "exclude": ["**/*.test.ts"]
 }

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -35,6 +35,7 @@ let { exitPlayPage, gameInfo, onFinish }: Props = $props();
 
 let platform = $state<string>('');
 let showDllOverridesModal = $state(false);
+let showRemoveConfirm = $state(false);
 
 // Get OS platform
 $effect(() => {
@@ -123,6 +124,7 @@ let dllOverridesCount = $derived.by(() => {
 });
 
 async function removeFromList() {
+  showRemoveConfirm = false;
   const result = await runFrontendEffect(
     electronRpc.app.removeApp(gameInfo.appID)
   );
@@ -138,7 +140,11 @@ async function removeFromList() {
   completeRequiredReadd(gameInfo.appID);
   createNotification({
     id: Math.random().toString(36).substring(7),
-    message: result.warning ?? 'Game removed from library and files deleted',
+    message:
+      result.warning ??
+      (result.filesDeleted
+        ? 'Game removed from library and files deleted'
+        : 'Game removed from library'),
     type: result.warning ? 'info' : 'success',
   });
   currentDownloads.update((downloads) =>
@@ -267,11 +273,39 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
       <ButtonModal
         text="Remove Game"
         variant="danger"
-        onclick={removeFromList}
+        onclick={() => (showRemoveConfirm = true)}
       />
       <ButtonModal text="Cancel" variant="secondary" onclick={closeModal} />
     </div>
   </Modal>
+
+  {#if showRemoveConfirm}
+    <Modal
+      open={true}
+      size="small"
+      closeOnOverlayClick={false}
+      onClose={() => (showRemoveConfirm = false)}
+    >
+      <TitleModal title={`Remove ${gameInfo.name}?`} />
+      <p class="mb-4 text-sm text-accent-dark">
+        This removes the game from your library and permanently deletes its
+        files{gameInfo.cwd ? ` in ${gameInfo.cwd}` : ''}. This cannot be
+        undone.
+      </p>
+      <div class="flex flex-row gap-3">
+        <ButtonModal
+          text="Delete Game"
+          variant="danger"
+          onclick={removeFromList}
+        />
+        <ButtonModal
+          text="Cancel"
+          variant="secondary"
+          onclick={() => (showRemoveConfirm = false)}
+        />
+      </div>
+    </Modal>
+  {/if}
 
   <WineDllOverridesModal
     open={showDllOverridesModal}

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -138,14 +138,19 @@ async function removeFromList() {
   completeRequiredReadd(gameInfo.appID);
   createNotification({
     id: Math.random().toString(36).substring(7),
-    message:
-      result.warning ?? 'Game removed from library. (Not deleted from disk)',
+    message: result.warning ?? 'Game removed from library and files deleted',
     type: result.warning ? 'info' : 'success',
   });
   currentDownloads.update((downloads) =>
     downloads.filter((download) => download.appID !== gameInfo.appID)
   );
   exitPlayPage();
+}
+
+function showInFolder() {
+  if (gameInfo.cwd) {
+    window.electronAPI.fs.showFileLoc(gameInfo.cwd);
+  }
 }
 
 async function addToSteam(button: HTMLButtonElement) {
@@ -253,6 +258,12 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
           }}
         />
       {/if}
+      <ButtonModal
+        text="Show in Folder"
+        variant="secondary"
+        onclick={showInFolder}
+        disabled={!gameInfo.cwd}
+      />
       <ButtonModal
         text="Remove Game"
         variant="danger"

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -23,7 +23,11 @@ import {
   completeRequiredReadd,
   getRequiredReadd,
 } from '@/frontend/states.svelte';
-import { createNotification, currentDownloads } from '@/frontend/store.svelte';
+import {
+  createNotification,
+  currentDownloads,
+  gamesLaunched,
+} from '@/frontend/store.svelte';
 
 interface Props {
   exitPlayPage: () => void;
@@ -124,6 +128,31 @@ let dllOverridesCount = $derived.by(() => {
 });
 
 async function removeFromList() {
+  if ($gamesLaunched[gameInfo.appID]) {
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message: 'Cannot remove a game while it is running.',
+      type: 'error',
+    });
+    return;
+  }
+  const activeDownload = $currentDownloads.find(
+    (download) =>
+      download.appID === gameInfo.appID &&
+      !['error', 'completed', 'seeding', 'setup-complete'].includes(
+        download.status
+      )
+  );
+  if (activeDownload) {
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message:
+        'Cannot remove a game while a download or install is in progress.',
+      type: 'error',
+    });
+    return;
+  }
+
   showRemoveConfirm = false;
   const result = await runFrontendEffect(
     electronRpc.app.removeApp(gameInfo.appID)

--- a/application/src/frontend/components/GameLaunchOverlay.svelte
+++ b/application/src/frontend/components/GameLaunchOverlay.svelte
@@ -3,6 +3,7 @@ import { formatError } from '@ogi-sdk/errors';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect } from 'effect';
 import { onDestroy, onMount } from 'svelte';
+import AddonFailurePromptModal from '@/frontend/components/built/AddonFailurePromptModal.svelte';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import {
@@ -136,10 +137,10 @@ onMount(async () => {
         );
         status = 'error';
         errorMessage = formatError(error) || 'Pre-launch failed';
-        onError(errorMessage);
         // Ask the user whether to continue launching despite the addon failure
         const proceed = await requestLaunchDespiteAddonFailure(errorMessage);
         if (!proceed) {
+          onError(errorMessage);
           if (isMounted) runFrontendEffect(electronRpc.app.quit());
           return;
         }
@@ -246,6 +247,8 @@ onDestroy(() => {
   isMounted = false;
   for (const id of timeouts) clearTimeout(id);
   timeouts.length = 0;
+  // Never leave the launch flow hanging if the overlay unmounts mid-prompt
+  answerAddonFailurePrompt(false);
 });
 </script>
 
@@ -337,20 +340,11 @@ onDestroy(() => {
 
       {#if isHookOnly || isWrapperLaunch}
         {#if addonFailureMessage !== null}
-          <div class="mt-4 flex justify-center gap-3">
-            <button
-              class="rounded-lg border-none bg-[#4CAF50] px-4 py-2 text-sm font-semibold text-white transition-colors duration-200 hover:bg-[#43a047]"
-              onclick={() => answerAddonFailurePrompt(true)}
-            >
-              Launch Anyway
-            </button>
-            <button
-              class="rounded-lg border-none bg-[#333] px-4 py-2 text-sm font-semibold text-white transition-colors duration-200 hover:bg-[#444]"
-              onclick={() => answerAddonFailurePrompt(false)}
-            >
-              Cancel
-            </button>
-          </div>
+          <AddonFailurePromptModal
+            gameName={gameName}
+            message={addonFailureMessage}
+            onAnswer={answerAddonFailurePrompt}
+          />
         {:else}
           <p class="text-sm text-gray-400 mt-4">Closing application...</p>
         {/if}

--- a/application/src/frontend/components/GameLaunchOverlay.svelte
+++ b/application/src/frontend/components/GameLaunchOverlay.svelte
@@ -4,6 +4,7 @@ import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect } from 'effect';
 import { onDestroy, onMount } from 'svelte';
 import AddonFailurePromptModal from '@/frontend/components/built/AddonFailurePromptModal.svelte';
+import { createLaunchPrompt } from '@/frontend/lib/core/launch-prompt.svelte';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import {
@@ -35,21 +36,7 @@ const timeouts: ReturnType<typeof setTimeout>[] = [];
 let isMounted = false;
 
 // Prompt state: lets the user launch even when the addon pre-launch step failed
-let addonFailureMessage = $state<string | null>(null);
-let resolveAddonFailurePrompt: ((proceed: boolean) => void) | null = null;
-
-function requestLaunchDespiteAddonFailure(error: string): Promise<boolean> {
-  addonFailureMessage = error;
-  return new Promise((resolve) => {
-    resolveAddonFailurePrompt = resolve;
-  });
-}
-
-function answerAddonFailurePrompt(proceed: boolean) {
-  addonFailureMessage = null;
-  resolveAddonFailurePrompt?.(proceed);
-  resolveAddonFailurePrompt = null;
-}
+const addonFailurePrompt = createLaunchPrompt();
 
 onMount(async () => {
   isMounted = true;
@@ -135,11 +122,11 @@ onMount(async () => {
           '[GameLaunchOverlay] Pre-launch hooks failed:',
           error
         );
-        status = 'error';
         errorMessage = formatError(error) || 'Pre-launch failed';
         // Ask the user whether to continue launching despite the addon failure
-        const proceed = await requestLaunchDespiteAddonFailure(errorMessage);
+        const proceed = await addonFailurePrompt.request(errorMessage);
         if (!proceed) {
+          status = 'error';
           onError(errorMessage);
           if (isMounted) runFrontendEffect(electronRpc.app.quit());
           return;
@@ -248,7 +235,7 @@ onDestroy(() => {
   for (const id of timeouts) clearTimeout(id);
   timeouts.length = 0;
   // Never leave the launch flow hanging if the overlay unmounts mid-prompt
-  answerAddonFailurePrompt(false);
+  addonFailurePrompt.answer(false);
 });
 </script>
 
@@ -339,11 +326,11 @@ onDestroy(() => {
       {/if}
 
       {#if isHookOnly || isWrapperLaunch}
-        {#if addonFailureMessage !== null}
+        {#if addonFailurePrompt.message !== null}
           <AddonFailurePromptModal
             gameName={gameName}
-            message={addonFailureMessage}
-            onAnswer={answerAddonFailurePrompt}
+            message={addonFailurePrompt.message}
+            onAnswer={addonFailurePrompt.answer}
           />
         {:else}
           <p class="text-sm text-gray-400 mt-4">Closing application...</p>

--- a/application/src/frontend/components/GameLaunchOverlay.svelte
+++ b/application/src/frontend/components/GameLaunchOverlay.svelte
@@ -124,11 +124,12 @@ onMount(async () => {
           '[GameLaunchOverlay] Pre-launch hooks failed:',
           error
         );
-        errorMessage = formatError(error) || 'Pre-launch failed';
+        const failureText = formatError(error) || 'Pre-launch failed';
         // Ask the user whether to continue launching despite the addon failure
-        const proceed = await addonFailurePrompt.request(errorMessage);
+        const proceed = await addonFailurePrompt.request(failureText);
         if (!proceed) {
           status = 'error';
+          errorMessage = failureText;
           onError(errorMessage);
           if (isMounted) runFrontendEffect(electronRpc.app.quit());
           return;
@@ -136,6 +137,7 @@ onMount(async () => {
         logger.sync.warn(
           '[GameLaunchOverlay] Continuing wrapped launch despite pre-launch hook failure'
         );
+        errorMessage = '';
         status = 'running';
       }
 

--- a/application/src/frontend/components/GameLaunchOverlay.svelte
+++ b/application/src/frontend/components/GameLaunchOverlay.svelte
@@ -33,6 +33,23 @@ let isWrapperLaunch = $state(false);
 const timeouts: ReturnType<typeof setTimeout>[] = [];
 let isMounted = false;
 
+// Prompt state: lets the user launch even when the addon pre-launch step failed
+let addonFailureMessage = $state<string | null>(null);
+let resolveAddonFailurePrompt: ((proceed: boolean) => void) | null = null;
+
+function requestLaunchDespiteAddonFailure(error: string): Promise<boolean> {
+  addonFailureMessage = error;
+  return new Promise((resolve) => {
+    resolveAddonFailurePrompt = resolve;
+  });
+}
+
+function answerAddonFailurePrompt(proceed: boolean) {
+  addonFailureMessage = null;
+  resolveAddonFailurePrompt?.(proceed);
+  resolveAddonFailurePrompt = null;
+}
+
 onMount(async () => {
   isMounted = true;
   // Parse query parameters
@@ -120,11 +137,16 @@ onMount(async () => {
         status = 'error';
         errorMessage = formatError(error) || 'Pre-launch failed';
         onError(errorMessage);
-        const t = setTimeout(() => {
+        // Ask the user whether to continue launching despite the addon failure
+        const proceed = await requestLaunchDespiteAddonFailure(errorMessage);
+        if (!proceed) {
           if (isMounted) runFrontendEffect(electronRpc.app.quit());
-        }, 5000);
-        timeouts.push(t);
-        return;
+          return;
+        }
+        logger.sync.warn(
+          '[GameLaunchOverlay] Continuing wrapped launch despite pre-launch hook failure'
+        );
+        status = 'running';
       }
 
       let wrapperError: string | null = null;
@@ -314,7 +336,24 @@ onDestroy(() => {
       {/if}
 
       {#if isHookOnly || isWrapperLaunch}
-        <p class="text-sm text-gray-400 mt-4">Closing application...</p>
+        {#if addonFailureMessage !== null}
+          <div class="mt-4 flex justify-center gap-3">
+            <button
+              class="rounded-lg border-none bg-[#4CAF50] px-4 py-2 text-sm font-semibold text-white transition-colors duration-200 hover:bg-[#43a047]"
+              onclick={() => answerAddonFailurePrompt(true)}
+            >
+              Launch Anyway
+            </button>
+            <button
+              class="rounded-lg border-none bg-[#333] px-4 py-2 text-sm font-semibold text-white transition-colors duration-200 hover:bg-[#444]"
+              onclick={() => answerAddonFailurePrompt(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        {:else}
+          <p class="text-sm text-gray-400 mt-4">Closing application...</p>
+        {/if}
       {/if}
     </div>
   </div>

--- a/application/src/frontend/components/GameLaunchOverlay.svelte
+++ b/application/src/frontend/components/GameLaunchOverlay.svelte
@@ -71,7 +71,9 @@ onMount(async () => {
     status = 'running';
 
     if (isHookOnly && hookType) {
-      // Hook-only mode: run addon event without launching game
+      // Hook-only mode: run addon event without launching game.
+      // No Launch Anyway prompt here — there is nothing to launch on
+      // failure, so the app just reports and quits.
       logger.sync.info(
         `[GameLaunchOverlay] Running ${hookType}-launch hooks for ${gameName}`
       );

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -8,12 +8,10 @@ import { onDestroy, onMount, tick } from 'svelte';
 import { quintOut } from 'svelte/easing';
 import { fly, slide } from 'svelte/transition';
 import AddonPicture from '@/frontend/components/AddonPicture.svelte';
+import AddonFailurePromptModal from '@/frontend/components/built/AddonFailurePromptModal.svelte';
 import UpdateAppModal from '@/frontend/components/built/UpdateAppModal.svelte';
 import GameConfiguration from '@/frontend/components/GameConfiguration.svelte';
 import Image from '@/frontend/components/Image.svelte';
-import ButtonModal from '@/frontend/components/modal/ButtonModal.svelte';
-import Modal from '@/frontend/components/modal/Modal.svelte';
-import TitleModal from '@/frontend/components/modal/TitleModal.svelte';
 import PlayIcon from '@/frontend/Icons/PlayIcon.svelte';
 import SettingsFilled from '@/frontend/Icons/SettingsFilled.svelte';
 import UpdateIcon from '@/frontend/Icons/UpdateIcon.svelte';
@@ -270,6 +268,8 @@ function onFinish(data: any) {
 onDestroy(() => {
   unsubscribe();
   unsubscribe2();
+  // Never leave the launch flow hanging if the page unmounts mid-prompt
+  answerAddonFailurePrompt(false);
   clearHeaderBackButton();
 });
 
@@ -484,30 +484,11 @@ function handleRunTask(task: SearchResult, addonID: string) {
 {/if}
 
 {#if addonFailureMessage !== null}
-  <Modal
-    open={true}
-    size="small"
-    closeOnOverlayClick={false}
-    onClose={() => answerAddonFailurePrompt(false)}
-  >
-    <TitleModal title="Addon launch step failed" />
-    <p class="mb-2 text-sm text-accent-dark">{addonFailureMessage}</p>
-    <p class="mb-4 text-sm text-accent-dark">
-      Launch {libraryInfo.name} anyway?
-    </p>
-    <div class="flex flex-row gap-3">
-      <ButtonModal
-        text="Launch Anyway"
-        variant="primary"
-        onclick={() => answerAddonFailurePrompt(true)}
-      />
-      <ButtonModal
-        text="Cancel"
-        variant="secondary"
-        onclick={() => answerAddonFailurePrompt(false)}
-      />
-    </div>
-  </Modal>
+  <AddonFailurePromptModal
+    gameName={libraryInfo.name}
+    message={addonFailureMessage}
+    onAnswer={answerAddonFailurePrompt}
+  />
 {/if}
 
 {#if showUpdateModal && updateInfo}

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { LibraryInfo, SearchResult } from '@ogi-sdk/connect';
+import { formatError } from '@ogi-sdk/errors';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect } from 'effect';
 import { ConfigurationBuilder } from 'ogi-addon/config';
@@ -10,6 +11,9 @@ import AddonPicture from '@/frontend/components/AddonPicture.svelte';
 import UpdateAppModal from '@/frontend/components/built/UpdateAppModal.svelte';
 import GameConfiguration from '@/frontend/components/GameConfiguration.svelte';
 import Image from '@/frontend/components/Image.svelte';
+import ButtonModal from '@/frontend/components/modal/ButtonModal.svelte';
+import Modal from '@/frontend/components/modal/Modal.svelte';
+import TitleModal from '@/frontend/components/modal/TitleModal.svelte';
 import PlayIcon from '@/frontend/Icons/PlayIcon.svelte';
 import SettingsFilled from '@/frontend/Icons/SettingsFilled.svelte';
 import UpdateIcon from '@/frontend/Icons/UpdateIcon.svelte';
@@ -110,6 +114,23 @@ async function doesLinkExist(url: string | undefined) {
 let playButton: HTMLButtonElement | undefined = $state(undefined);
 let openedGameConfiguration = $state(false);
 
+// Prompt state: lets the user launch even when the addon pre-launch step failed
+let addonFailureMessage = $state<string | null>(null);
+let resolveAddonFailurePrompt: ((proceed: boolean) => void) | null = null;
+
+function requestLaunchDespiteAddonFailure(error: string): Promise<boolean> {
+  addonFailureMessage = error;
+  return new Promise((resolve) => {
+    resolveAddonFailurePrompt = resolve;
+  });
+}
+
+function answerAddonFailurePrompt(proceed: boolean) {
+  addonFailureMessage = null;
+  resolveAddonFailurePrompt?.(proceed);
+  resolveAddonFailurePrompt = null;
+}
+
 async function launchGame() {
   if ($gamesLaunched[libraryInfo.appID]) return;
   if (!playButton) return;
@@ -132,17 +153,24 @@ async function launchGame() {
     await runFrontendEffect(runLaunchAppAddons(libraryInfo, 'pre'));
   } catch (error) {
     logger.sync.error(error);
-    // remove the game from the gamesLaunched state first so the play button is restored
-    gamesLaunched.update((games) => {
-      delete games[libraryInfo.appID];
-      return games;
-    });
-    // wait for the DOM to update so playButton is restored
-    await tick();
-    if (playButton) {
-      playButton.setAttribute('data-error', 'true');
+    // Ask the user whether to continue launching despite the addon failure
+    const proceed = await requestLaunchDespiteAddonFailure(
+      formatError(error) || 'The addon pre-launch step failed.'
+    );
+    if (!proceed) {
+      // remove the game from the gamesLaunched state first so the play button is restored
+      gamesLaunched.update((games) => {
+        delete games[libraryInfo.appID];
+        return games;
+      });
+      // wait for the DOM to update so playButton is restored
+      await tick();
+      if (playButton) {
+        playButton.setAttribute('data-error', 'true');
+      }
+      return;
     }
-    return;
+    logger.sync.warn('Launching game despite addon pre-launch failure');
   }
 
   logger.sync.info('pre-launch complete');
@@ -453,6 +481,33 @@ function handleRunTask(task: SearchResult, addonID: string) {
 
 {#if openedGameConfiguration}
   <GameConfiguration gameInfo={libraryInfo} {onFinish} {exitPlayPage} />
+{/if}
+
+{#if addonFailureMessage !== null}
+  <Modal
+    open={true}
+    size="small"
+    closeOnOverlayClick={false}
+    onClose={() => answerAddonFailurePrompt(false)}
+  >
+    <TitleModal title="Addon launch step failed" />
+    <p class="mb-2 text-sm text-accent-dark">{addonFailureMessage}</p>
+    <p class="mb-4 text-sm text-accent-dark">
+      Launch {libraryInfo.name} anyway?
+    </p>
+    <div class="flex flex-row gap-3">
+      <ButtonModal
+        text="Launch Anyway"
+        variant="primary"
+        onclick={() => answerAddonFailurePrompt(true)}
+      />
+      <ButtonModal
+        text="Cancel"
+        variant="secondary"
+        onclick={() => answerAddonFailurePrompt(false)}
+      />
+    </div>
+  </Modal>
 {/if}
 
 {#if showUpdateModal && updateInfo}

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -15,6 +15,7 @@ import Image from '@/frontend/components/Image.svelte';
 import PlayIcon from '@/frontend/Icons/PlayIcon.svelte';
 import SettingsFilled from '@/frontend/Icons/SettingsFilled.svelte';
 import UpdateIcon from '@/frontend/Icons/UpdateIcon.svelte';
+import { createLaunchPrompt } from '@/frontend/lib/core/launch-prompt.svelte';
 import { runDetached, runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { addToSteam } from '@/frontend/lib/core/steam';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
@@ -113,21 +114,7 @@ let playButton: HTMLButtonElement | undefined = $state(undefined);
 let openedGameConfiguration = $state(false);
 
 // Prompt state: lets the user launch even when the addon pre-launch step failed
-let addonFailureMessage = $state<string | null>(null);
-let resolveAddonFailurePrompt: ((proceed: boolean) => void) | null = null;
-
-function requestLaunchDespiteAddonFailure(error: string): Promise<boolean> {
-  addonFailureMessage = error;
-  return new Promise((resolve) => {
-    resolveAddonFailurePrompt = resolve;
-  });
-}
-
-function answerAddonFailurePrompt(proceed: boolean) {
-  addonFailureMessage = null;
-  resolveAddonFailurePrompt?.(proceed);
-  resolveAddonFailurePrompt = null;
-}
+const addonFailurePrompt = createLaunchPrompt();
 
 async function launchGame() {
   if ($gamesLaunched[libraryInfo.appID]) return;
@@ -152,7 +139,7 @@ async function launchGame() {
   } catch (error) {
     logger.sync.error(error);
     // Ask the user whether to continue launching despite the addon failure
-    const proceed = await requestLaunchDespiteAddonFailure(
+    const proceed = await addonFailurePrompt.request(
       formatError(error) || 'The addon pre-launch step failed.'
     );
     if (!proceed) {
@@ -269,7 +256,7 @@ onDestroy(() => {
   unsubscribe();
   unsubscribe2();
   // Never leave the launch flow hanging if the page unmounts mid-prompt
-  answerAddonFailurePrompt(false);
+  addonFailurePrompt.answer(false);
   clearHeaderBackButton();
 });
 
@@ -483,11 +470,11 @@ function handleRunTask(task: SearchResult, addonID: string) {
   <GameConfiguration gameInfo={libraryInfo} {onFinish} {exitPlayPage} />
 {/if}
 
-{#if addonFailureMessage !== null}
+{#if addonFailurePrompt.message !== null}
   <AddonFailurePromptModal
     gameName={libraryInfo.name}
-    message={addonFailureMessage}
-    onAnswer={answerAddonFailurePrompt}
+    message={addonFailurePrompt.message}
+    onAnswer={addonFailurePrompt.answer}
   />
 {/if}
 

--- a/application/src/frontend/components/built/AddonFailurePromptModal.svelte
+++ b/application/src/frontend/components/built/AddonFailurePromptModal.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+import ButtonModal from '@/frontend/components/modal/ButtonModal.svelte';
+import Modal from '@/frontend/components/modal/Modal.svelte';
+import TitleModal from '@/frontend/components/modal/TitleModal.svelte';
+
+interface Props {
+  gameName: string;
+  message: string;
+  onAnswer: (proceed: boolean) => void;
+}
+
+let { gameName, message, onAnswer }: Props = $props();
+</script>
+
+<Modal
+  open={true}
+  size="small"
+  closeOnOverlayClick={false}
+  onClose={() => onAnswer(false)}
+>
+  <TitleModal title="Addon launch step failed" />
+  <p class="mb-2 text-sm text-accent-dark">{message}</p>
+  <p class="mb-4 text-sm text-accent-dark">Launch {gameName} anyway?</p>
+  <div class="flex flex-row gap-3">
+    <ButtonModal
+      text="Launch Anyway"
+      variant="primary"
+      onclick={() => onAnswer(true)}
+    />
+    <ButtonModal
+      text="Cancel"
+      variant="secondary"
+      onclick={() => onAnswer(false)}
+    />
+  </div>
+</Modal>

--- a/application/src/frontend/lib/core/launch-prompt.svelte.ts
+++ b/application/src/frontend/lib/core/launch-prompt.svelte.ts
@@ -11,6 +11,8 @@ export function createLaunchPrompt() {
       return message;
     },
     request(error: string): Promise<boolean> {
+      // Settle any previous pending request so its flow never hangs
+      resolver?.(false);
       message = error;
       return new Promise((resolve) => {
         resolver = resolve;

--- a/application/src/frontend/lib/core/launch-prompt.svelte.ts
+++ b/application/src/frontend/lib/core/launch-prompt.svelte.ts
@@ -1,0 +1,25 @@
+/**
+ * Promise-backed "Launch Anyway" prompt state shared by launch surfaces.
+ * Must live in a `.svelte.ts` module for rune support.
+ */
+export function createLaunchPrompt() {
+  let message = $state<string | null>(null);
+  let resolver: ((proceed: boolean) => void) | null = null;
+
+  return {
+    get message() {
+      return message;
+    },
+    request(error: string): Promise<boolean> {
+      message = error;
+      return new Promise((resolve) => {
+        resolver = resolve;
+      });
+    },
+    answer(proceed: boolean) {
+      message = null;
+      resolver?.(proceed);
+      resolver = null;
+    },
+  };
+}

--- a/application/src/frontend/lib/setup/setup.ts
+++ b/application/src/frontend/lib/setup/setup.ts
@@ -307,21 +307,17 @@ export function startRedistributableInstallation(
     }
 
     if (result === 'success') {
-      // Redistributable failures are non-fatal, so surface them as a
-      // partial-success warning instead of a plain "complete".
-      let partialError: string | undefined;
+      updateDownloadStatus(downloadId, { status: 'setup-complete' });
       redistributableInstalls.update((setups) => {
-        partialError = setups[downloadId]?.error;
         const { [downloadId]: _, ...remaining } = setups;
         return remaining;
       });
-      updateDownloadStatus(downloadId, { status: 'setup-complete' });
+      // Partial redistributable failures were already surfaced as warnings
+      // by the backend during installation.
       createNotification({
         id: Math.random().toString(36).substring(2, 9),
-        type: partialError ? 'warning' : 'success',
-        message: partialError
-          ? `Setup complete for ${setup.gameName}, but some redistributables failed.`
-          : `Setup complete for ${setup.gameName}!`,
+        type: 'success',
+        message: `Setup complete for ${setup.gameName}!`,
       });
       return;
     }
@@ -331,7 +327,7 @@ export function startRedistributableInstallation(
       error:
         result === 'not-found'
           ? 'redistributables-app-not-found'
-          : 'setup-redistributables-failed',
+          : 'redistributables-failed',
     });
     createNotification({
       id: Math.random().toString(36).substring(2, 9),

--- a/application/src/frontend/lib/setup/setup.ts
+++ b/application/src/frontend/lib/setup/setup.ts
@@ -312,12 +312,37 @@ export function startRedistributableInstallation(
         const { [downloadId]: _, ...remaining } = setups;
         return remaining;
       });
-      // Partial redistributable failures were already surfaced as warnings
-      // by the backend during installation.
       createNotification({
         id: Math.random().toString(36).substring(2, 9),
         type: 'success',
         message: `Setup complete for ${setup.gameName}!`,
+      });
+      return;
+    }
+
+    if (result === 'partial' || result === 'failed') {
+      // The game itself is installed; keep the install entry around so the
+      // redistributables can be retried from the downloads view.
+      updateDownloadStatus(downloadId, { status: 'setup-complete' });
+      redistributableInstalls.update((setups) => {
+        const current = setups[downloadId];
+        if (!current) return setups;
+        return {
+          ...setups,
+          [downloadId]: {
+            ...current,
+            overallProgress: 100,
+            isComplete: true,
+            error:
+              current.error ??
+              'Some redistributables failed to install and can be retried.',
+          },
+        };
+      });
+      createNotification({
+        id: Math.random().toString(36).substring(2, 9),
+        type: 'warning',
+        message: `Setup complete for ${setup.gameName}, but redistributable installation ${result === 'partial' ? 'partially failed' : 'failed'}.`,
       });
       return;
     }

--- a/application/src/frontend/lib/setup/setup.ts
+++ b/application/src/frontend/lib/setup/setup.ts
@@ -307,15 +307,21 @@ export function startRedistributableInstallation(
     }
 
     if (result === 'success') {
-      updateDownloadStatus(downloadId, { status: 'setup-complete' });
+      // Redistributable failures are non-fatal, so surface them as a
+      // partial-success warning instead of a plain "complete".
+      let partialError: string | undefined;
       redistributableInstalls.update((setups) => {
+        partialError = setups[downloadId]?.error;
         const { [downloadId]: _, ...remaining } = setups;
         return remaining;
       });
+      updateDownloadStatus(downloadId, { status: 'setup-complete' });
       createNotification({
         id: Math.random().toString(36).substring(2, 9),
-        type: 'success',
-        message: `Setup complete for ${setup.gameName}!`,
+        type: partialError ? 'warning' : 'success',
+        message: partialError
+          ? `Setup complete for ${setup.gameName}, but some redistributables failed.`
+          : `Setup complete for ${setup.gameName}!`,
       });
       return;
     }
@@ -392,10 +398,7 @@ export function runSetupApp(
         )
       );
 
-    if (
-      result === 'setup-failed' ||
-      result === 'setup-redistributables-failed'
-    ) {
+    if (result === 'setup-failed') {
       updateDownloadStatus(downloadedItem.id, {
         status: 'error',
         error: result,

--- a/application/src/frontend/lib/setup/setup.ts
+++ b/application/src/frontend/lib/setup/setup.ts
@@ -20,6 +20,7 @@ import { saveFailedSetup } from '@/frontend/lib/recovery/failedSetups';
 import { updatesManager } from '@/frontend/states.svelte';
 import {
   createNotification,
+  currentDownloads,
   type DownloadStatusAndInfo,
   redistributableInstalls,
   setupLogs,
@@ -45,6 +46,16 @@ type RedistributableProgressDetail = {
   result?: 'success' | 'failed' | 'not-found';
   error?: string;
 };
+
+/** Redistributables finish into the same terminal status the download had. */
+function settledDownloadStatus(
+  downloadId: string
+): 'seeding' | 'setup-complete' {
+  const download = get(currentDownloads).find(
+    (candidate) => candidate.id === downloadId
+  );
+  return download?.downloadType === 'torrent' ? 'seeding' : 'setup-complete';
+}
 
 function dispatchSetupEvent(
   eventType: 'log' | 'progress',
@@ -307,7 +318,9 @@ export function startRedistributableInstallation(
     }
 
     if (result === 'success') {
-      updateDownloadStatus(downloadId, { status: 'setup-complete' });
+      updateDownloadStatus(downloadId, {
+        status: settledDownloadStatus(downloadId),
+      });
       redistributableInstalls.update((setups) => {
         const { [downloadId]: _, ...remaining } = setups;
         return remaining;
@@ -323,7 +336,9 @@ export function startRedistributableInstallation(
     if (result === 'partial' || result === 'failed') {
       // The game itself is installed; keep the install entry around so the
       // redistributables can be retried from the downloads view.
-      updateDownloadStatus(downloadId, { status: 'setup-complete' });
+      updateDownloadStatus(downloadId, {
+        status: settledDownloadStatus(downloadId),
+      });
       redistributableInstalls.update((setups) => {
         const current = setups[downloadId];
         if (!current) return setups;

--- a/application/src/frontend/views/DownloadView.svelte
+++ b/application/src/frontend/views/DownloadView.svelte
@@ -6,6 +6,7 @@ import { onDestroy, onMount } from 'svelte';
 import RedistributablesProgress from '@/frontend/components/RedistributablesProgress.svelte';
 import SetupPrompt from '@/frontend/components/SetupPrompt.svelte';
 import { runDetached, runFrontendEffect } from '@/frontend/lib/core/runtime';
+import { updateDownloadStatus } from '@/frontend/lib/downloads/lifecycle';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import { startRedistributableInstallation } from '@/frontend/lib/setup/setup';
 import {
@@ -184,6 +185,7 @@ function handleRetryRedistributables(downloadId: string, appID: number) {
       },
     };
   });
+  updateDownloadStatus(downloadId, { status: 'installing-redistributables' });
   runDetached(
     startRedistributableInstallation(downloadId, appID),
     'Failed to retry redistributable installation'

--- a/application/src/frontend/views/DownloadView.svelte
+++ b/application/src/frontend/views/DownloadView.svelte
@@ -171,6 +171,21 @@ async function runDownloadAction<A, E>(
   );
 }
 
+/** The failed redistributable setup for a finished download, if any. */
+function redistFailureFor(
+  download: { id: string; status: string }
+) {
+  const setup = $redistributableInstalls[download.id];
+  if (
+    (download.status === 'setup-complete' || download.status === 'seeding') &&
+    setup?.isComplete === true &&
+    setup.error
+  ) {
+    return setup;
+  }
+  return undefined;
+}
+
 function handleRetryRedistributables(downloadId: string, appID: number) {
   redistributableInstalls.update((setups) => {
     const current = setups[downloadId];
@@ -673,9 +688,7 @@ onDestroy(() => {
                   <div class="spinner"></div>
                   Installing Dependencies
                 </div>
-              {:else if download.status === 'setup-complete' &&
-                $redistributableInstalls[download.id]?.isComplete &&
-                $redistributableInstalls[download.id]?.error}
+              {:else if redistFailureFor(download)}
                 <div class="status-badge installing-redistributables">
                   <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                     <path
@@ -687,7 +700,7 @@ onDestroy(() => {
                   Redistributables Need Attention
                 </div>
                 <p class="text-sm text-error mt-2 break-words">
-                  {$redistributableInstalls[download.id]!!.error}
+                  {redistFailureFor(download)?.error}
                 </p>
               {:else if download.status === 'setup-complete'}
                 <div class="status-badge complete">
@@ -783,16 +796,11 @@ onDestroy(() => {
             </div>
 
             <div class="download-actions">
-              {#if download.status === 'setup-complete' &&
-                $redistributableInstalls[download.id]?.isComplete &&
-                $redistributableInstalls[download.id]?.error}
+              {#if redistFailureFor(download)}
                 <button
                   class="btn btn-primary btn-sm"
                   onclick={() =>
-                    handleRetryRedistributables(
-                      download.id,
-                      download.appID
-                    )}
+                    handleRetryRedistributables(download.id, download.appID)}
                 >
                   Retry Redistributables
                 </button>
@@ -920,10 +928,8 @@ onDestroy(() => {
             />
           </div>
         {/if}
-        {#if ((download.status === 'installing-redistributables' || (download.status === 'paused' && $redistributableInstalls[download.id] && !$redistributableInstalls[download.id].isComplete)) ||
-          (download.status === 'setup-complete' &&
-            $redistributableInstalls[download.id]?.isComplete &&
-            $redistributableInstalls[download.id]?.error)) &&
+        {#if (download.status === 'installing-redistributables' || (download.status === 'paused' && $redistributableInstalls[download.id] && !$redistributableInstalls[download.id].isComplete) ||
+          redistFailureFor(download)) &&
           $redistributableInstalls[download.id]}
           <div class="mt-4 w-full">
             <RedistributablesProgress

--- a/application/src/frontend/views/DownloadView.svelte
+++ b/application/src/frontend/views/DownloadView.svelte
@@ -7,6 +7,7 @@ import RedistributablesProgress from '@/frontend/components/RedistributablesProg
 import SetupPrompt from '@/frontend/components/SetupPrompt.svelte';
 import { runDetached, runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
+import { startRedistributableInstallation } from '@/frontend/lib/setup/setup';
 import {
   createNotification,
   currentDownloads,
@@ -166,6 +167,26 @@ async function runDownloadAction<A, E>(
         })
       )
     )
+  );
+}
+
+function handleRetryRedistributables(downloadId: string, appID: number) {
+  redistributableInstalls.update((setups) => {
+    const current = setups[downloadId];
+    if (!current) return setups;
+    return {
+      ...setups,
+      [downloadId]: {
+        ...current,
+        overallProgress: 0,
+        isComplete: false,
+        error: undefined,
+      },
+    };
+  });
+  runDetached(
+    startRedistributableInstallation(downloadId, appID),
+    'Failed to retry redistributable installation'
   );
 }
 
@@ -650,6 +671,22 @@ onDestroy(() => {
                   <div class="spinner"></div>
                   Installing Dependencies
                 </div>
+              {:else if download.status === 'setup-complete' &&
+                $redistributableInstalls[download.id]?.isComplete &&
+                $redistributableInstalls[download.id]?.error}
+                <div class="status-badge installing-redistributables">
+                  <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                    <path
+                      fill-rule="evenodd"
+                      d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+                      clip-rule="evenodd"
+                    ></path>
+                  </svg>
+                  Redistributables Need Attention
+                </div>
+                <p class="text-sm text-error mt-2 break-words">
+                  {$redistributableInstalls[download.id]!!.error}
+                </p>
               {:else if download.status === 'setup-complete'}
                 <div class="status-badge complete">
                   <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
@@ -744,6 +781,20 @@ onDestroy(() => {
             </div>
 
             <div class="download-actions">
+              {#if download.status === 'setup-complete' &&
+                $redistributableInstalls[download.id]?.isComplete &&
+                $redistributableInstalls[download.id]?.error}
+                <button
+                  class="btn btn-primary btn-sm"
+                  onclick={() =>
+                    handleRetryRedistributables(
+                      download.id,
+                      download.appID
+                    )}
+                >
+                  Retry Redistributables
+                </button>
+              {/if}
               {#if download.status === 'setup-complete'}
                 <button
                   class="btn btn-primary btn-sm"
@@ -867,7 +918,11 @@ onDestroy(() => {
             />
           </div>
         {/if}
-        {#if (download.status === 'installing-redistributables' || (download.status === 'paused' && $redistributableInstalls[download.id] && !$redistributableInstalls[download.id].isComplete)) && $redistributableInstalls[download.id]}
+        {#if ((download.status === 'installing-redistributables' || (download.status === 'paused' && $redistributableInstalls[download.id] && !$redistributableInstalls[download.id].isComplete)) ||
+          (download.status === 'setup-complete' &&
+            $redistributableInstalls[download.id]?.isComplete &&
+            $redistributableInstalls[download.id]?.error)) &&
+          $redistributableInstalls[download.id]}
           <div class="mt-4 w-full">
             <RedistributablesProgress
               setup={$redistributableInstalls[download.id]}

--- a/application/src/frontend/views/DownloadView.svelte
+++ b/application/src/frontend/views/DownloadView.svelte
@@ -172,9 +172,7 @@ async function runDownloadAction<A, E>(
 }
 
 /** The failed redistributable setup for a finished download, if any. */
-function redistFailureFor(
-  download: { id: string; status: string }
-) {
+function redistFailureFor(download: { id: string; status: string }) {
   const setup = $redistributableInstalls[download.id];
   if (
     (download.status === 'setup-complete' || download.status === 'seeding') &&

--- a/application/src/lib/electron-rpc.ts
+++ b/application/src/lib/electron-rpc.ts
@@ -154,7 +154,11 @@ export const ElectronRpc = {
       'app.removeApp',
       [Schema.Number],
       opaque<
-        | { status: 'success'; warning?: string }
+        | {
+            status: 'success';
+            warning?: string;
+            filesDeleted?: boolean;
+          }
         | { status: 'cancelled'; message: string }
         | { status: 'error'; error: string }
       >()
@@ -169,7 +173,6 @@ export const ElectronRpc = {
       Schema.Literal(
         'setup-failed',
         'setup-success',
-        'setup-redistributables-failed',
         'setup-redistributables-success',
         'setup-prefix-required'
       )

--- a/application/src/lib/electron-rpc.ts
+++ b/application/src/lib/electron-rpc.ts
@@ -204,7 +204,7 @@ export const ElectronRpc = {
     installRedistributables: rpc(
       'app.installRedistributables',
       [Schema.Number, OptionalString],
-      Schema.Literal('success', 'failed', 'not-found')
+      Schema.Literal('success', 'partial', 'failed', 'not-found')
     ),
     checkUmuInstalled: rpc('app.checkUmuInstalled', [], Schema.Boolean),
     installUmu: rpc(
@@ -220,7 +220,7 @@ export const ElectronRpc = {
     installRedistributablesUmu: rpc(
       'app.installRedistributablesUmu',
       [Schema.Number],
-      Schema.Literal('success', 'failed', 'not-found')
+      Schema.Literal('success', 'partial', 'failed', 'not-found')
     ),
     migrateToUmu: rpc(
       'app.migrateToUmu',

--- a/packages/addon-server/package.json
+++ b/packages/addon-server/package.json
@@ -39,7 +39,7 @@
     "@ogi-sdk/logger": "^1.0.0",
     "effect": "^3.22.0",
     "elysia": "^1.4.28",
-    "ogi-addon": "^4.1.0",
+    "ogi-addon": "^5.0.0",
     "websocket": "^1.0.35",
     "ws": "^8.20.0"
   },

--- a/packages/client-kit/package.json
+++ b/packages/client-kit/package.json
@@ -35,7 +35,7 @@
     "@ogi-sdk/errors": "^1.0.0",
     "@ogi-sdk/logger": "^1.0.0",
     "effect": "^3.22.0",
-    "ogi-addon": "^4.1.0",
+    "ogi-addon": "^5.0.0",
     "ws": "^8.20.0"
   },
   "description": "Client SDK for connecting OpenGameInstaller to addon servers.",

--- a/packages/connection/lib/protocol.ts
+++ b/packages/connection/lib/protocol.ts
@@ -603,10 +603,19 @@ export type AddonProtocolEventListenerTypes<
 
 /** Local SDK lifecycle hooks (not declared in `addonProtocol.serverToAddon`). */
 export type AddonSDKLifecycleEventListenerTypes<EventResponse> = {
-  connect: (event: EventResponse) => void;
+  connect: (event: EventResponse, context?: OGIAddonConnectContext) => void;
   disconnect: (reason: string) => void;
   exit: () => void;
   response: (response: unknown) => void;
+};
+
+/**
+ * Context passed to the addon SDK `connect` listener. `gameSpecificLaunch` is
+ * true when this session was started for a specific game (Steam shortcut
+ * launch), so addons can selectively start only the components they need.
+ */
+export type OGIAddonConnectContext = {
+  gameSpecificLaunch: boolean;
 };
 
 /** Host-side events emitted by `@ogi-sdk/addon-server`. */

--- a/packages/executor/lib/addon.ts
+++ b/packages/executor/lib/addon.ts
@@ -30,7 +30,7 @@ export type AddonConfig = {
   readonly path: string;
   readonly name: string;
   /** True when this session was launched for a specific game (Steam shortcut). */
-  readonly gameLaunch?: boolean;
+  readonly gameSpecificLaunch?: boolean;
   scripts: AddonFileConfiguration['scripts'];
 };
 
@@ -158,7 +158,7 @@ export class Addon {
           // Flag game-specific launches so the addon SDK can expose it on connect
           env: {
             ...process.env,
-            ...(this.config.gameLaunch ? { OGI_GAME_LAUNCH: '1' } : {}),
+            ...(this.config.gameSpecificLaunch ? { OGI_GAME_LAUNCH: '1' } : {}),
           },
           stdio: ['ignore', 'pipe', 'pipe'],
         }),

--- a/packages/executor/lib/addon.ts
+++ b/packages/executor/lib/addon.ts
@@ -29,6 +29,8 @@ export type AddonConfig = {
   readonly secret: string;
   readonly path: string;
   readonly name: string;
+  /** True when this session was launched for a specific game (Steam shortcut). */
+  readonly gameLaunch?: boolean;
   scripts: AddonFileConfiguration['scripts'];
 };
 
@@ -153,6 +155,11 @@ export class Addon {
       try: () =>
         spawn(command, args, {
           cwd: this.config.path,
+          // Flag game-specific launches so the addon SDK can expose it on connect
+          env: {
+            ...process.env,
+            ...(this.config.gameLaunch ? { OGI_GAME_LAUNCH: '1' } : {}),
+          },
           stdio: ['ignore', 'pipe', 'pipe'],
         }),
       catch: (cause) =>

--- a/packages/executor/lib/addon.ts
+++ b/packages/executor/lib/addon.ts
@@ -151,13 +151,15 @@ export class Addon {
     command: string,
     args: string[]
   ): Effect.Effect<ChildProcess, AddonError> {
+    // Strip any inherited flag so only the session config decides the value
+    const { OGI_GAME_LAUNCH: _inheritedFlag, ...inheritedEnv } = process.env;
     return Effect.try({
       try: () =>
         spawn(command, args, {
           cwd: this.config.path,
           // Flag game-specific launches so the addon SDK can expose it on connect
           env: {
-            ...process.env,
+            ...inheritedEnv,
             ...(this.config.gameSpecificLaunch ? { OGI_GAME_LAUNCH: '1' } : {}),
           },
           stdio: ['ignore', 'pipe', 'pipe'],

--- a/packages/ogi-addon/package.json
+++ b/packages/ogi-addon/package.json
@@ -3,7 +3,7 @@
   "module": "./build/main.mjs",
   "type": "module",
   "main": "./build/main.cjs",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "exports": {
     ".": {
       "import": {

--- a/packages/ogi-addon/src/EventResponse.test.ts
+++ b/packages/ogi-addon/src/EventResponse.test.ts
@@ -1,60 +1,57 @@
 import { describe, expect, test } from 'bun:test';
-import { AddonError } from '@ogi-sdk/errors';
-import { Effect } from 'effect';
 import EventResponse from './EventResponse';
 
-describe('EventResponse deferred effects', () => {
+describe('EventResponse deferred work', () => {
   test('provides deferred work registered before supervision starts', async () => {
     const event = new EventResponse<void>();
-    event.defer(() => Effect.sync(() => event.complete()));
+    event.defer(() => event.complete());
 
-    const deferred = await Effect.runPromise(event.awaitDeferredEffect());
-    expect(deferred).toBeDefined();
-    await Effect.runPromise(deferred!);
+    const work = await event.nextDeferred();
+    expect(work).toBeDefined();
+    await work!();
     expect(event.resolved).toBe(true);
   });
 
   test('waits for deferred work registered asynchronously', async () => {
     const event = new EventResponse<string>();
-    const deferredPromise = Effect.runPromise(event.awaitDeferredEffect());
+    const workPromise = event.nextDeferred();
 
     await Promise.resolve();
-    event.defer(() => Effect.sync(() => event.resolve('done')));
+    event.defer(() => event.resolve('done'));
 
-    const deferred = await deferredPromise;
-    expect(deferred).toBeDefined();
-    await Effect.runPromise(deferred!);
+    const work = await workPromise;
+    expect(work).toBeDefined();
+    await work!();
     expect(event.data).toBe('done');
   });
 
-  test('maps a rejected deferred promise to AddonError', async () => {
+  test('surfaces a rejected deferred promise to the supervisor', async () => {
     const event = new EventResponse<void>();
     event.defer(() => Promise.reject(new Error('deferred failure')));
 
-    const deferred = await Effect.runPromise(event.awaitDeferredEffect());
-    expect(deferred).toBeDefined();
-    const result = await Effect.runPromise(deferred!.pipe(Effect.either));
-    expect(result._tag).toBe('Left');
-    if (result._tag === 'Left') expect(result.left).toBeInstanceOf(AddonError);
+    const work = await event.nextDeferred();
+    expect(work).toBeDefined();
+    await expect(work!()).rejects.toThrow('deferred failure');
+    expect(event.resolved).toBe(false);
   });
 
   test('releases a waiting supervisor when the event resolves directly', async () => {
     const event = new EventResponse<string>();
-    const deferredPromise = Effect.runPromise(event.awaitDeferredEffect());
+    const workPromise = event.nextDeferred();
 
     event.resolve('done');
 
-    expect(await deferredPromise).toBeUndefined();
+    expect(await workPromise).toBeUndefined();
     expect(event.data).toBe('done');
   });
 
   test('releases a waiting supervisor when the event fails', async () => {
     const event = new EventResponse<string>();
-    const deferredPromise = Effect.runPromise(event.awaitDeferredEffect());
+    const workPromise = event.nextDeferred();
 
     event.fail('failed');
 
-    expect(await deferredPromise).toBeUndefined();
+    expect(await workPromise).toBeUndefined();
     expect(event.failed).toBe('failed');
   });
 });

--- a/packages/ogi-addon/src/EventResponse.ts
+++ b/packages/ogi-addon/src/EventResponse.ts
@@ -98,6 +98,7 @@ export default class EventResponse<T> {
         new AddonError({ message: 'No input callback is registered' })
       );
     }
-    return Promise.resolve(this.onInputAsked(screen, name, description));
+    const callback = this.onInputAsked;
+    return Promise.resolve().then(() => callback(screen, name, description));
   }
 }

--- a/packages/ogi-addon/src/EventResponse.ts
+++ b/packages/ogi-addon/src/EventResponse.ts
@@ -1,16 +1,15 @@
 import { AddonError } from '@ogi-sdk/errors';
-import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
-import { Effect } from 'effect';
 import { ConfigurationBuilder } from './config/ConfigurationBuilder';
-
-const logger = createLogger(LOGGER_PREFIXES.addon);
 
 type InputValues = Record<string, string | number | boolean>;
 type InputCallback = <U extends InputValues>(
   screen: ConfigurationBuilder<U>,
   name: string,
   description: string
-) => Effect.Effect<U, AddonError> | Promise<U>;
+) => Promise<U>;
+
+/** Work registered by addon code to run while the event is deferred. */
+export type DeferredWork = () => void | Promise<void>;
 
 export default class EventResponse<T> {
   data: T | undefined = undefined;
@@ -19,70 +18,37 @@ export default class EventResponse<T> {
   progress: number = 0;
   logs: string[] = [];
   failed: string | undefined = undefined;
-  onInputAsked?: InputCallback;
-  private readonly deferredEffects: Effect.Effect<void, unknown>[] = [];
+  private onInputAsked?: InputCallback;
+  private readonly deferredQueue: DeferredWork[] = [];
   private readonly deferredWaiters = new Set<
-    (effect: Effect.Effect<void, unknown> | undefined) => void
+    (work: DeferredWork | undefined) => void
   >();
 
   constructor(onInputAsked?: InputCallback) {
     this.onInputAsked = onInputAsked;
   }
 
-  public defer(
-    effect?: () => Effect.Effect<void, unknown> | Promise<void>
-  ): void {
+  public defer(work?: DeferredWork): void {
     this.deffered = true;
-    if (!effect) return;
+    if (!work) return;
 
-    const deferredEffect = Effect.try({
-      try: effect,
-      catch: (cause) =>
-        new AddonError({
-          message: `Deferred event failed: ${String(cause)}`,
-        }),
-    }).pipe(
-      Effect.flatMap((result) =>
-        Effect.isEffect(result)
-          ? result
-          : Effect.tryPromise({
-              try: () => result,
-              catch: (cause) =>
-                new AddonError({
-                  message: `Deferred event failed: ${String(cause)}`,
-                }),
-            })
-      )
-    );
     const waiter = this.deferredWaiters.values().next().value;
     if (waiter) {
       this.deferredWaiters.delete(waiter);
-      waiter(deferredEffect);
+      waiter(work);
     } else {
-      this.deferredEffects.push(deferredEffect);
+      this.deferredQueue.push(work);
     }
   }
 
-  /** Returns queued deferred work without waiting for later registrations. */
-  public takeDeferredEffect(): Effect.Effect<void, unknown> | undefined {
-    return this.deferredEffects.shift();
-  }
+  /** Resolves with queued work immediately, waits for later registrations, and resolves `undefined` once the event settles. */
+  public nextDeferred(): Promise<DeferredWork | undefined> {
+    const queued = this.deferredQueue.shift();
+    if (queued || this.resolved) return Promise.resolve(queued);
 
-  /** Waits for deferred work registered before or after event emission. */
-  public awaitDeferredEffect(): Effect.Effect<
-    Effect.Effect<void, unknown> | undefined
-  > {
-    return Effect.async((resume) => {
-      const deferredEffect = this.takeDeferredEffect();
-      if (deferredEffect || this.resolved) {
-        resume(Effect.succeed(deferredEffect));
-        return Effect.void;
-      }
-
-      const waiter = (effect: Effect.Effect<void, unknown> | undefined): void =>
-        resume(Effect.succeed(effect));
+    return new Promise((resolve) => {
+      const waiter = (work: DeferredWork | undefined): void => resolve(work);
       this.deferredWaiters.add(waiter);
-      return Effect.sync(() => this.deferredWaiters.delete(waiter));
     });
   }
 
@@ -121,46 +87,17 @@ export default class EventResponse<T> {
     this.logs.push(message);
   }
 
-  /** Effect-native input request API. */
-  public askForInputEffect<U extends InputValues>(
-    name: string,
-    description: string,
-    screen: ConfigurationBuilder<U>
-  ): Effect.Effect<U, AddonError> {
-    if (!this.onInputAsked) {
-      return Effect.fail(
-        new AddonError({ message: 'No input callback is registered' })
-      );
-    }
-    return Effect.try({
-      try: () => this.onInputAsked!(screen, name, description),
-      catch: (cause) =>
-        new AddonError({
-          message: `Input request failed: ${String(cause)}`,
-        }),
-    }).pipe(
-      Effect.flatMap((result) =>
-        Effect.isEffect(result)
-          ? result
-          : Effect.tryPromise({
-              try: () => result,
-              catch: (cause) =>
-                new AddonError({
-                  message: `Input request failed: ${String(cause)}`,
-                }),
-            })
-      )
-    );
-  }
-
-  /** Promise compatibility adapter for existing addon implementations. */
+  /** Ask the user for input; rejects with an {@link AddonError} when no callback is registered. */
   public askForInput<U extends InputValues>(
     name: string,
     description: string,
     screen: ConfigurationBuilder<U>
   ): Promise<U> {
-    return Effect.runPromise(
-      logger.observe(this.askForInputEffect(name, description, screen))
-    );
+    if (!this.onInputAsked) {
+      return Promise.reject(
+        new AddonError({ message: 'No input callback is registered' })
+      );
+    }
+    return Promise.resolve(this.onInputAsked(screen, name, description));
   }
 }

--- a/packages/ogi-addon/src/extraction.ts
+++ b/packages/ogi-addon/src/extraction.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import * as fsAsync from 'node:fs/promises';
 import { join } from 'node:path';
 import { FileSystemError, PlatformError } from '@ogi-sdk/errors';
+import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect } from 'effect';
 import {
   detectUnarFromVersionOutput,
@@ -14,6 +15,8 @@ import {
   parseZipInfoTotal,
   type UnrarType,
 } from './extraction-progress';
+
+const logger = createLogger(LOGGER_PREFIXES.addon);
 
 const sevenZipPath = 'C:\\Program Files\\7-Zip\\7z.exe';
 const progressPollIntervalMs = 150;
@@ -230,7 +233,7 @@ const reportProgress = (
   }
 };
 
-export const extraction = (
+const extractArchiveEffect = (
   filePath: string,
   outputDir: string,
   onProgress?: ExtractionProgressCallback
@@ -401,3 +404,13 @@ export const extraction = (
       )
     );
   });
+
+/** Promise-based archive extraction; the Effect pipeline stays internal. */
+export const extraction = (
+  filePath: string,
+  outputDir: string,
+  onProgress?: ExtractionProgressCallback
+): Promise<void> =>
+  Effect.runPromise(
+    logger.observe(extractArchiveEffect(filePath, outputDir, onProgress))
+  );

--- a/packages/ogi-addon/src/main.ts
+++ b/packages/ogi-addon/src/main.ts
@@ -109,7 +109,7 @@ export type EventListenerTypes = AddonSDKLifecycleEventListenerTypes<
  */
 export default class OGIAddon {
   public eventEmitter = new events.EventEmitter();
-  public addonWSListener: OGIAddonWSListener;
+  private readonly addonWSListener: OGIAddonWSListener;
   public addonInfo: OGIAddonConfiguration;
   public config: Configuration = new Configuration({});
   private eventsAvailable: OGIAddonSDKEventListener[] = [];
@@ -132,8 +132,11 @@ export default class OGIAddon {
     // The constructor remains the synchronous compatibility boundary for addons.
     this.addonWSListener = this.runtime.runSync(
       logger.observe(
-        OGIAddonWSListener.make(this, this.eventEmitter, (effect) =>
-          this.runBackground(effect)
+        OGIAddonWSListener.make(
+          this,
+          this.eventEmitter,
+          (effect) => this.runBackground(effect),
+          () => this.sendEventsAvailable()
         )
       )
     );
@@ -154,7 +157,7 @@ export default class OGIAddon {
     return this.runtime.runPromise(logger.observe(effect));
   }
 
-  public closeEffect(): Effect.Effect<void, NetworkError> {
+  private closeEffect(): Effect.Effect<void, NetworkError> {
     return this.addonWSListener.close();
   }
 
@@ -188,7 +191,7 @@ export default class OGIAddon {
     return this.eventEmitter.emit(event, ...args);
   }
 
-  public sendEventsAvailable(): Effect.Effect<
+  private sendEventsAvailable(): Effect.Effect<
     void,
     NetworkError | ValidationError
   > {
@@ -200,7 +203,7 @@ export default class OGIAddon {
       .pipe(Effect.asVoid);
   }
 
-  public notifyEffect(
+  private notifyEffect(
     notification: AddonNotificationMessage
   ): Effect.Effect<void, NetworkError | ValidationError> {
     return this.addonWSListener
@@ -219,7 +222,7 @@ export default class OGIAddon {
    * @param storefront {string}
    * @returns {Promise<StoreData>}
    */
-  public getAppDetailsEffect(
+  private getAppDetailsEffect(
     appID: number,
     storefront: string
   ): Effect.Effect<StoreData | undefined, NetworkError | ValidationError> {
@@ -237,7 +240,7 @@ export default class OGIAddon {
     return this.runPromise(this.getAppDetailsEffect(appID, storefront));
   }
 
-  public searchGameEffect(
+  private searchGameEffect(
     query: string,
     storefront: string
   ): Effect.Effect<BasicLibraryInfo[], NetworkError | ValidationError> {
@@ -259,7 +262,7 @@ export default class OGIAddon {
    * Notify the OGI Addon Server that you are performing a background task. This can be used to help users understand what is happening in the background.
    * @returns {Promise<Task>} A Task instance for managing the background task.
    */
-  public taskEffect(): Effect.Effect<Task, NetworkError | ValidationError> {
+  private taskEffect(): Effect.Effect<Task, NetworkError | ValidationError> {
     return Effect.gen(this, function* () {
       const id = yield* randomMessageId();
       const progress = 0;
@@ -422,15 +425,6 @@ export class Task {
    * Log a message to the task. Returns this for chaining.
    * @param message {string} The message to log.
    */
-  logEffect(
-    message: string
-  ): Effect.Effect<void, NetworkError | ValidationError> {
-    return Effect.sync(() => {
-      if (this.event) this.event.log(message);
-      else this.logs.push(message);
-    }).pipe(Effect.zipRight(this.update()));
-  }
-
   log(message: string): this {
     if (this.event) this.event.log(message);
     else {
@@ -444,15 +438,6 @@ export class Task {
    * Set the progress of the task (0-100). Returns this for chaining.
    * @param progress {number} The progress value (0-100).
    */
-  setProgressEffect(
-    progress: number
-  ): Effect.Effect<void, NetworkError | ValidationError> {
-    return Effect.sync(() => {
-      if (this.event) this.event.progress = progress;
-      else this.progress = progress;
-    }).pipe(Effect.zipRight(this.update()));
-  }
-
   setProgress(progress: number): this {
     if (this.event) this.event.progress = progress;
     else {
@@ -465,13 +450,6 @@ export class Task {
   /**
    * Complete the task successfully.
    */
-  completeEffect(): Effect.Effect<void, NetworkError | ValidationError> {
-    return Effect.sync(() => {
-      if (this.event) this.event.complete();
-      else this.finished = true;
-    }).pipe(Effect.zipRight(this.update()));
-  }
-
   complete(): void {
     if (this.event) this.event.complete();
     else {
@@ -484,15 +462,6 @@ export class Task {
    * Fail the task with an error message.
    * @param message {string} The error message.
    */
-  failEffect(
-    message: string
-  ): Effect.Effect<void, NetworkError | ValidationError> {
-    return Effect.sync(() => {
-      if (this.event) this.event.fail(message);
-      else this.failed = message;
-    }).pipe(Effect.zipRight(this.update()));
-  }
-
   fail(message: string): void {
     if (this.event) this.event.fail(message);
     else {
@@ -511,31 +480,20 @@ export class Task {
    * @returns {Promise<U>} The user's input with types matching the configuration options.
    * @throws {Error} If called on a WebSocket-based task.
    */
-  askForInputEffect<U extends Record<string, string | number | boolean>>(
+  askForInput<U extends Record<string, string | number | boolean>>(
     name: string,
     description: string,
     screen: ConfigurationBuilder<U>
-  ): Effect.Effect<U, AddonError> {
+  ): Promise<U> {
     if (!this.event) {
-      return Effect.fail(
+      return Promise.reject(
         new AddonError({
           message:
             'askForInput() is only available for EventResponse-based tasks (onTask handlers)',
         })
       );
     }
-    return this.event.askForInputEffect(name, description, screen);
-  }
-
-  /** Promise compatibility adapter. */
-  askForInput<U extends Record<string, string | number | boolean>>(
-    name: string,
-    description: string,
-    screen: ConfigurationBuilder<U>
-  ): Promise<U> {
-    return Effect.runPromise(
-      logger.observe(this.askForInputEffect(name, description, screen))
-    );
+    return this.event.askForInput(name, description, screen);
   }
 
   /**
@@ -652,7 +610,11 @@ class OGIAddonWSListener {
       AddonClientToServerWebsocketMessage
     >,
     private readonly secret: string,
-    private readonly schedule: EffectScheduler
+    private readonly schedule: EffectScheduler,
+    private readonly sendEventsAvailable: () => Effect.Effect<
+      void,
+      NetworkError | ValidationError
+    >
   ) {
     this.addon = addon;
     this.eventEmitter = eventEmitter;
@@ -661,7 +623,11 @@ class OGIAddonWSListener {
   public static make(
     addon: OGIAddon,
     eventEmitter: events.EventEmitter,
-    schedule: EffectScheduler
+    schedule: EffectScheduler,
+    sendEventsAvailable: () => Effect.Effect<
+      void,
+      NetworkError | ValidationError
+    >
   ): Effect.Effect<OGIAddonWSListener, AddonError | NetworkError> {
     return Effect.gen(function* () {
       const secret = process.argv
@@ -705,7 +671,8 @@ class OGIAddonWSListener {
         socket,
         transport,
         secret,
-        schedule
+        schedule,
+        sendEventsAvailable
       );
       yield* listener.registerMessageReceiver();
       return listener;
@@ -850,9 +817,13 @@ class OGIAddonWSListener {
           if (!this.configConnected) {
             this.configConnected = true;
             const connectEvent = this.makeEventResponse<void>();
-            this.eventEmitter.emit('connect', connectEvent);
-            this.schedule(this.runDeferredEffect(connectEvent));
-            yield* this.addon.sendEventsAvailable();
+            // Game-specific launches (Steam shortcut) set OGI_GAME_LAUNCH so
+            // addons can selectively start only the components they need.
+            this.eventEmitter.emit('connect', connectEvent, {
+              gameSpecificLaunch: process.env.OGI_GAME_LAUNCH === '1',
+            });
+            this.schedule(this.runDeferred(connectEvent));
+            yield* this.sendEventsAvailable();
           }
           yield* this.respondToMessage(
             id,
@@ -919,26 +890,29 @@ class OGIAddonWSListener {
 
   private makeEventResponse<T>(): EventResponse<T> {
     return new EventResponse<T>((screen, name, description) =>
-      this.userInputAsked(screen, name, description).pipe(
-        Effect.mapError(
-          (error) => new AddonError({ message: formatError(error) })
+      Effect.runPromise(
+        logger.observe(
+          this.userInputAsked(screen, name, description).pipe(
+            Effect.mapError(
+              (error) => new AddonError({ message: formatError(error) })
+            )
+          )
         )
       )
     );
   }
 
-  private runDeferredEffect(
-    event: EventResponse<unknown>
-  ): Effect.Effect<void> {
-    return Effect.gen(function* () {
+  /** Promise pump over the event's deferred work, wrapped for the Effect scheduler. */
+  private runDeferred(event: EventResponse<unknown>): Effect.Effect<void> {
+    return Effect.promise(async () => {
       while (!event.resolved) {
-        const deferred = yield* event.awaitDeferredEffect();
-        if (!deferred) return;
-        yield* deferred.pipe(
-          Effect.catchAll((error) =>
-            Effect.sync(() => event.fail(formatError(error)))
-          )
-        );
+        const work = await event.nextDeferred();
+        if (!work) return;
+        try {
+          await work();
+        } catch (cause) {
+          event.fail(formatError(cause));
+        }
       }
     });
   }
@@ -967,7 +941,7 @@ class OGIAddonWSListener {
       Effect.gen(this, function* () {
         const event = this.makeEventResponse<SetupResponse>();
         this.eventEmitter.emit('setup', message.args, event);
-        yield* Effect.forkScoped(this.runDeferredEffect(event));
+        yield* Effect.forkScoped(this.runDeferred(event));
         yield* Effect.forkScoped(this.reportDeferred(event, message.id!));
         const result = yield* this.waitForEventToRespond(event);
         yield* this.respondToMessage(message.id!, result.data, event);
@@ -994,7 +968,7 @@ class OGIAddonWSListener {
           info: SearchResult;
         };
         this.eventEmitter.emit('request-dl', appID, info, event);
-        yield* Effect.forkScoped(this.runDeferredEffect(event));
+        yield* Effect.forkScoped(this.runDeferred(event));
         const result = yield* this.waitForEventToRespond(event);
         if (event.failed) {
           yield* this.respondToMessage(message.id!, undefined, event);
@@ -1113,7 +1087,7 @@ class OGIAddonWSListener {
           return;
         }
         emit(event);
-        yield* Effect.forkScoped(this.runDeferredEffect(event));
+        yield* Effect.forkScoped(this.runDeferred(event));
         const result = yield* this.waitForEventToRespond(event);
         yield* this.respondToMessage(message.id!, result.data, event);
       })
@@ -1128,7 +1102,7 @@ class OGIAddonWSListener {
       Effect.gen(this, function* () {
         const event = new EventResponse<T>();
         emit(event);
-        yield* Effect.forkScoped(this.runDeferredEffect(event));
+        yield* Effect.forkScoped(this.runDeferred(event));
         const result = yield* this.waitForEventToRespond(event);
         yield* this.respondToMessage(message.id!, result.data, event);
       })


### PR DESCRIPTION
# Description

A batch of library/launch quality-of-life changes plus the removal of all effectual (Effect-typed) APIs from the `ogi-addon` public surface.

- **Remove Game now deletes files**: removing a game from the library also deletes its install directory (`cwd`). Deletion failures surface as a warning instead of failing the removal.
- **Redistributable failures are non-fatal**: a failed redistributable no longer fails the whole setup — per-item warnings still show, and the Steam shortcut is added either way (Linux UMU flow) or the game is kept in the library (Windows flow).
- **Show in Folder**: new button in the per-game configuration modal, opening the game's install directory via the existing `fs:show-file-loc` IPC.
- **Launch despite addon failure**: when pre-launch addon hooks fail, PlayPage and the GameLaunchOverlay (wrapper launches) now prompt with Launch Anyway / Cancel instead of hard-failing.
- **Game-specific launch context**: addons receive a second argument on their `connect` listener: `{ gameSpecificLaunch: boolean }`. OGI threads an `OGI_GAME_LAUNCH=1` env var from `--game-id` detection through the executor spawn so addons can selectively start components.
- **ogi-addon API cleanup**: all `*Effect` publics on `OGIAddon`, `Task`, and `EventResponse` are private or removed; `extraction` is exported as a promise; `EventResponse.defer` takes plain thunks and `nextDeferred()` replaces the Effect-based deferred accessors. Effects remain internal implementation detail only — verified via generated d.ts.

# Example

```ts
// addon side
ogi.on('connect', (_event, context) => {
  if (!context?.gameSpecificLaunch) startHeavyComponents();
});
```

# Next Steps

- [ ] Manual pass: remove a game, force a redistributable failure, and launch with a broken addon hook
- [ ] Consider deleting the per-game UMU wine prefix on remove as well
- [ ] Hide `Task`'s constructor overloads that reference the unexported `OGIAddonWSListener` type
- [ ] Bump package versions for `@ogi-sdk/connect` / `@ogi-sdk/executor` / `ogi-addon`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Show in Folder” for configured game directories.
  - Added confirmation before removing games.
  - Added “Launch Anyway” or “Cancel” options when an addon fails before launch.
  - Game-specific launches now provide improved addon context.
  - Added retry handling for failed redistributable installations.

- **Bug Fixes**
  - Prevented deletion of protected, shared, or active game directories.
  - Removal now reports whether files were deleted.
  - Partial redistributable failures no longer block setup.
  - Improved archive extraction errors and prompt cancellation.

- **Improvements**
  - Simplified addon event handling and extraction behavior with Promise-based APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->