### PR TITLE
fix(application/updater): desktop shortcut icon survives updates on linux

### DIFF
--- a/application/src/electron/handlers/handler.app.ts
+++ b/application/src/electron/handlers/handler.app.ts
@@ -1,6 +1,5 @@
 import * as fs from 'node:fs';
 import * as fsAsync from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { join } from 'node:path';
 import {
@@ -17,7 +16,7 @@ import { registerRedistributableHandlers } from '@/electron/handlers/handler.red
 import { registerSteamHandlers } from '@/electron/handlers/handler.steam.js';
 import { getEffectiveOnlineState } from '@/electron/lib/online.js';
 import { currentScreens, screenInputCallbacks } from '@/electron/main.js';
-import { __dirname, isDev } from '@/electron/manager/manager.paths.js';
+import { __dirname } from '@/electron/manager/manager.paths.js';
 import {
   ipcProcedure,
   mergeRouters,
@@ -28,6 +27,7 @@ import { runEffectBoundary as runBoundary } from '@/electron/runtime.js';
 import { addonServer } from '@/electron/server/addon-server.js';
 import type { OperatingSystem } from '@/lib/electron-rpc.js';
 import { ElectronRpc } from '@/lib/electron-rpc.js';
+import { addToDesktop } from './helpers.app/desktop-shortcut.js';
 import { getCurrentUsername } from './helpers.app/platform.js';
 
 export function escapeShellArg(arg: string): string {
@@ -37,71 +37,6 @@ export function escapeShellArg(arg: string): string {
     .replace(/\$/g, '\\$')
     .replace(/`/g, '\\`');
 }
-
-export const addToDesktop = (): Effect.Effect<
-  { success: true; path: string } | { success: false; error: string },
-  FileSystemError
-> => {
-  if (process.platform === 'win32') {
-    return Effect.succeed({
-      success: false,
-      error: 'This feature is only available on Linux',
-    });
-  }
-  return Effect.gen(function* () {
-    let appDirPath = isDev()
-      ? `${app.getAppPath()}/../`
-      : path.dirname(process.execPath);
-    if (process.platform === 'linux') appDirPath = './';
-    let execPath = path.resolve(
-      appDirPath,
-      fs.readdirSync(appDirPath).find((file) => file.endsWith('.AppImage')) ??
-        './OpenGameInstaller.AppImage'
-    );
-    const desktopDir = path.join(os.homedir(), 'Desktop');
-    const desktopFilePath = path.join(desktopDir, 'OpenGameInstaller.desktop');
-    yield* Effect.tryPromise({
-      try: () => fsAsync.mkdir(desktopDir, { recursive: true }),
-      catch: (cause) =>
-        new FileSystemError({
-          message: formatError(cause),
-          path: desktopDir,
-          cause,
-        }),
-    });
-    const setupPath = path.resolve(
-      path.resolve(appDirPath, '..'),
-      'OpenGameInstaller-Setup.AppImage'
-    );
-    if (fs.existsSync(setupPath)) execPath = setupPath;
-    const sourceIcon = app.isPackaged
-      ? path.join(app.getPath('exe'), '..', 'opengameinstaller-gui.png')
-      : path.join(__dirname, '..', '..', 'public', 'favicon.png');
-    const targetIcon = path.join(appDirPath, 'favicon.png');
-    yield* Effect.tryPromise({
-      try: () => fsAsync.copyFile(sourceIcon, targetIcon),
-      catch: (cause) =>
-        new FileSystemError({
-          message: formatError(cause),
-          path: sourceIcon,
-          cause,
-        }),
-    });
-    const absoluteIcon = path.resolve(targetIcon);
-    const desktopContent = `[Desktop Entry]\nType=Application\nName=OpenGameInstaller\nExec=${execPath}\nPath=${execPath.endsWith('-Setup.AppImage') ? path.resolve(appDirPath, '..') : path.resolve(appDirPath)}\nIcon=${absoluteIcon}\nTerminal=false\nCategories=Game;\nStartupNotify=true\n`;
-    yield* Effect.tryPromise({
-      try: () =>
-        fsAsync.writeFile(desktopFilePath, desktopContent, { mode: 0o755 }),
-      catch: (cause) =>
-        new FileSystemError({
-          message: formatError(cause),
-          path: desktopFilePath,
-          cause,
-        }),
-    });
-    return { success: true as const, path: desktopFilePath };
-  });
-};
 
 const axiosRequest = (
   options: AxiosRequestConfig

--- a/application/src/electron/handlers/helpers.app/desktop-shortcut.ts
+++ b/application/src/electron/handlers/helpers.app/desktop-shortcut.ts
@@ -1,0 +1,75 @@
+import * as fs from 'node:fs';
+import * as fsAsync from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { FileSystemError, formatError } from '@ogi-sdk/errors';
+import { Effect } from 'effect';
+import { app } from 'electron';
+import { __dirname, isDev } from '@/electron/manager/manager.paths.js';
+
+export const addToDesktop = (): Effect.Effect<
+  { success: true; path: string } | { success: false; error: string },
+  FileSystemError
+> => {
+  if (process.platform === 'win32') {
+    return Effect.succeed({
+      success: false,
+      error: 'This feature is only available on Linux',
+    });
+  }
+  return Effect.gen(function* () {
+    let appDirPath = isDev()
+      ? `${app.getAppPath()}/../`
+      : path.dirname(process.execPath);
+    if (process.platform === 'linux') appDirPath = './';
+    let execPath = path.resolve(
+      appDirPath,
+      fs.readdirSync(appDirPath).find((file) => file.endsWith('.AppImage')) ??
+        './OpenGameInstaller.AppImage'
+    );
+    const desktopDir = path.join(os.homedir(), 'Desktop');
+    const desktopFilePath = path.join(desktopDir, 'OpenGameInstaller.desktop');
+    yield* Effect.tryPromise({
+      try: () => fsAsync.mkdir(desktopDir, { recursive: true }),
+      catch: (cause) =>
+        new FileSystemError({
+          message: formatError(cause),
+          path: desktopDir,
+          cause,
+        }),
+    });
+    const setupPath = path.resolve(
+      path.resolve(appDirPath, '..'),
+      'OpenGameInstaller-Setup.AppImage'
+    );
+    if (fs.existsSync(setupPath)) execPath = setupPath;
+    const sourceIcon = app.isPackaged
+      ? path.join(app.getPath('exe'), '..', 'opengameinstaller-gui.png')
+      : path.join(__dirname, '..', '..', 'public', 'favicon.png');
+    // The icon must live in the OGI data dir: the updater wipes the update/
+    // cwd on every update, which would delete an icon stored next to the app.
+    const targetIcon = path.join(__dirname, 'favicon.png');
+    yield* Effect.tryPromise({
+      try: () => fsAsync.copyFile(sourceIcon, targetIcon),
+      catch: (cause) =>
+        new FileSystemError({
+          message: formatError(cause),
+          path: sourceIcon,
+          cause,
+        }),
+    });
+    const absoluteIcon = path.resolve(targetIcon);
+    const desktopContent = `[Desktop Entry]\nType=Application\nName=OpenGameInstaller\nExec=${execPath}\nPath=${execPath.endsWith('-Setup.AppImage') ? path.resolve(appDirPath, '..') : path.resolve(appDirPath)}\nIcon=${absoluteIcon}\nTerminal=false\nCategories=Game;\nStartupNotify=true\n`;
+    yield* Effect.tryPromise({
+      try: () =>
+        fsAsync.writeFile(desktopFilePath, desktopContent, { mode: 0o755 }),
+      catch: (cause) =>
+        new FileSystemError({
+          message: formatError(cause),
+          path: desktopFilePath,
+          cause,
+        }),
+    });
+    return { success: true as const, path: desktopFilePath };
+  });
+};

--- a/application/src/electron/migrations.ts
+++ b/application/src/electron/migrations.ts
@@ -4,9 +4,10 @@ import { exec, spawn } from 'child_process';
 import { Effect } from 'effect';
 import * as fsSync from 'fs';
 import * as fs from 'fs/promises';
+import * as os from 'os';
 import { join } from 'path';
 import semver from 'semver';
-import { addToDesktop } from '@/electron/handlers/handler.app.js';
+import { addToDesktop } from '@/electron/handlers/helpers.app/desktop-shortcut.js';
 import { normalizeAddonLink } from '@/electron/lib/addon-links.js';
 import { migrateLegacySteamGridDbKey } from '@/electron/lib/steam-grid-db.js';
 import { sendIPCMessage, sendNotification, VERSION } from '@/electron/main.js';
@@ -278,6 +279,24 @@ let migrations: {
           )
         )
       ),
+  },
+  'repair-desktop-shortcut-icon': {
+    from: '2.5.0',
+    to: '4.3.0',
+    description:
+      'Rewrites the desktop shortcut so its icon lives in the OGI data dir instead of the update dir the updater wipes.',
+    platform: 'linux',
+    run: () =>
+      Effect.gen(function* () {
+        const desktopFilePath = join(
+          os.homedir(),
+          'Desktop',
+          'OpenGameInstaller.desktop'
+        );
+        // If the user removed the shortcut, respect that and do nothing.
+        if (!fsSync.existsSync(desktopFilePath)) return;
+        yield* addToDesktop();
+      }),
   },
   'migrate-addon-source-associations': {
     from: '0.0.0',

--- a/application/tests/desktop-shortcut.test.ts
+++ b/application/tests/desktop-shortcut.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Effect } from 'effect';
+
+// Layout mirrors a real Linux install: the updater launches the AppImage with
+// cwd = <updater>/update, wipes that directory on every update (keeping only
+// artifacts/latest.log/logs), and the OGI data dir lives elsewhere.
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ogi-desktop-shortcut-'));
+const updateDir = path.join(root, 'updater', 'update');
+const homeDir = path.join(root, 'home');
+const dataDir = path.join(root, 'data', 'OpenGameInstaller');
+
+mock.module('electron', () => ({
+  app: {
+    isPackaged: false,
+    getAppPath: () => root,
+    getPath: () => root,
+  },
+}));
+// manager.paths caches __dirname at first import, and other test files may
+// import it earlier with their own OGI_DIRECTORY — mock it directly instead.
+mock.module('@/electron/manager/manager.paths.js', () => ({
+  __dirname: dataDir,
+  isDev: () => false,
+}));
+// Bun's os.homedir() ignores $HOME, so redirect it to keep the real
+// ~/Desktop untouched.
+mock.module('node:os', () => ({ ...os, homedir: () => homeDir }));
+
+let addToDesktop: typeof import('../src/electron/handlers/helpers.app/desktop-shortcut.js').addToDesktop;
+
+const originalCwd = process.cwd();
+
+beforeAll(async () => {
+  fs.mkdirSync(updateDir, { recursive: true });
+  fs.mkdirSync(homeDir, { recursive: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  // dev-mode source icon resolves to <__dirname>/../../public/favicon.png
+  fs.mkdirSync(path.join(root, 'public'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'public', 'favicon.png'), 'icon-bytes');
+  fs.writeFileSync(
+    path.join(updateDir, 'OpenGameInstaller.AppImage'),
+    'app-bytes'
+  );
+  process.chdir(updateDir);
+  ({ addToDesktop } = await import(
+    '../src/electron/handlers/helpers.app/desktop-shortcut.js'
+  ));
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// Same wipe the updater's prepareUpdateDestination performs before installing
+// a new release into update/.
+function simulateUpdaterWipe() {
+  const preserved = new Set(['artifacts', 'latest.log', 'logs']);
+  for (const entry of fs.readdirSync(updateDir)) {
+    if (preserved.has(entry)) continue;
+    fs.rmSync(path.join(updateDir, entry), { recursive: true, force: true });
+  }
+  fs.writeFileSync(
+    path.join(updateDir, 'OpenGameInstaller.AppImage'),
+    'new-app-bytes'
+  );
+}
+
+test('desktop shortcut icon survives an updater wipe of update/', async () => {
+  const result = await Effect.runPromise(addToDesktop());
+  expect(result.success).toBe(true);
+
+  const desktopFile = path.join(
+    homeDir,
+    'Desktop',
+    'OpenGameInstaller.desktop'
+  );
+  expect(fs.existsSync(desktopFile)).toBe(true);
+  const iconLine = fs
+    .readFileSync(desktopFile, 'utf-8')
+    .split('\n')
+    .find((line) => line.startsWith('Icon='));
+  expect(iconLine).toBeDefined();
+  const iconPath = (iconLine as string).slice('Icon='.length);
+  expect(fs.existsSync(iconPath)).toBe(true);
+
+  simulateUpdaterWipe();
+
+  expect(fs.existsSync(iconPath)).toBe(true);
+});

--- a/updater/src/main.ts
+++ b/updater/src/main.ts
@@ -131,7 +131,14 @@ const PATCH_DOWNLOAD_PROGRESS_INTERVAL_MS = 100;
 const HTTP_RETRY_ATTEMPTS = 4;
 const HTTP_RETRY_BASE_DELAY_MS = 1500;
 const HTTP_REQUEST_TIMEOUT_MS = 60000;
-const PRESERVED_UPDATE_ENTRIES = new Set(['artifacts', 'latest.log', 'logs']);
+// favicon.png is the desktop shortcut icon older app versions copied next to
+// the AppImage; deleting it would blank the user's shortcut icon.
+const PRESERVED_UPDATE_ENTRIES = new Set([
+  'artifacts',
+  'latest.log',
+  'logs',
+  'favicon.png',
+]);
 const OGI_REPO_URL = 'https://github.com/Nat3z/OpenGameInstaller';
 const ALL_ORIGIN_HEADS_REFSPEC = '+refs/heads/*:refs/remotes/origin/*';
 const HTTP_RANGE_AGENTS = {


### PR DESCRIPTION
# Description

On Linux, `addToDesktop()` copied the shortcut icon to `./favicon.png` — but the app's cwd is the updater's `update/` directory, which `prepareUpdateDestination()` wipes on every update. The `.desktop` file's `Icon=` path then pointed at a deleted file, blanking the shortcut icon.

Fixes:

- `addToDesktop` now copies the icon into the OGI data dir (`~/.local/share/OpenGameInstaller/favicon.png`), which updates never touch. Moved it out of `handler.app.ts` into `helpers.app/desktop-shortcut.ts` so migrations and the RPC handler import a testable leaf module.
- Added a `repair-desktop-shortcut-icon` migration (linux, `2.5.0` → `4.3.0`) that rewrites the shortcut with the durable icon path — only if the user still has the `.desktop` file.
- The updater's `PRESERVED_UPDATE_ENTRIES` now keeps `favicon.png`, so shortcuts written by older app versions survive updates too.

Regression test recreates the real layout (cwd = `update/`, sandboxed home + data dirs), creates the shortcut, simulates the updater wipe, and asserts the icon path still exists. Red before the fix, green after.

# Example

```
$ bun test tests/desktop-shortcut.test.ts
 1 pass
 0 fail
```

`.desktop` now points at the durable copy:

```
Icon=/home/user/.local/share/OpenGameInstaller/favicon.png
```

# Next Steps

- Lower the migration's `to: 4.3.0` bound if the next release is 4.2.10 instead.
- Optionally regenerate the shortcut on every launch to self-heal stale `Exec=` paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux desktop shortcut creation with support for development, installed, and setup environments.
  * Existing shortcuts are automatically refreshed during Linux migrations.

* **Bug Fixes**
  * Desktop shortcut icons now remain available after application updates and cleanup operations.

* **Tests**
  * Added coverage verifying shortcut creation and icon persistence after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->