### PR TITLE
feat(ogi-addon): addon-enqueued download queue API

### DIFF
--- a/application/src/electron/handlers/handler.ddl.ts
+++ b/application/src/electron/handlers/handler.ddl.ts
@@ -40,6 +40,7 @@ import {
   removeQueueCancel,
 } from '@/electron/rpc/queue-cancel.js';
 import { procedure, router } from '@/electron/rpc/router-core.js';
+import { setAddonDownloadContext } from '@/electron/server/addon-downloads.js';
 import {
   clearDownloadHandshake,
   type DownloadHandshakeResult,
@@ -126,7 +127,7 @@ class ThrottleStream extends Transform {
   }
 }
 
-interface DownloadJob {
+export interface DownloadJob {
   link: string;
   path: string;
   headers?: Record<string, string>;
@@ -178,7 +179,7 @@ interface ConnectionHealthMonitor {
   readonly run: Effect.Effect<never>;
 }
 
-type DownloadStatus =
+export type DownloadStatus =
   | 'queued'
   | 'downloading'
   | 'merging'
@@ -193,8 +194,30 @@ type DownloadEffectRunner = <E>(
 
 interface DownloadLifecycle {
   readonly runEffect: DownloadEffectRunner;
-  readonly onStatusChange: () => void;
-  readonly onTerminal: (id: string) => void;
+  readonly onStatusChange: (status: DownloadStatus) => void;
+  readonly onTerminal: (
+    id: string,
+    outcome: 'completed' | 'failed' | 'cancelled',
+    error?: string
+  ) => void;
+  readonly onProgress?: (data: DownloadProgress) => void;
+  readonly preservePartialFilesOnCancel?: boolean;
+}
+
+export interface DownloadProgress {
+  progress: number;
+  downloadSpeed: number;
+  queuePosition?: number;
+  part: number;
+  totalParts: number;
+  status: DownloadStatus;
+}
+
+export interface DownloadHooks {
+  readonly onProgress?: DownloadLifecycle['onProgress'];
+  readonly onTerminal?: DownloadLifecycle['onTerminal'];
+  readonly onStatusChange?: DownloadLifecycle['onStatusChange'];
+  readonly preservePartialFilesOnCancel?: boolean;
 }
 
 const standaloneDownloadLifecycle: DownloadLifecycle = {
@@ -270,7 +293,7 @@ export class Download {
 
   public set status(newStatus: DownloadStatus) {
     this._status = newStatus;
-    this.lifecycle.onStatusChange();
+    this.lifecycle.onStatusChange(newStatus);
   }
 
   private mainWindow: BrowserWindow;
@@ -508,7 +531,7 @@ export class Download {
         this.removeCancelHandler();
         this.reportHandshake({ status: 'error', error: 'Download cancelled' });
         clearDownloadHandshake(this.id);
-        this.lifecycle.onTerminal(this.id);
+        this.lifecycle.onTerminal(this.id, 'cancelled');
         return;
       }
 
@@ -1849,12 +1872,14 @@ export class Download {
         this.cleanupPart();
       }
 
-      yield* this.cleanupAllFiles();
+      if (!this.lifecycle.preservePartialFilesOnCancel) {
+        yield* this.cleanupAllFiles();
+      }
       this.removeCancelHandler();
       this.sendIpc('ddl:download-cancelled', { id: this.id });
       this.taskFinisher();
       clearDownloadHandshake(this.id);
-      this.lifecycle.onTerminal(this.id);
+      this.lifecycle.onTerminal(this.id, 'cancelled');
       logger.sync.info('[direct] Download Cancelled', this.id);
     }).pipe(Effect.ignore);
   }
@@ -1902,7 +1927,7 @@ export class Download {
       this.removeCancelHandler();
       this.taskFinisher();
       clearDownloadHandshake(this.id);
-      this.lifecycle.onTerminal(this.id);
+      this.lifecycle.onTerminal(this.id, 'completed');
     });
   }
 
@@ -1953,7 +1978,7 @@ export class Download {
           this.removeCancelHandler();
           this.taskFinisher();
           clearDownloadHandshake(this.id);
-          this.lifecycle.onTerminal(this.id);
+          this.lifecycle.onTerminal(this.id, 'failed', error.message);
         })
       ),
       Effect.ignore
@@ -2390,8 +2415,7 @@ export class Download {
             if (incompletePart) currentPartNumber = incompletePart.index + 1;
           }
 
-          this.sendIpc('ddl:download-progress', {
-            id: this.id,
+          this.sendProgress({
             progress:
               this.multiPartTotalBytes > 0
                 ? totalDownloaded / this.multiPartTotalBytes
@@ -2399,8 +2423,6 @@ export class Download {
             downloadSpeed: elapsedTime > 0 ? totalDownloaded / elapsedTime : 0,
             fileSize: this.multiPartTotalBytes,
             part: currentPartNumber,
-            status: this.status,
-            totalParts: this.totalParts,
             queuePosition: 1,
           });
         })
@@ -2680,18 +2702,34 @@ export class Download {
     progress?: number;
     downloadSpeed?: number;
     queuePosition?: number;
+    fileSize?: number;
+    part?: number;
     processingPhase?: 'Merging chunks';
   }) {
+    const progress = data.progress ?? 0;
+    const downloadSpeed = data.downloadSpeed ?? 0;
+    const queuePosition = data.queuePosition ?? 1;
+    const part = data.part ?? this.currentPart;
     this.sendIpc('ddl:download-progress', {
       id: this.id,
-      progress: data.progress ?? 0,
-      downloadSpeed: data.downloadSpeed ?? 0,
-      fileSize: this.useParallel ? this.parallelTotalSize : this.totalSize,
-      part: this.currentPart,
+      progress,
+      downloadSpeed,
+      fileSize:
+        data.fileSize ??
+        (this.useParallel ? this.parallelTotalSize : this.totalSize),
+      part,
       status: this.status,
       totalParts: this.totalParts,
-      queuePosition: data.queuePosition ?? 1,
+      queuePosition,
       processingPhase: data.processingPhase,
+    });
+    this.lifecycle.onProgress?.({
+      progress,
+      downloadSpeed,
+      queuePosition,
+      part,
+      totalParts: this.totalParts,
+      status: this.status,
     });
   }
 
@@ -2797,11 +2835,12 @@ interface ActiveDownload {
   fiber?: Fiber.RuntimeFiber<void, DownloadError>;
 }
 
-interface DownloadServiceShape {
+export interface DownloadServiceShape {
   readonly start: (
     jobs: DownloadJob[],
-    part?: number
-  ) => Effect.Effect<unknown, DownloadError>;
+    part?: number,
+    hooks?: DownloadHooks
+  ) => Effect.Effect<DownloadHandshakeResult, DownloadError>;
   readonly pause: (id: string) => Effect.Effect<void, DownloadNotActive>;
   readonly resume: (
     id: string
@@ -2837,17 +2876,34 @@ const makeDownloadService = (
       }));
 
     const service: DownloadServiceShape = {
-      start: (jobs, part) =>
+      start: (jobs, part, hooks) =>
         Effect.gen(function* () {
           yield* checkParallelChunkCount(downloads()).pipe(
             Effect.mapError(
               (cause) => new DownloadError({ message: cause.message, cause })
             )
           );
-          const download = new Download(mainWindow, jobs, part, {
+          const baseLifecycle: DownloadLifecycle = {
             runEffect: runInScope,
             onStatusChange: () => {},
-            onTerminal: (id) => activeDownloads.delete(id),
+            onTerminal: (id) => {
+              activeDownloads.delete(id);
+            },
+          };
+          const download = new Download(mainWindow, jobs, part, {
+            runEffect: baseLifecycle.runEffect,
+            onStatusChange: (status) => {
+              baseLifecycle.onStatusChange(status);
+              hooks?.onStatusChange?.(status);
+            },
+            onTerminal: (id, outcome, error) => {
+              baseLifecycle.onTerminal(id, outcome, error);
+              hooks?.onTerminal?.(id, outcome, error);
+            },
+            onProgress: hooks?.onProgress ?? baseLifecycle.onProgress,
+            preservePartialFilesOnCancel:
+              hooks?.preservePartialFilesOnCancel ??
+              baseLifecycle.preservePartialFilesOnCancel,
           });
           const active: ActiveDownload = {
             download,
@@ -2948,6 +3004,7 @@ export const DownloadServiceLive = (
 
 export default function handler(mainWindow: BrowserWindow) {
   const service = Effect.runSync(makeDownloadService(mainWindow));
+  setAddonDownloadContext(service, mainWindow);
   const layer = Layer.succeed(DownloadService, service);
   const run = <A, E>(effect: Effect.Effect<A, E, DownloadService>) =>
     runEffectBoundary(effect.pipe(Effect.provide(layer)));

--- a/application/src/electron/preload.mts
+++ b/application/src/electron/preload.mts
@@ -88,6 +88,15 @@ ipcRenderer.on(
 );
 
 ipcRenderer.on(
+  'ddl:addon-download-created',
+  wrap((_, arg) => {
+    document.dispatchEvent(
+      new CustomEvent('ddl:addon-download-created', { detail: arg })
+    );
+  })
+);
+
+ipcRenderer.on(
   'processing:progress',
   wrap((_, arg) => {
     document.dispatchEvent(

--- a/application/src/electron/server/addon-downloads.ts
+++ b/application/src/electron/server/addon-downloads.ts
@@ -299,6 +299,10 @@ function handleDownloadRequest(
       return;
     }
     if (handshake.status === 'error') {
+      // Usually a no-op (the download already cleaned itself up), but a
+      // handshake timeout can report an error while the queued fiber is
+      // still alive — cancel so it isn't stranded without a handle.
+      yield* Effect.promise(() => cancelDownload(handshake.id));
       yield* replyWith(reply, {
         error: handshake.error ?? 'download failed to start',
       });

--- a/application/src/electron/server/addon-downloads.ts
+++ b/application/src/electron/server/addon-downloads.ts
@@ -1,0 +1,392 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import type { AddonServer } from '@ogi-sdk/addon-server';
+import type {
+  AddonDownloadAck,
+  AddonDownloadRequest,
+  AddonDownloadStatus,
+  AddonDownloadStatusUpdate,
+} from '@ogi-sdk/connect';
+import { formatError, runEffectBoundary } from '@ogi-sdk/errors';
+import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
+import { Cause, Effect } from 'effect';
+import type { BrowserWindow } from 'electron';
+import type {
+  DownloadJob,
+  DownloadServiceShape,
+  DownloadStatus,
+} from '@/electron/handlers/handler.ddl.js';
+import { loadLibraryInfo } from '@/electron/handlers/helpers.app/library.js';
+import {
+  getStoredValue,
+  refreshCached,
+} from '@/electron/manager/manager.config.js';
+import { consumeDownloadReplayEvents } from '@/lib/download-handshake.js';
+
+const logger = createLogger(LOGGER_PREFIXES.electron);
+
+export type AddonDownloadCardPayload = {
+  id: string;
+  addonSource: string;
+  name: string;
+  appID: number;
+  capsuleImage: string;
+  coverImage: string;
+  storefront: string;
+  downloadPath: string;
+  files: { path: string }[];
+  queuePosition: number;
+  totalParts: number;
+};
+
+type AddonDownloadContext = {
+  service: DownloadServiceShape;
+  mainWindow: BrowserWindow;
+};
+
+type PendingRequest = { disconnected: boolean };
+
+let context: AddonDownloadContext | undefined;
+const ownedDownloads = new Map<string, Set<string>>();
+const downloadServices = new Map<string, DownloadServiceShape>();
+
+export function setAddonDownloadContext(
+  service: DownloadServiceShape,
+  mainWindow: BrowserWindow
+): void {
+  context = { service, mainWindow };
+}
+
+function sanitizePathSegment(segment: string): string {
+  let result = segment.replace(/[/\\]+/g, '/');
+  let previous: string;
+  do {
+    previous = result;
+    result = result.replace(/\.\./g, '');
+  } while (result !== previous);
+
+  const parts = result
+    .split('/')
+    .filter((part) => part !== '' && part !== '.' && part !== '..');
+  const last = parts[parts.length - 1] ?? 'download';
+  return last.replace(/[\0<>:"|?*]/g, '_').substring(0, 255) || 'download';
+}
+
+function resolveRelativeDownloadPath(
+  baseDir: string,
+  filePath: string
+): string {
+  if (isAbsolute(filePath)) return filePath;
+  const segments = filePath
+    .split(/[/\\]+/)
+    .filter((segment) => segment !== '' && segment !== '.' && segment !== '..')
+    .map(sanitizePathSegment);
+  return resolve(baseDir, ...(segments.length > 0 ? segments : ['download']));
+}
+
+function validateRequest(request: AddonDownloadRequest): string | undefined {
+  if (!request || !Array.isArray(request.files) || request.files.length === 0) {
+    return 'download request must include at least one file';
+  }
+
+  for (const file of request.files) {
+    if (!file || typeof file.path !== 'string') {
+      return 'download file path is invalid';
+    }
+    try {
+      const url = new URL(file.link);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return 'download links must use http(s)';
+      }
+    } catch {
+      return 'download links must use http(s)';
+    }
+  }
+  return undefined;
+}
+
+function replyWith(
+  reply: (ack: AddonDownloadAck) => void | Promise<void>,
+  ack: AddonDownloadAck
+): Effect.Effect<void> {
+  return Effect.tryPromise({
+    try: () => Promise.resolve(reply(ack)),
+    catch: (cause) => cause,
+  }).pipe(
+    Effect.tapError((error) =>
+      logger.error('[addon-download] Failed to reply:', error)
+    ),
+    Effect.ignore
+  );
+}
+
+function sendStatus(
+  server: AddonServer,
+  addonID: string,
+  update: AddonDownloadStatusUpdate
+): void {
+  void runEffectBoundary(server.sendDownloadStatus(addonID, update));
+}
+
+function untrackDownload(addonID: string, downloadID: string): void {
+  const owned = ownedDownloads.get(addonID);
+  owned?.delete(downloadID);
+  if (owned?.size === 0) ownedDownloads.delete(addonID);
+  downloadServices.delete(downloadID);
+}
+
+function abortOwnedDownload(addonID: string, downloadID: string): void {
+  if (!ownedDownloads.get(addonID)?.has(downloadID)) return;
+  const service = downloadServices.get(downloadID);
+  if (!service) return;
+  void runEffectBoundary(
+    service
+      .abort(downloadID)
+      .pipe(Effect.catchTag('DownloadNotActive', () => Effect.void))
+  );
+}
+
+function handleDownloadRequest(
+  server: AddonServer,
+  addonID: string,
+  request: AddonDownloadRequest,
+  reply: (ack: AddonDownloadAck) => void | Promise<void>,
+  pendingRequest: PendingRequest,
+  onSettled: () => void
+): void {
+  const activeContext = context;
+  if (!activeContext) {
+    void runEffectBoundary(
+      replyWith(reply, { error: 'download service unavailable' }).pipe(
+        Effect.ensuring(Effect.sync(onSettled))
+      )
+    );
+    return;
+  }
+
+  const validationError = validateRequest(request);
+  if (validationError) {
+    void runEffectBoundary(
+      replyWith(reply, { error: validationError }).pipe(
+        Effect.ensuring(Effect.sync(onSettled))
+      )
+    );
+    return;
+  }
+
+  let downloadID: string | undefined;
+  let lastStatus: AddonDownloadStatus | undefined;
+  // Terminal renderer events (download-complete/error) also buffer in the
+  // handshake replay map; frontend services normally consume them after
+  // creating their card. Addon cards are created by our push instead, so we
+  // drain the buffer ourselves: forward events that raced ahead of the card
+  // push, drop ones the renderer already received directly.
+  let cardAnnounced = false;
+  const drainReplayEvents = (id: string, forward: boolean): void => {
+    const events = consumeDownloadReplayEvents(id);
+    if (!forward || activeContext.mainWindow.isDestroyed()) return;
+    for (const event of events) {
+      activeContext.mainWindow.webContents.send(event.channel, event.data);
+    }
+  };
+  const sendDedupedStatus = (
+    id: string,
+    status: AddonDownloadStatus,
+    error?: string
+  ): void => {
+    if (lastStatus === status) return;
+    lastStatus = status;
+    sendStatus(server, addonID, { id, kind: 'status', status, error });
+  };
+  const mapStatus = (
+    status: DownloadStatus
+  ): 'queued' | 'downloading' | 'paused' | undefined => {
+    if (status === 'queued' || status === 'paused') return status;
+    if (status === 'downloading' || status === 'merging') return 'downloading';
+    return undefined;
+  };
+
+  const operation = Effect.gen(function* () {
+    yield* refreshCached('general');
+    const configuredLocation: unknown = yield* getStoredValue(
+      'general',
+      'fileDownloadLocation'
+    );
+    const configuredDir =
+      typeof configuredLocation === 'string' && configuredLocation.length > 0
+        ? configuredLocation
+        : './downloads';
+    const baseDir = resolve(process.cwd(), configuredDir);
+    const prepared = yield* Effect.try({
+      try: () => ({
+        jobs: request.files.map(
+          (file): DownloadJob => ({
+            link: file.link,
+            path: resolveRelativeDownloadPath(baseDir, file.path),
+            headers: file.headers,
+          })
+        ),
+        library: request.appID ? loadLibraryInfo(request.appID) : null,
+      }),
+      catch: (cause) => cause,
+    });
+    const { jobs, library } = prepared;
+    yield* Effect.tryPromise({
+      try: () =>
+        Promise.all(
+          jobs.map((job) => mkdir(dirname(job.path), { recursive: true }))
+        ),
+      catch: (cause) => cause,
+    });
+
+    if (pendingRequest.disconnected) {
+      yield* replyWith(reply, { error: 'addon disconnected' });
+      return;
+    }
+
+    const handshake = yield* activeContext.service.start(jobs, undefined, {
+      preservePartialFilesOnCancel: true,
+      onProgress: (progress) => {
+        if (!downloadID) return;
+        sendStatus(server, addonID, {
+          id: downloadID,
+          kind: 'progress',
+          progress: progress.progress,
+          downloadSpeed: progress.downloadSpeed,
+          queuePosition: progress.queuePosition,
+          part: progress.part,
+          totalParts: progress.totalParts,
+        });
+      },
+      onStatusChange: (status) => {
+        const addonStatus = mapStatus(status);
+        if (downloadID && addonStatus) {
+          sendDedupedStatus(downloadID, addonStatus);
+        }
+      },
+      onTerminal: (id, outcome, error) => {
+        const terminalStatus: AddonDownloadStatus =
+          outcome === 'completed'
+            ? 'completed'
+            : outcome === 'failed'
+              ? 'error'
+              : 'cancelled';
+        sendDedupedStatus(id, terminalStatus, error);
+        untrackDownload(addonID, id);
+        // Card already live: renderer got the terminal IPC directly, so the
+        // buffered copy is stale. Pre-card terminals stay buffered for the
+        // card push to forward.
+        if (cardAnnounced) drainReplayEvents(id, false);
+      },
+    });
+
+    downloadID = handshake.id;
+    if (pendingRequest.disconnected) {
+      yield* activeContext.service
+        .abort(handshake.id)
+        .pipe(Effect.catchTag('DownloadNotActive', () => Effect.void));
+      yield* replyWith(reply, { error: 'addon disconnected' });
+      drainReplayEvents(handshake.id, false);
+      return;
+    }
+    if (handshake.status === 'error') {
+      yield* replyWith(reply, {
+        error: handshake.error ?? 'download failed to start',
+      });
+      drainReplayEvents(handshake.id, false);
+      return;
+    }
+    if (handshake.queuePosition === undefined) {
+      yield* activeContext.service
+        .abort(handshake.id)
+        .pipe(Effect.catchTag('DownloadNotActive', () => Effect.void));
+      yield* replyWith(reply, { error: 'download queue position unavailable' });
+      drainReplayEvents(handshake.id, false);
+      return;
+    }
+
+    if (handshake.status !== 'completed') {
+      const owned = ownedDownloads.get(addonID) ?? new Set<string>();
+      owned.add(handshake.id);
+      ownedDownloads.set(addonID, owned);
+      downloadServices.set(handshake.id, activeContext.service);
+    }
+    if (handshake.status === 'queued' || handshake.status === 'downloading') {
+      sendDedupedStatus(handshake.id, handshake.status);
+    }
+
+    const payload: AddonDownloadCardPayload = {
+      id: handshake.id,
+      addonSource: addonID,
+      name: request.name,
+      appID: request.appID ?? 0,
+      capsuleImage: request.capsuleImage ?? library?.capsuleImage ?? '',
+      coverImage: library?.coverImage ?? '',
+      storefront: library?.storefront ?? '',
+      downloadPath: jobs[0].path,
+      files: jobs.map(({ path }) => ({ path })),
+      queuePosition: handshake.queuePosition,
+      totalParts: jobs.length,
+    };
+    if (!activeContext.mainWindow.isDestroyed()) {
+      activeContext.mainWindow.webContents.send(
+        'ddl:addon-download-created',
+        payload
+      );
+    }
+    cardAnnounced = true;
+    drainReplayEvents(handshake.id, true);
+    yield* replyWith(reply, {
+      id: handshake.id,
+      queuePosition: handshake.queuePosition,
+    });
+  }).pipe(
+    Effect.catchAllCause((cause) =>
+      replyWith(reply, { error: formatError(Cause.squash(cause)) })
+    ),
+    Effect.ensuring(Effect.sync(onSettled))
+  );
+
+  void runEffectBoundary(operation);
+}
+
+export function attachAddonDownloadBridge(server: AddonServer): void {
+  const pendingRequests = new Map<string, Set<PendingRequest>>();
+  server.on('download-request', (addonID, request, reply) => {
+    const pendingRequest: PendingRequest = { disconnected: false };
+    const addonRequests = pendingRequests.get(addonID) ?? new Set();
+    addonRequests.add(pendingRequest);
+    pendingRequests.set(addonID, addonRequests);
+    handleDownloadRequest(
+      server,
+      addonID,
+      request,
+      reply,
+      pendingRequest,
+      () => {
+        addonRequests.delete(pendingRequest);
+        if (
+          addonRequests.size === 0 &&
+          pendingRequests.get(addonID) === addonRequests
+        ) {
+          pendingRequests.delete(addonID);
+        }
+      }
+    );
+  });
+  server.on('download-action', (addonID, downloadID, action) => {
+    if (action === 'abort') abortOwnedDownload(addonID, downloadID);
+  });
+  server.on('addon-disconnect', (addonID) => {
+    for (const pendingRequest of pendingRequests.get(addonID) ?? []) {
+      pendingRequest.disconnected = true;
+    }
+    pendingRequests.delete(addonID);
+    const downloads = Array.from(ownedDownloads.get(addonID) ?? []);
+    for (const downloadID of downloads) {
+      abortOwnedDownload(addonID, downloadID);
+      downloadServices.delete(downloadID);
+    }
+    ownedDownloads.delete(addonID);
+  });
+}

--- a/application/src/electron/server/addon-downloads.ts
+++ b/application/src/electron/server/addon-downloads.ts
@@ -21,6 +21,7 @@ import {
   getStoredValue,
   refreshCached,
 } from '@/electron/manager/manager.config.js';
+import { cancelQueuedDownload } from '@/electron/rpc/queue-cancel.js';
 import { consumeDownloadReplayEvents } from '@/lib/download-handshake.js';
 
 const logger = createLogger(LOGGER_PREFIXES.electron);
@@ -48,7 +49,6 @@ type PendingRequest = { disconnected: boolean };
 
 let context: AddonDownloadContext | undefined;
 const ownedDownloads = new Map<string, Set<string>>();
-const downloadServices = new Map<string, DownloadServiceShape>();
 
 export function setAddonDownloadContext(
   service: DownloadServiceShape,
@@ -132,17 +132,15 @@ function untrackDownload(addonID: string, downloadID: string): void {
   const owned = ownedDownloads.get(addonID);
   owned?.delete(downloadID);
   if (owned?.size === 0) ownedDownloads.delete(addonID);
-  downloadServices.delete(downloadID);
 }
 
 function abortOwnedDownload(addonID: string, downloadID: string): void {
   if (!ownedDownloads.get(addonID)?.has(downloadID)) return;
-  const service = downloadServices.get(downloadID);
-  if (!service) return;
-  void runEffectBoundary(
-    service
-      .abort(downloadID)
-      .pipe(Effect.catchTag('DownloadNotActive', () => Effect.void))
+  // Route through the queue-cancel handler (same path as UI cancel) so
+  // queued-but-not-processing downloads are removed from the queue instead
+  // of being stranded by a direct service abort.
+  void cancelQueuedDownload(downloadID).catch((error) =>
+    logger.sync.error('[addon-download] Failed to abort download:', error)
   );
 }
 
@@ -175,6 +173,17 @@ function handleDownloadRequest(
   }
 
   let downloadID: string | undefined;
+  let ackDelivered = false;
+  const pendingUpdates: Array<(id: string) => AddonDownloadStatusUpdate> = [];
+  const emitStatus = (
+    make: (id: string) => AddonDownloadStatusUpdate
+  ): void => {
+    if (ackDelivered && downloadID) {
+      sendStatus(server, addonID, make(downloadID));
+    } else {
+      pendingUpdates.push(make);
+    }
+  };
   let lastStatus: AddonDownloadStatus | undefined;
   // Terminal renderer events (download-complete/error) also buffer in the
   // handshake replay map; frontend services normally consume them after
@@ -190,13 +199,12 @@ function handleDownloadRequest(
     }
   };
   const sendDedupedStatus = (
-    id: string,
     status: AddonDownloadStatus,
     error?: string
   ): void => {
     if (lastStatus === status) return;
     lastStatus = status;
-    sendStatus(server, addonID, { id, kind: 'status', status, error });
+    emitStatus((id) => ({ id, kind: 'status', status, error }));
   };
   const mapStatus = (
     status: DownloadStatus
@@ -241,28 +249,26 @@ function handleDownloadRequest(
 
     if (pendingRequest.disconnected) {
       yield* replyWith(reply, { error: 'addon disconnected' });
+      pendingUpdates.length = 0;
       return;
     }
 
     const handshake = yield* activeContext.service.start(jobs, undefined, {
       preservePartialFilesOnCancel: true,
       onProgress: (progress) => {
-        if (!downloadID) return;
-        sendStatus(server, addonID, {
-          id: downloadID,
+        emitStatus((id) => ({
+          id,
           kind: 'progress',
           progress: progress.progress,
           downloadSpeed: progress.downloadSpeed,
           queuePosition: progress.queuePosition,
           part: progress.part,
           totalParts: progress.totalParts,
-        });
+        }));
       },
       onStatusChange: (status) => {
         const addonStatus = mapStatus(status);
-        if (downloadID && addonStatus) {
-          sendDedupedStatus(downloadID, addonStatus);
-        }
+        if (addonStatus) sendDedupedStatus(addonStatus);
       },
       onTerminal: (id, outcome, error) => {
         const terminalStatus: AddonDownloadStatus =
@@ -271,7 +277,7 @@ function handleDownloadRequest(
             : outcome === 'failed'
               ? 'error'
               : 'cancelled';
-        sendDedupedStatus(id, terminalStatus, error);
+        sendDedupedStatus(terminalStatus, error);
         untrackDownload(addonID, id);
         // Card already live: renderer got the terminal IPC directly, so the
         // buffered copy is stale. Pre-card terminals stay buffered for the
@@ -286,6 +292,7 @@ function handleDownloadRequest(
         .abort(handshake.id)
         .pipe(Effect.catchTag('DownloadNotActive', () => Effect.void));
       yield* replyWith(reply, { error: 'addon disconnected' });
+      pendingUpdates.length = 0;
       drainReplayEvents(handshake.id, false);
       return;
     }
@@ -293,6 +300,7 @@ function handleDownloadRequest(
       yield* replyWith(reply, {
         error: handshake.error ?? 'download failed to start',
       });
+      pendingUpdates.length = 0;
       drainReplayEvents(handshake.id, false);
       return;
     }
@@ -301,6 +309,7 @@ function handleDownloadRequest(
         .abort(handshake.id)
         .pipe(Effect.catchTag('DownloadNotActive', () => Effect.void));
       yield* replyWith(reply, { error: 'download queue position unavailable' });
+      pendingUpdates.length = 0;
       drainReplayEvents(handshake.id, false);
       return;
     }
@@ -309,10 +318,9 @@ function handleDownloadRequest(
       const owned = ownedDownloads.get(addonID) ?? new Set<string>();
       owned.add(handshake.id);
       ownedDownloads.set(addonID, owned);
-      downloadServices.set(handshake.id, activeContext.service);
     }
     if (handshake.status === 'queued' || handshake.status === 'downloading') {
-      sendDedupedStatus(handshake.id, handshake.status);
+      sendDedupedStatus(handshake.status);
     }
 
     const payload: AddonDownloadCardPayload = {
@@ -340,9 +348,20 @@ function handleDownloadRequest(
       id: handshake.id,
       queuePosition: handshake.queuePosition,
     });
+    ackDelivered = true;
+    for (const make of pendingUpdates) {
+      sendStatus(server, addonID, make(handshake.id));
+    }
+    pendingUpdates.length = 0;
   }).pipe(
     Effect.catchAllCause((cause) =>
-      replyWith(reply, { error: formatError(Cause.squash(cause)) })
+      Effect.sync(() => {
+        pendingUpdates.length = 0;
+      }).pipe(
+        Effect.zipRight(
+          replyWith(reply, { error: formatError(Cause.squash(cause)) })
+        )
+      )
     ),
     Effect.ensuring(Effect.sync(onSettled))
   );
@@ -385,7 +404,6 @@ export function attachAddonDownloadBridge(server: AddonServer): void {
     const downloads = Array.from(ownedDownloads.get(addonID) ?? []);
     for (const downloadID of downloads) {
       abortOwnedDownload(addonID, downloadID);
-      downloadServices.delete(downloadID);
     }
     ownedDownloads.delete(addonID);
   });

--- a/application/src/electron/server/addon-downloads.ts
+++ b/application/src/electron/server/addon-downloads.ts
@@ -134,14 +134,18 @@ function untrackDownload(addonID: string, downloadID: string): void {
   if (owned?.size === 0) ownedDownloads.delete(addonID);
 }
 
-function abortOwnedDownload(addonID: string, downloadID: string): void {
-  if (!ownedDownloads.get(addonID)?.has(downloadID)) return;
-  // Route through the queue-cancel handler (same path as UI cancel) so
-  // queued-but-not-processing downloads are removed from the queue instead
-  // of being stranded by a direct service abort.
-  void cancelQueuedDownload(downloadID).catch((error) =>
+// Route through the queue-cancel handler (same path as UI cancel) so
+// queued-but-not-processing downloads are removed from the queue instead
+// of being stranded by a direct service abort.
+function cancelDownload(downloadID: string): Promise<void> {
+  return cancelQueuedDownload(downloadID).catch((error) =>
     logger.sync.error('[addon-download] Failed to abort download:', error)
   );
+}
+
+function abortOwnedDownload(addonID: string, downloadID: string): void {
+  if (!ownedDownloads.get(addonID)?.has(downloadID)) return;
+  void cancelDownload(downloadID);
 }
 
 function handleDownloadRequest(
@@ -288,9 +292,7 @@ function handleDownloadRequest(
 
     downloadID = handshake.id;
     if (pendingRequest.disconnected) {
-      yield* activeContext.service
-        .abort(handshake.id)
-        .pipe(Effect.catchTag('DownloadNotActive', () => Effect.void));
+      yield* Effect.promise(() => cancelDownload(handshake.id));
       yield* replyWith(reply, { error: 'addon disconnected' });
       pendingUpdates.length = 0;
       drainReplayEvents(handshake.id, false);
@@ -305,9 +307,7 @@ function handleDownloadRequest(
       return;
     }
     if (handshake.queuePosition === undefined) {
-      yield* activeContext.service
-        .abort(handshake.id)
-        .pipe(Effect.catchTag('DownloadNotActive', () => Effect.void));
+      yield* Effect.promise(() => cancelDownload(handshake.id));
       yield* replyWith(reply, { error: 'download queue position unavailable' });
       pendingUpdates.length = 0;
       drainReplayEvents(handshake.id, false);

--- a/application/src/electron/server/addon-server.ts
+++ b/application/src/electron/server/addon-server.ts
@@ -6,6 +6,7 @@ import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect, Schema } from 'effect';
 import { __dirname } from '@/electron/manager/manager.paths.js';
 import { runElectronSync } from '@/electron/runtime.js';
+import { attachAddonDownloadBridge } from '@/electron/server/addon-downloads.js';
 
 const logger = createLogger(LOGGER_PREFIXES.electron);
 
@@ -61,6 +62,7 @@ const createAddonServer = (): AddonServer => {
       id: `addon-disconnect-${Math.random().toString(36).slice(2)}`,
     });
   });
+  attachAddonDownloadBridge(server);
   return server;
 };
 

--- a/application/src/frontend/lib/downloads/persistence.ts
+++ b/application/src/frontend/lib/downloads/persistence.ts
@@ -238,6 +238,8 @@ export function initDownloadPersistence() {
       const nextSnapshot: Record<string, string> = {};
       for (const download of downloads) {
         if (!isPersistableStatus(download.status)) continue;
+        // Addon-enqueued downloads can't be restored (owning addon session is gone).
+        if (download.isAddonDownload) continue;
         const serialized = JSON.stringify(download);
         nextSnapshot[download.id] = serialized;
         if (lastSnapshot[download.id] !== serialized) saveRecord(download);

--- a/application/src/frontend/lib/downloads/restart.ts
+++ b/application/src/frontend/lib/downloads/restart.ts
@@ -167,6 +167,8 @@ export function restartDownload(
   return Effect.gen(function* () {
     const latest = getDownloadItem(pausedState.id);
     if (!latest) return false;
+    // Addon-enqueued downloads can only resume in place; the addon owns the links.
+    if (latest.isAddonDownload) return false;
 
     const download = { ...pausedState.downloadInfo, ...latest };
     newDownloadId = Math.random().toString(36).substring(7);

--- a/application/src/frontend/managers/DownloadManager.svelte
+++ b/application/src/frontend/managers/DownloadManager.svelte
@@ -4,6 +4,7 @@ import { FileSystemError } from '@ogi-sdk/errors';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { Effect } from 'effect';
 import { get } from 'svelte/store';
+import type { AddonDownloadCardPayload } from '@/electron/server/addon-downloads';
 import { getApp } from '@/frontend/lib/core/library';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
@@ -579,6 +580,38 @@ document.addEventListener(
   handleDownloadCancelled
 );
 
+// -- Addon-enqueued downloads (raw files, no setup phase) --
+
+document.addEventListener('ddl:addon-download-created', (event: Event) => {
+  if (!isCustomEvent(event)) return;
+  const payload = event.detail as AddonDownloadCardPayload;
+  if (getDownloadItem(payload.id)) return;
+  const card: DownloadStatusAndInfo = {
+    downloadType: 'direct',
+    id: payload.id,
+    name: payload.name,
+    appID: payload.appID,
+    status: 'downloading',
+    progress: 0,
+    downloadPath: payload.downloadPath,
+    files: payload.files.map((file) => ({
+      name: basename(file.path),
+      path: file.path,
+      downloadURL: '',
+    })),
+    downloadSpeed: 0,
+    downloadSize: 0,
+    addonSource: payload.addonSource,
+    capsuleImage: payload.capsuleImage,
+    coverImage: payload.coverImage,
+    storefront: payload.storefront,
+    queuePosition: payload.queuePosition,
+    totalParts: payload.totalParts,
+    isAddonDownload: true,
+  };
+  currentDownloads.update((downloads) => [...downloads, card]);
+});
+
 // -- Download Complete --
 
 document.addEventListener('torrent:download-complete', async (event: Event) => {
@@ -588,6 +621,16 @@ document.addEventListener('torrent:download-complete', async (event: Event) => {
 
 document.addEventListener('ddl:download-complete', async (event: Event) => {
   if (!isCustomEvent(event)) return;
+  // Addon-enqueued raw downloads finish here; they never enter the setup phase.
+  if (getDownloadItem(event.detail.id)?.isAddonDownload) {
+    updateDownloadStatus(event.detail.id, {
+      status: 'setup-complete',
+      progress: 1,
+      downloadSpeed: 0,
+      queuePosition: undefined,
+    });
+    return;
+  }
   await processDownloadComplete(event.detail.id, false);
 });
 

--- a/application/src/frontend/store.svelte.ts
+++ b/application/src/frontend/store.svelte.ts
@@ -76,6 +76,8 @@ export type DownloadStatusAndInfo = SearchResult & {
   clearOldFilesBeforeUpdate?: boolean;
   // Manifest data from the search result, passed to the setup handler
   manifest?: Record<string, unknown>;
+  // Raw file download enqueued by an addon via addon.download(); skips the setup phase
+  isAddonDownload?: boolean;
 };
 
 export type DeferredTask = {

--- a/application/src/frontend/views/DownloadView.svelte
+++ b/application/src/frontend/views/DownloadView.svelte
@@ -709,7 +709,9 @@ onDestroy(() => {
                       clip-rule="evenodd"
                     ></path>
                   </svg>
-                  Setup Complete
+                  {download.isAddonDownload
+                    ? 'Download Complete'
+                    : 'Setup Complete'}
                 </div>
               {:else if download.status === 'error'}
                 <div class="status-badge error">

--- a/docs/handoff-addon-download-api.md
+++ b/docs/handoff-addon-download-api.md
@@ -1,0 +1,51 @@
+# Handoff: `addon.download()` — addon-enqueued downloads via the app's download queue
+
+## Task
+
+Add an API to the OGI addon SDK so addons can enqueue raw file downloads into the app's global download queue and track them with a promise/abort/wait handle. Spec was fully grilled and confirmed by shar; do not re-litigate decisions below.
+
+## Confirmed spec
+
+**SDK API** (new on `OGIAddon` in `packages/ogi-addon/src/main.ts`):
+
+```ts
+const dl = await addon.download({
+  name: string,
+  files: [{ link: string, path: string, headers?: Record<string, string> }],
+  appID?: number,        // infers card metadata from library/store data
+  capsuleImage?: string, // explicit fields win over appID inference
+});
+dl.id; dl.queuePosition;          // queuePosition live-updated
+dl.on('progress', ({ progress, downloadSpeed, queuePosition }) => {});
+dl.on('status', ...);             // paused / resumed / etc.
+await dl.wait();                  // resolves on complete; rejects on fail/abort/user-cancel
+dl.abort();
+```
+
+**Decisions (final):**
+
+1. **Raw file primitive** — no setup phase, no library entry. Direct HTTP(S) only for v1 (no torrent/magnet/debrid; `downloadType` can be added later).
+2. **Same global `DOWNLOAD_QUEUE`** as user downloads — one-at-a-time invariant, shared bandwidth token bucket, parallel-chunk limits, real queue positions.
+3. **Shows in the download manager UI** as a normal card. Main process must push card creation to the renderer (new plumbing — today cards are created renderer-side in e.g. `DirectService`). Metadata resolution: explicit fields → appID lookup → name + generic fallback (card component may need a no-imagery fallback path).
+4. **Paths**: absolute allowed; relative resolves under the user's download dir (sanitized like `safeDownloadPath`). Addons are trusted local processes; no sandbox theater.
+5. **Full user control from UI** — pause/resume/cancel all work on addon cards. Addon gets status events; user-cancel rejects `wait()` identically to `dl.abort()`.
+6. **Addon disconnect aborts its queued/in-flight downloads.** Partial files stay on disk (engine already resumes partials if re-enqueued).
+7. **Progress pushed to the addon** over the socket, throttled (~100ms cadence like `defer-update`'s reporter).
+
+## Codebase map (verified)
+
+- **Queue**: `application/src/electron/manager/manager.queue.ts` — `DOWNLOAD_QUEUE.enqueue(id, item)` returns `{ initialPosition, wait, cancelHandler, finish }`. Don't leak this shape to addons; `finish`/`cancelHandler` are internal.
+- **Download engine**: `application/src/electron/handlers/handler.ddl.ts` — `Download` class; `start()` enqueues into `DOWNLOAD_QUEUE`, registers cancel via `registerQueueCancel` (`application/src/electron/rpc/queue-cancel.ts`), reports via handshake. Reuse this class rather than duplicating.
+- **Handshake/lifecycle**: `application/src/lib/download-handshake.ts` — enqueue-ack pattern (`waitForDownloadHandshake`) plus terminal-event replay. `addon.download()`'s initial resolve mirrors this.
+- **Protocol registry (single source of truth)**: `packages/connection/lib/protocol.ts` — add new `addonToServer` rows (e.g. `download-request`, plus whatever the ack/progress/terminal flow needs; study `task-update` + `defer-update` and `get-app-details` request/response for the two existing patterns). Wire envelopes/unions derive automatically from the registry.
+- **Server handlers**: `packages/addon-server/lib/handlers/client-message-handlers.ts` — add handler(s); follow `handleTaskUpdate`/`handleGetAppDetails` style. The addon-server package is transport; the electron app (`application/src/electron/server/addon-server.ts` instantiates `AddonServer`) is where the bridge to `DOWNLOAD_QUEUE`/`Download` lives — likely a server event the electron layer subscribes to, like `notification`/`input-asked` do.
+- **SDK handle**: `packages/ogi-addon/src/main.ts` — follow the existing `Task` class pattern (WebSocket-mode: id + `schedule(effect)` runner; Effect internals, promise-compatibility adapters public). The SDK is Effect-based (`@ogi-sdk` packages, effect-ts) — match that style.
+- **Disconnect cleanup**: server side tracks addon-owned download ids per connection; on client disconnect, abort them (queue-cancel path already unifies queued vs in-flight cancel).
+
+## Proof
+
+Add a small `addon.download()` usage to `test-addon` (e.g. behind a task/config action downloading a small file) to verify socket → server → queue → UI card → progress events → `wait()` end to end. No test suite beyond anything that falls out naturally (shar's preference — minimal, focused tests only).
+
+## Style notes
+
+- Concise, layered abstractions; no function sprawl. Explicit typing. Effect-ts primitives in SDK/server code. Conventional-commit format, concise (e.g. `feat(ogi-addon): addon-enqueued downloads`). Comments sparse but kept in sync — update any queue/protocol comments touched. PRs via the `make-pr` skill.

--- a/packages/addon-server/lib/_generated/event-proxy.ts
+++ b/packages/addon-server/lib/_generated/event-proxy.ts
@@ -54,6 +54,7 @@ const eventMessagePackers: EventMessagePackerMap = {
   'game-details': ([args]) => ({ args }),
   'request-dl': ([appID, info]) => ({ args: { appID, info } }),
   catalog: () => ({ args: undefined }),
+  'download-status': ([args]) => ({ args }),
 };
 const _eventMessagePackersCheck: EventMessagePackers = eventMessagePackers;
 void _eventMessagePackersCheck;

--- a/packages/addon-server/lib/handlers/client-message-handlers.ts
+++ b/packages/addon-server/lib/handlers/client-message-handlers.ts
@@ -1,5 +1,6 @@
 import type {
   AddonClientToServerEventArgs,
+  AddonDownloadAck,
   AddonNotificationMessage,
   ConfigurationFile,
   OGIAddonSDKEventListener,
@@ -198,6 +199,48 @@ const handleFlag: ClientMessageHandler = (context, message) =>
     }
   });
 
+const handleDownloadRequest: ClientMessageHandler = (context, message) =>
+  Effect.gen(function* () {
+    if (!requireAuthenticated(context, 'download-request')) return;
+    if (!requireMessageId(context, 'download-request', message.id)) return;
+    if (context.server.listenerCount('download-request') === 0) {
+      yield* context.connection.events
+        .response(message.id, {
+          error: 'download-request not supported by host',
+        } satisfies AddonDownloadAck)
+        .pipe(Effect.asVoid);
+      return;
+    }
+    const request =
+      message.args as AddonClientToServerEventArgs['download-request'];
+    yield* context.server.emitEffect(
+      'download-request',
+      context.connection.addonInfo!.id,
+      request,
+      (ack) =>
+        Effect.runPromise(
+          logger.observe(
+            context.connection.events
+              .response(message.id!, ack)
+              .pipe(Effect.asVoid)
+          )
+        )
+    );
+  });
+
+const handleDownloadAction: ClientMessageHandler = (context, message) =>
+  Effect.gen(function* () {
+    if (!requireAuthenticated(context, 'download-action')) return;
+    const { downloadID, action } =
+      message.args as AddonClientToServerEventArgs['download-action'];
+    yield* context.server.emitEffect(
+      'download-action',
+      context.connection.addonInfo!.id,
+      downloadID,
+      action
+    );
+  });
+
 export const createClientMessageHandlers = (): ClientMessageHandlers => ({
   notification: handleNotification,
   authenticate: handleAuthenticate,
@@ -207,5 +250,7 @@ export const createClientMessageHandlers = (): ClientMessageHandlers => ({
   'task-update': handleTaskUpdate,
   'get-app-details': handleGetAppDetails,
   'search-app-name': handleSearchAppName,
+  'download-request': handleDownloadRequest,
+  'download-action': handleDownloadAction,
   flag: handleFlag,
 });

--- a/packages/addon-server/lib/server.ts
+++ b/packages/addon-server/lib/server.ts
@@ -1,4 +1,5 @@
 import type {
+  AddonDownloadStatusUpdate,
   AddonNotificationMessage,
   AddonServerHostEventListeners,
   AddonServerHostEventName,
@@ -112,6 +113,22 @@ export class AddonServer {
   public getClient(id: string): AddonConnection | undefined {
     return this.clients.get(id);
   }
+
+  public sendDownloadStatus(
+    addonID: string,
+    update: AddonDownloadStatusUpdate
+  ): Effect.Effect<void> {
+    const connection = this.getClient(addonID);
+    return connection
+      ? connection.events.noResponse
+          .downloadStatus(update)
+          .pipe(Effect.asVoid, Effect.ignore)
+      : Effect.void;
+  }
+
+  public listenerCount(event: AddonServerEventName): number {
+    return this.eventEmitter.listenerCount(event);
+  }
   public addClient(id: string, connection: AddonConnection): void {
     this.clients.set(id, connection);
   }
@@ -206,11 +223,13 @@ export class AddonServer {
       const connection = yield* AddonConnection.make(ws, this.config, this);
       this.connections.add(connection);
       ws.on('close', () => {
+        const addonID = connection.addonInfo?.id;
         this.removeConnection(connection);
         this.eventEmitter.emit(
           'disconnect',
           `${connection.addonInfo?.name ?? 'Addon'} websocket closed`
         );
+        if (addonID) this.eventEmitter.emit('addon-disconnect', addonID);
       });
       const success = yield* connection.setupWebsocket();
       if (!success) {

--- a/packages/client-kit/lib/_generated/addon-proxy.ts
+++ b/packages/client-kit/lib/_generated/addon-proxy.ts
@@ -131,6 +131,7 @@ export const addonEventAliases = [
   'game-details',
   'request-dl',
   'catalog',
+  'download-status',
 ].reduce(
   (aliases, event) => {
     aliases[toCamelCaseEvent(event)] = event as AddonServerToClientEventName;

--- a/packages/connection/lib/protocol-base.ts
+++ b/packages/connection/lib/protocol-base.ts
@@ -79,6 +79,48 @@ export type BasicLibraryInfo = {
   storefront: string;
 };
 
+export type AddonDownloadFile = {
+  link: string;
+  path: string;
+  headers?: Record<string, string>;
+};
+
+export type AddonDownloadRequest = {
+  name: string;
+  files: AddonDownloadFile[];
+  appID?: number;
+  capsuleImage?: string;
+};
+
+export type AddonDownloadAck =
+  | { id: string; queuePosition: number }
+  | { error: string };
+
+export type AddonDownloadStatus =
+  | 'queued'
+  | 'downloading'
+  | 'paused'
+  | 'completed'
+  | 'error'
+  | 'cancelled';
+
+export type AddonDownloadStatusUpdate =
+  | {
+      id: string;
+      kind: 'progress';
+      progress: number;
+      downloadSpeed: number;
+      queuePosition?: number;
+      part?: number;
+      totalParts?: number;
+    }
+  | {
+      id: string;
+      kind: 'status';
+      status: AddonDownloadStatus;
+      error?: string;
+    };
+
 export interface CatalogSection {
   name: string;
   description: string;

--- a/packages/connection/lib/protocol.ts
+++ b/packages/connection/lib/protocol.ts
@@ -7,6 +7,9 @@
  */
 
 import type {
+  AddonDownloadAck,
+  AddonDownloadRequest,
+  AddonDownloadStatusUpdate,
   AddonNotificationMessage,
   AddonTaskRunEventArgs,
   BasicLibraryInfo,
@@ -40,6 +43,11 @@ import type { WebsocketMessage } from './types';
 
 export type {
   ActionConfigurationOption,
+  AddonDownloadAck,
+  AddonDownloadFile,
+  AddonDownloadRequest,
+  AddonDownloadStatus,
+  AddonDownloadStatusUpdate,
   AddonNotificationMessage,
   AddonTaskRunEventArgs,
   BasicLibraryInfo,
@@ -171,6 +179,10 @@ export const addonProtocol = defineAddonProtocol({
       addonListener: true,
       pack: { type: 'none' },
     }),
+    'download-status': serverCommand<
+      [update: AddonDownloadStatusUpdate],
+      void
+    >(),
   },
   addonToServer: {
     response: addonMessage<unknown>(),
@@ -202,6 +214,11 @@ export const addonProtocol = defineAddonProtocol({
     }>(),
     'get-app-details': addonMessage<{ appID: number; storefront: string }>(),
     'search-app-name': addonMessage<{ query: string; storefront: string }>(),
+    'download-request': addonMessage<AddonDownloadRequest>(),
+    'download-action': addonMessage<{
+      downloadID: string;
+      action: 'abort';
+    }>(),
     flag: addonMessage<{ flag: string; value: string | string[] }>(),
   },
   sdkToServer: {
@@ -619,15 +636,23 @@ export type OGIAddonConnectContext = {
 };
 
 /** Host-side events emitted by `@ogi-sdk/addon-server`. */
-export type AddonServerLifecycleEvent = 'connect' | 'disconnect' | 'start';
+export type AddonServerLifecycleEvent =
+  | 'connect'
+  | 'disconnect'
+  | 'addon-disconnect'
+  | 'start';
 
 export type AddonServerHostEventName =
   | AddonServerLifecycleEvent
-  | Extract<'notification' | 'input-asked', AddonClientToServerEventName>;
+  | Extract<
+      'notification' | 'input-asked' | 'download-request' | 'download-action',
+      AddonClientToServerEventName
+    >;
 
 export type AddonServerHostEventListeners<Connection = unknown> = {
   connect: (connection: Connection) => void;
   disconnect: (reason: string) => void;
+  'addon-disconnect': (addonID: string) => void;
   start: () => void;
   notification: (notification: AddonNotificationMessage) => void;
   'input-asked': (
@@ -637,6 +662,16 @@ export type AddonServerHostEventListeners<Connection = unknown> = {
     reply: (
       result: Record<string, string | number | boolean>
     ) => void | Promise<void>
+  ) => void;
+  'download-request': (
+    addonID: string,
+    request: AddonDownloadRequest,
+    reply: (result: AddonDownloadAck) => void | Promise<void>
+  ) => void;
+  'download-action': (
+    addonID: string,
+    downloadID: string,
+    action: 'abort'
   ) => void;
 };
 

--- a/packages/ogi-addon/src/main.ts
+++ b/packages/ogi-addon/src/main.ts
@@ -3,6 +3,10 @@ import type {
   AddonClientToServerEventArgs,
   AddonClientToServerEventName,
   AddonClientToServerWebsocketMessage,
+  AddonDownloadAck,
+  AddonDownloadRequest,
+  AddonDownloadStatus,
+  AddonDownloadStatusUpdate,
   AddonNotificationMessage,
   AddonProtocolEventListenerTypes,
   AddonSDKLifecycleEventListenerTypes,
@@ -25,7 +29,7 @@ import {
   ValidationError,
 } from '@ogi-sdk/errors';
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
-import { Effect, Layer, ManagedRuntime, Schema } from 'effect';
+import { Deferred, Effect, Layer, ManagedRuntime, Schema } from 'effect';
 import Fuse, { IFuseOptions } from 'fuse.js';
 import { Configuration, DefiniteConfig } from './config/Configuration';
 import { ConfigurationBuilder } from './config/ConfigurationBuilder';
@@ -44,6 +48,11 @@ export type {
   AddonClientToServerEventArgs,
   AddonClientToServerEventName,
   AddonClientToServerWebsocketMessage,
+  AddonDownloadAck,
+  AddonDownloadFile,
+  AddonDownloadRequest,
+  AddonDownloadStatus,
+  AddonDownloadStatusUpdate,
   AddonNotificationMessage,
   AddonProtocolEventListenerTypes,
   AddonSDKLifecycleEventListenerTypes,
@@ -73,6 +82,102 @@ export type {
 
 /** @deprecated Use {@link AddonNotificationMessage}. */
 export type Notification = AddonNotificationMessage;
+
+type AddonDownloadProgress = {
+  progress: number;
+  downloadSpeed: number;
+  queuePosition?: number;
+  part?: number;
+  totalParts?: number;
+};
+
+type AddonDownloadStatusEvent = {
+  status: AddonDownloadStatus;
+  error?: string;
+};
+
+export class AddonDownload {
+  public queuePosition: number;
+  private readonly progressListeners: Array<
+    (progress: AddonDownloadProgress) => void
+  > = [];
+  private readonly statusListeners: Array<
+    (status: AddonDownloadStatusEvent) => void
+  > = [];
+
+  public constructor(
+    public readonly id: string,
+    queuePosition: number,
+    private readonly completion: Deferred.Deferred<void, Error>,
+    private readonly sendAbort: () => Effect.Effect<void, unknown>,
+    private readonly schedule: EffectScheduler
+  ) {
+    this.queuePosition = queuePosition;
+  }
+
+  public on(
+    event: 'progress',
+    callback: (progress: AddonDownloadProgress) => void
+  ): this;
+  public on(
+    event: 'status',
+    callback: (status: AddonDownloadStatusEvent) => void
+  ): this;
+  public on(
+    event: 'progress' | 'status',
+    callback:
+      | ((progress: AddonDownloadProgress) => void)
+      | ((status: AddonDownloadStatusEvent) => void)
+  ): this {
+    if (event === 'progress') {
+      this.progressListeners.push(
+        callback as (progress: AddonDownloadProgress) => void
+      );
+    } else {
+      this.statusListeners.push(
+        callback as (status: AddonDownloadStatusEvent) => void
+      );
+    }
+    return this;
+  }
+
+  public wait(): Promise<void> {
+    return Effect.runPromise(Deferred.await(this.completion));
+  }
+
+  public abort(): void {
+    this.schedule(this.sendAbort());
+  }
+
+  public dispatch(update: AddonDownloadStatusUpdate): Effect.Effect<void> {
+    return Effect.gen(this, function* () {
+      if (update.kind === 'progress') {
+        if (update.queuePosition !== undefined)
+          this.queuePosition = update.queuePosition;
+        const progress: AddonDownloadProgress = {
+          progress: update.progress,
+          downloadSpeed: update.downloadSpeed,
+          queuePosition: update.queuePosition,
+          part: update.part,
+          totalParts: update.totalParts,
+        };
+        this.progressListeners.forEach((listener) => listener(progress));
+        return;
+      }
+
+      if (update.status === 'completed') {
+        yield* Deferred.succeed(this.completion, undefined).pipe(Effect.asVoid);
+      } else if (update.status === 'error' || update.status === 'cancelled') {
+        yield* Deferred.fail(
+          this.completion,
+          new Error(update.error ?? update.status)
+        ).pipe(Effect.asVoid);
+      }
+      const status = { status: update.status, error: update.error };
+      this.statusListeners.forEach((listener) => listener(status));
+    });
+  }
+}
 
 /**
  * Addon SDK listener signatures. Protocol commands come from `addonProtocol` in
@@ -256,6 +361,52 @@ export default class OGIAddon {
     storefront: string
   ): Promise<BasicLibraryInfo[]> {
     return this.runPromise(this.searchGameEffect(query, storefront));
+  }
+
+  private downloadEffect(
+    request: AddonDownloadRequest
+  ): Effect.Effect<AddonDownload, AddonError> {
+    return Effect.gen(this, function* () {
+      const ack = yield* this.addonWSListener
+        .requestResponse<AddonDownloadAck>('download-request', request)
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new AddonError({
+                message: formatError(error),
+                addonName: this.addonInfo.name,
+              })
+          )
+        );
+      if ('error' in ack) {
+        return yield* Effect.fail(
+          new AddonError({
+            message: ack.error,
+            addonName: this.addonInfo.name,
+          })
+        );
+      }
+      const completion = yield* Deferred.make<void, Error>();
+      const download = new AddonDownload(
+        ack.id,
+        ack.queuePosition,
+        completion,
+        () =>
+          this.addonWSListener
+            .send('download-action', {
+              downloadID: ack.id,
+              action: 'abort',
+            })
+            .pipe(Effect.asVoid),
+        (effect) => this.runBackground(effect)
+      );
+      this.addonWSListener.registerDownload(download);
+      return download;
+    });
+  }
+
+  public download(request: AddonDownloadRequest): Promise<AddonDownload> {
+    return this.runPromise(this.downloadEffect(request));
   }
 
   /**
@@ -600,6 +751,7 @@ class OGIAddonWSListener {
   public readonly eventEmitter: events.EventEmitter;
   public readonly addon: OGIAddon;
   private configConnected = false;
+  private readonly downloads = new Map<string, AddonDownload>();
 
   private constructor(
     addon: OGIAddon,
@@ -737,6 +889,10 @@ class OGIAddonWSListener {
     return this.configConnected;
   }
 
+  public registerDownload(download: AddonDownload): void {
+    this.downloads.set(download.id, download);
+  }
+
   private onOpen(): Effect.Effect<void, NetworkError | ValidationError> {
     return Effect.gen(this, function* () {
       yield* logger.info('Connected to OGI Addon Server');
@@ -781,6 +937,7 @@ class OGIAddonWSListener {
       'catalog',
       'task-run',
       'launch-app',
+      'download-status',
     ];
     return Effect.forEach(
       protocolEvents,
@@ -796,6 +953,21 @@ class OGIAddonWSListener {
     message: AddonServerToClientWebsocketMessage
   ): Effect.Effect<void> {
     return Effect.gen(this, function* () {
+      if (message.event === 'download-status') {
+        const update = message.args as AddonDownloadStatusUpdate;
+        const download = this.downloads.get(update.id);
+        if (!download) return;
+        if (
+          update.kind === 'status' &&
+          (update.status === 'completed' ||
+            update.status === 'error' ||
+            update.status === 'cancelled')
+        ) {
+          this.downloads.delete(update.id);
+        }
+        yield* download.dispatch(update);
+        return;
+      }
       const id = message.id;
       if (!id) {
         return yield* Effect.fail(

--- a/packages/ogi-addon/src/main.ts
+++ b/packages/ogi-addon/src/main.ts
@@ -400,7 +400,7 @@ export default class OGIAddon {
             .pipe(Effect.asVoid),
         (effect) => this.runBackground(effect)
       );
-      this.addonWSListener.registerDownload(download);
+      yield* this.addonWSListener.registerDownload(download);
       return download;
     });
   }
@@ -752,6 +752,10 @@ class OGIAddonWSListener {
   public readonly addon: OGIAddon;
   private configConnected = false;
   private readonly downloads = new Map<string, AddonDownload>();
+  private readonly pendingDownloadUpdates = new Map<
+    string,
+    AddonDownloadStatusUpdate[]
+  >();
 
   private constructor(
     addon: OGIAddon,
@@ -889,8 +893,31 @@ class OGIAddonWSListener {
     return this.configConnected;
   }
 
-  public registerDownload(download: AddonDownload): void {
-    this.downloads.set(download.id, download);
+  public registerDownload(download: AddonDownload): Effect.Effect<void> {
+    return Effect.gen(this, function* () {
+      this.downloads.set(download.id, download);
+      const buffered = this.pendingDownloadUpdates.get(download.id);
+      if (!buffered) return;
+      this.pendingDownloadUpdates.delete(download.id);
+      for (const update of buffered) {
+        yield* this.dispatchDownloadUpdate(download, update);
+      }
+    });
+  }
+
+  private dispatchDownloadUpdate(
+    download: AddonDownload,
+    update: AddonDownloadStatusUpdate
+  ): Effect.Effect<void> {
+    if (
+      update.kind === 'status' &&
+      (update.status === 'completed' ||
+        update.status === 'error' ||
+        update.status === 'cancelled')
+    ) {
+      this.downloads.delete(update.id);
+    }
+    return download.dispatch(update);
   }
 
   private onOpen(): Effect.Effect<void, NetworkError | ValidationError> {
@@ -956,16 +983,15 @@ class OGIAddonWSListener {
       if (message.event === 'download-status') {
         const update = message.args as AddonDownloadStatusUpdate;
         const download = this.downloads.get(update.id);
-        if (!download) return;
-        if (
-          update.kind === 'status' &&
-          (update.status === 'completed' ||
-            update.status === 'error' ||
-            update.status === 'cancelled')
-        ) {
-          this.downloads.delete(update.id);
+        if (!download) {
+          // The ack fiber may not have registered the handle yet; buffer so
+          // registerDownload can replay these in order instead of dropping.
+          const buffered = this.pendingDownloadUpdates.get(update.id) ?? [];
+          buffered.push(update);
+          this.pendingDownloadUpdates.set(update.id, buffered);
+          return;
         }
-        yield* download.dispatch(update);
+        yield* this.dispatchDownloadUpdate(download, update);
         return;
       }
       const id = message.id;

--- a/test-addon/main.ts
+++ b/test-addon/main.ts
@@ -170,7 +170,7 @@ addon.onTask('download-test', async (task) => {
     name: 'Download API test',
     files: [
       {
-        link: 'https://raw.githubusercontent.com/Nat3z/OpenGameInstaller/main/README.md',
+        link: 'https://raw.githubusercontent.com/Nat3z/OpenGameInstaller/872c79ac7f975cbd40ef75178cd134517a0248d7/README.md',
         path: 'ogi-download-test/test-file.bin',
       },
     ],

--- a/test-addon/main.ts
+++ b/test-addon/main.ts
@@ -47,6 +47,14 @@ addon.on('configure', (config) =>
         .setButtonText('Run Custom Task')
         .setTaskName('custom-task-name')
     )
+    .addActionOption((option) =>
+      option
+        .setDisplayName('Download API Test')
+        .setName('downloadTest')
+        .setDescription('Enqueue and track a download from the addon SDK')
+        .setButtonText('Run Download Test')
+        .setTaskName('download-test')
+    )
     .addNumberOption((option) =>
       option
         .setDisplayName('Test Number Range Option')
@@ -155,6 +163,26 @@ addon.onTask('task-test', (task) => {
   setTimeout(() => {
     task.complete();
   }, 1000);
+});
+
+addon.onTask('download-test', async (task) => {
+  const download = await addon.download({
+    name: 'Download API test',
+    files: [
+      {
+        link: 'https://raw.githubusercontent.com/Nat3z/OpenGameInstaller/main/README.md',
+        path: 'ogi-download-test/test-file.bin',
+      },
+    ],
+  });
+  download.on('progress', (progress) => {
+    task.log(`Download progress: ${JSON.stringify(progress)}`);
+  });
+  download.on('status', (status) => {
+    task.log(`Download status: ${JSON.stringify(status)}`);
+  });
+  await download.wait();
+  task.complete();
 });
 
 addon.on('search', ({ storefront, appID, for: searchFor }, event) => {


### PR DESCRIPTION
# Description

Adds `addon.download()` to the addon SDK: addons can enqueue raw HTTP(S) file downloads into the same global download queue as user downloads, with a live handle for progress, status, queue position, `wait()`, and `abort()`. Downloads appear in the download manager as normal cards with full user pause/resume/cancel; user cancel rejects `wait()` the same as `dl.abort()`. Addon disconnect aborts its in-flight downloads and preserves partial files on disk.

- **`@ogi-sdk/connect`**: new protocol types (`AddonDownloadRequest`, `AddonDownloadAck`, `AddonDownloadStatusUpdate`), `download-request` / `download-action` addon messages, `download-status` server command, and `addon-disconnect` / `download-request` / `download-action` host events.
- **`@ogi-sdk/addon-server`**: message handlers with error-ack when the host has no listener, `sendDownloadStatus`, and `addon-disconnect` emission on socket close.
- **`ogi-addon`**: `AddonDownload` handle (Deferred-backed `wait()`, live `queuePosition`, `on('progress'|'status')`) behind a promise adapter over the Effect internals.
- **Electron**: `addon-downloads.ts` bridge — request validation, sanitized path resolution (absolute pass-through, relative under the configured download dir), library metadata lookup, per-addon ownership tracking, disconnect-race handling, and card push to the renderer over `ddl:addon-download-created`. `handler.ddl.ts` gains typed lifecycle hooks (`onProgress`, `onTerminal` outcomes, `preservePartialFilesOnCancel`) threaded through `DownloadServiceShape.start`.
- **Frontend**: addon cards reuse the direct-download card path (`isAddonDownload` flag), skip the setup phase on completion, and are excluded from persistence/restart since the owning addon session holds the links.

# Example

```ts
addon.onTask('download-test', async (task) => {
  const download = await addon.download({
    name: 'Download API test',
    files: [{ link: 'https://…/README.md', path: 'ogi-download-test/test-file.bin' }],
  });
  download.on('progress', (p) => task.log(`progress: ${JSON.stringify(p)}`));
  download.on('status', (s) => task.log(`status: ${JSON.stringify(s)}`));
  await download.wait();
  task.complete();
});
```

Runnable from the test-addon's "Download API Test" action button.

# Next Steps

- Live end-to-end smoke test in the packaged app (addon socket + renderer together)
- Consider addon-facing pause/resume actions (only abort is exposed today)
- Document `addon.download()` in the addon developer docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Addons can start HTTP(S) file downloads directly in the app.
  - Downloads appear in the global queue with progress, status, queue position, and completion updates.
  - Addon downloads support cancellation, completion tracking, and cleanup when an addon disconnects.
  - Downloaded addon files bypass unnecessary setup processing and display “Download Complete.”
  - Download progress and terminal outcomes are now reported consistently.

- **Documentation**
  - Added API guidance and an end-to-end example for addon-initiated downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->