### PR TITLE
feat(application): show update-check spinner on play button

### DIFF
--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -541,7 +541,7 @@ function handleRunTask(task: SearchResult, addonID: string) {
       <div
         class="flex flex-wrap items-center gap-3 rounded-b-lg bg-accent-lighter px-6 py-4 backdrop-blur-sm"
       >
-        {#if updateInfo && !hasActiveUpdateDownload && !isUpdateDismissed}
+        {#if updateInfo && !hasActiveUpdateDownload && !isUpdateDismissed && !$gamesLaunched[libraryInfo.appID]}
           <button
             class="flex items-center justify-center gap-2 rounded-lg border-none bg-success px-6 py-3 text-overlay-text transition-colors duration-200 hover:bg-success-hover disabled:cursor-not-allowed disabled:bg-disabled"
             onclick={() => (showUpdateModal = true)}
@@ -642,7 +642,7 @@ function handleRunTask(task: SearchResult, addonID: string) {
           </button>
         {/if}
 
-        {#if updateInfo && !hasActiveUpdateDownload && isUpdateDismissed}
+        {#if updateInfo && !hasActiveUpdateDownload && isUpdateDismissed && !$gamesLaunched[libraryInfo.appID]}
           <button
             aria-label="Open update options"
             title="Open update options"

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -80,6 +80,9 @@ interface Props {
 
 let { libraryInfo = $bindable(), exitPlayPage }: Props = $props();
 
+let isCheckingForUpdates = $derived(
+  updatesManager.isCheckingAppUpdate(libraryInfo.appID)
+);
 let requiresSteamReadd = $derived(
   libraryInfo.umu?.steamShortcutReaddId !== undefined ||
     appUpdates.requiredReadds.some((r) => r.appID === libraryInfo.appID)
@@ -612,6 +615,18 @@ function handleRunTask(task: SearchResult, addonID: string) {
             disabled
           >
             <p class="font-archivo font-semibold text-overlay-text">PLAYING</p>
+          </button>
+        {:else if isCheckingForUpdates}
+          <button
+            class="flex items-center justify-center gap-2 rounded-lg border-none bg-disabled px-6 py-3 text-overlay-text transition-colors duration-200 cursor-not-allowed"
+            disabled
+          >
+            <div
+              class="h-5 w-5 rounded-full border-2 border-overlay-text/40 border-t-overlay-text animate-spin"
+            ></div>
+            <p class="font-archivo font-semibold text-overlay-text">
+              Checking for updates
+            </p>
           </button>
         {:else}
           <button

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -121,9 +121,10 @@ const addonFailurePrompt = createLaunchPrompt();
 
 async function launchGame() {
   if ($gamesLaunched[libraryInfo.appID]) return;
-  if (!playButton) return;
   logger.sync.info('Launching game with appID: ' + libraryInfo.appID);
-  playButton.setAttribute('data-error', 'false');
+  // playButton may be unbound (e.g. update-available button rendered instead);
+  // launching still proceeds since gamesLaunched drives the button states
+  playButton?.setAttribute('data-error', 'false');
 
   // Fire of the addon launch-app event first
 
@@ -132,9 +133,11 @@ async function launchGame() {
     return games;
   });
 
-  playButton.disabled = true;
-  playButton.querySelector('svg')!!.style.display = 'none';
-  playButton.querySelector('p')!!.textContent = 'WAITING';
+  if (playButton) {
+    playButton.disabled = true;
+    playButton.querySelector('svg')!!.style.display = 'none';
+    playButton.querySelector('p')!!.textContent = 'WAITING';
+  }
   try {
     logger.sync.info('launching pre-launch');
     logger.sync.info('launchApp', libraryInfo);

--- a/application/src/frontend/managers/AppUpdateManager.svelte
+++ b/application/src/frontend/managers/AppUpdateManager.svelte
@@ -40,6 +40,9 @@ async function onAddonManifestsReady() {
 function checkForAppUpdates() {
   const runId = ++updateCheckRunId;
   updatesManager.clearAppUpdates();
+  // mark the sweep as resolving immediately so games don't briefly show as
+  // playable while the library/connected addons are still being loaded
+  updatesManager.beginAppUpdateSweep();
   logger.sync.info('checking for app updates');
 
   const workflow = Effect.gen(function* () {

--- a/application/src/frontend/managers/AppUpdateManager.svelte
+++ b/application/src/frontend/managers/AppUpdateManager.svelte
@@ -24,7 +24,17 @@ document.addEventListener('addon-manifests-ready', () => {
 async function onAddonManifestsReady() {
   await runFrontendEffect(
     Effect.gen(function* () {
-      const connectedAddons = yield* fetchAddonsWithConfigure();
+      // the handshake retries its addon-server queries forever; bound it so
+      // this handler can't hang indefinitely when the server never comes up
+      const connectedAddons = yield* fetchAddonsWithConfigure().pipe(
+        Effect.timeoutFail({
+          duration: '30 seconds',
+          onTimeout: () =>
+            new UpdateError({
+              message: 'Timed out configuring addons for update checks',
+            }),
+        })
+      );
       yield* checkForAppUpdates(connectedAddons);
     }).pipe(
       Effect.catchAll((error) =>

--- a/application/src/frontend/managers/AppUpdateManager.svelte
+++ b/application/src/frontend/managers/AppUpdateManager.svelte
@@ -52,16 +52,25 @@ function checkForAppUpdates() {
     });
     const connectedAddons = yield* queryConnectedAddons();
     const addonServer = yield* getAddonServer();
+    const checkableApps = library
+      .map((app) => ({
+        app,
+        addons: connectedAddons.filter(
+          (addon) =>
+            supportsStorefront(addon.storefronts, app.storefront) &&
+            isAddonEventAvailable(addon, 'check-for-updates')
+        ),
+      }))
+      .filter(({ addons }) => addons.length > 0);
+    if (runId === updateCheckRunId) {
+      updatesManager.setCheckingAppUpdates(
+        checkableApps.map(({ app }) => app.appID)
+      );
+    }
     yield* Effect.forEach(
-      library,
-      (app) =>
+      checkableApps,
+      ({ app, addons }) =>
         Effect.gen(function* () {
-          const addons = connectedAddons.filter(
-            (addon) =>
-              supportsStorefront(addon.storefronts, app.storefront) &&
-              isAddonEventAvailable(addon, 'check-for-updates')
-          );
-          if (addons.length === 0) return;
           if (addons.length > 1) {
             return yield* Effect.fail(
               new UpdateError({
@@ -92,12 +101,29 @@ function checkForAppUpdates() {
         }).pipe(
           Effect.catchAll((error) =>
             logger.error('Error checking for updates for app', app.name, error)
+          ),
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (runId === updateCheckRunId) {
+                updatesManager.finishAppUpdateCheck(app.appID);
+              }
+            })
           )
         ),
       { concurrency: 4 }
     );
   });
 
-  return workflow;
+  return workflow.pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        // if the whole run dies early (e.g. addon server unavailable),
+        // never leave games stuck on the checking spinner
+        if (runId === updateCheckRunId) {
+          updatesManager.setCheckingAppUpdates([]);
+        }
+      })
+    )
+  );
 }
 </script>

--- a/application/src/frontend/managers/AppUpdateManager.svelte
+++ b/application/src/frontend/managers/AppUpdateManager.svelte
@@ -6,10 +6,10 @@ import core from '@/frontend/lib/core';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { updatesManager } from '@/frontend/states.svelte';
 import {
+  type AddonInfo,
   fetchAddonsWithConfigure,
   getAddonServer,
   isAddonEventAvailable,
-  queryConnectedAddons,
 } from '@/frontend/utils';
 import { supportsStorefront } from '@/lib/storefronts';
 
@@ -24,8 +24,8 @@ document.addEventListener('addon-manifests-ready', () => {
 async function onAddonManifestsReady() {
   await runFrontendEffect(
     Effect.gen(function* () {
-      yield* fetchAddonsWithConfigure();
-      yield* checkForAppUpdates();
+      const connectedAddons = yield* fetchAddonsWithConfigure();
+      yield* checkForAppUpdates(connectedAddons);
     }).pipe(
       Effect.catchAll((error) =>
         logger.error(
@@ -37,39 +37,24 @@ async function onAddonManifestsReady() {
   );
 }
 
-function checkForAppUpdates() {
+function checkForAppUpdates(connectedAddons: AddonInfo[]) {
   const runId = ++updateCheckRunId;
   updatesManager.clearAppUpdates();
-  // mark the sweep as resolving immediately so games don't briefly show as
-  // playable while the library/connected addons are still being loaded
+  // mark the sweep as resolving immediately so checkable games don't briefly
+  // show as playable while the library is still being loaded
   updatesManager.beginAppUpdateSweep();
   logger.sync.info('checking for app updates');
 
   const workflow = Effect.gen(function* () {
-    // bound resolution so a permanently unavailable addon server (getAddonServer
-    // retries forever) can't leave every game stuck on the checking spinner
-    const { library, connectedAddons, addonServer } = yield* Effect.gen(
-      function* () {
-        const library = yield* Effect.tryPromise({
-          try: () => core.library.getAllApps(),
-          catch: (cause) =>
-            new UpdateError({
-              message: `Failed to load library: ${formatError(cause)}`,
-            }),
-        });
-        const connectedAddons = yield* queryConnectedAddons();
-        const addonServer = yield* getAddonServer();
-        return { library, connectedAddons, addonServer };
-      }
-    ).pipe(
-      Effect.timeoutFail({
-        duration: '15 seconds',
-        onTimeout: () =>
-          new UpdateError({
-            message: 'Timed out resolving addon server for update checks',
-          }),
-      })
-    );
+    const library = yield* Effect.tryPromise({
+      try: () => core.library.getAllApps(),
+      catch: (cause) =>
+        new UpdateError({
+          message: `Failed to load library: ${formatError(cause)}`,
+        }),
+    });
+    // narrow the spinner to games with an update-capable addon before touching
+    // the addon server, so everything else returns to PLAY immediately
     const checkableApps = library
       .map((app) => ({
         app,
@@ -85,6 +70,18 @@ function checkForAppUpdates() {
         checkableApps.map(({ app }) => app.appID)
       );
     }
+    if (checkableApps.length === 0) return;
+    // bound resolution so a permanently unavailable addon server (getAddonServer
+    // retries forever) can't leave checkable games stuck on the spinner
+    const addonServer = yield* getAddonServer().pipe(
+      Effect.timeoutFail({
+        duration: '15 seconds',
+        onTimeout: () =>
+          new UpdateError({
+            message: 'Timed out resolving addon server for update checks',
+          }),
+      })
+    );
     yield* Effect.forEach(
       checkableApps,
       ({ app, addons }) =>

--- a/application/src/frontend/managers/AppUpdateManager.svelte
+++ b/application/src/frontend/managers/AppUpdateManager.svelte
@@ -46,15 +46,30 @@ function checkForAppUpdates() {
   logger.sync.info('checking for app updates');
 
   const workflow = Effect.gen(function* () {
-    const library = yield* Effect.tryPromise({
-      try: () => core.library.getAllApps(),
-      catch: (cause) =>
-        new UpdateError({
-          message: `Failed to load library: ${formatError(cause)}`,
-        }),
-    });
-    const connectedAddons = yield* queryConnectedAddons();
-    const addonServer = yield* getAddonServer();
+    // bound resolution so a permanently unavailable addon server (getAddonServer
+    // retries forever) can't leave every game stuck on the checking spinner
+    const { library, connectedAddons, addonServer } = yield* Effect.gen(
+      function* () {
+        const library = yield* Effect.tryPromise({
+          try: () => core.library.getAllApps(),
+          catch: (cause) =>
+            new UpdateError({
+              message: `Failed to load library: ${formatError(cause)}`,
+            }),
+        });
+        const connectedAddons = yield* queryConnectedAddons();
+        const addonServer = yield* getAddonServer();
+        return { library, connectedAddons, addonServer };
+      }
+    ).pipe(
+      Effect.timeoutFail({
+        duration: '15 seconds',
+        onTimeout: () =>
+          new UpdateError({
+            message: 'Timed out resolving addon server for update checks',
+          }),
+      })
+    );
     const checkableApps = library
       .map((app) => ({
         app,

--- a/application/src/frontend/states.svelte.ts
+++ b/application/src/frontend/states.svelte.ts
@@ -79,6 +79,8 @@ export let appUpdates = $state({
   }[],
   requiredReadds: [] as RequiredReadd[],
   dismissedUpdates: [] as DismissedUpdate[],
+  // appIDs currently awaiting a check-for-updates response from an addon
+  checkingApps: [] as number[],
 });
 
 export function queueRequiredReadd(appID: number, steamAppId?: number): void {
@@ -189,6 +191,17 @@ export const updatesManager = {
   },
   getAppUpdate: (appID: number) => {
     return appUpdates.apps.find((app) => app.appID === appID);
+  },
+  setCheckingAppUpdates: (appIDs: number[]) => {
+    appUpdates.checkingApps = appIDs;
+  },
+  finishAppUpdateCheck: (appID: number) => {
+    appUpdates.checkingApps = appUpdates.checkingApps.filter(
+      (id) => id !== appID
+    );
+  },
+  isCheckingAppUpdate: (appID: number) => {
+    return appUpdates.checkingApps.includes(appID);
   },
   dismissAppUpdate: (appID: number, updateVersion: string) => {
     if (

--- a/application/src/frontend/states.svelte.ts
+++ b/application/src/frontend/states.svelte.ts
@@ -81,6 +81,9 @@ export let appUpdates = $state({
   dismissedUpdates: [] as DismissedUpdate[],
   // appIDs currently awaiting a check-for-updates response from an addon
   checkingApps: [] as number[],
+  // true while a sweep is still resolving which games are checkable,
+  // so games don't show as playable before their check even starts
+  updateSweepResolving: false,
 });
 
 export function queueRequiredReadd(appID: number, steamAppId?: number): void {
@@ -192,8 +195,12 @@ export const updatesManager = {
   getAppUpdate: (appID: number) => {
     return appUpdates.apps.find((app) => app.appID === appID);
   },
+  beginAppUpdateSweep: () => {
+    appUpdates.updateSweepResolving = true;
+  },
   setCheckingAppUpdates: (appIDs: number[]) => {
     appUpdates.checkingApps = appIDs;
+    appUpdates.updateSweepResolving = false;
   },
   finishAppUpdateCheck: (appID: number) => {
     appUpdates.checkingApps = appUpdates.checkingApps.filter(
@@ -201,7 +208,9 @@ export const updatesManager = {
     );
   },
   isCheckingAppUpdate: (appID: number) => {
-    return appUpdates.checkingApps.includes(appID);
+    return (
+      appUpdates.updateSweepResolving || appUpdates.checkingApps.includes(appID)
+    );
   },
   dismissAppUpdate: (appID: number, updateVersion: string) => {
     if (


### PR DESCRIPTION
# Description

When addons connect, the app sweeps the library with each addon's `check-for-updates` event. Until now the Play button rendered normally during that sweep, so an available update could pop in after the user already hit Play. The Play button now shows a disabled "Checking for updates" spinner while that game's check is in flight.

- `states.svelte.ts`: added `checkingApps` to the `appUpdates` state with `setCheckingAppUpdates` / `finishAppUpdateCheck` / `isCheckingAppUpdate` on `updatesManager`.
- `AppUpdateManager.svelte`: the sweep precomputes which games have a connected addon serving `check-for-updates` and marks only those as checking; each game clears its flag as soon as its own check settles, and an `Effect.ensuring` on the whole workflow clears everything if the run dies early. `runId` guards keep a stale sweep from clobbering a newer one.
- `PlayPage.svelte`: new button branch with a spinner ring and "Checking for updates", yielding to the launching/playing and update-available states.

# Example

While an addon's `check-for-updates` runs for the opened game:

```
[ (spinner) Checking for updates ]   ← disabled, in place of PLAY
```

Games with no update-capable addon skip `checkingApps` entirely and show PLAY immediately.

# Next Steps

- Optionally mirror the checking state on library grid tiles in `LibraryView.svelte`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear progress feedback while games are being checked for updates.
  * Games remain unavailable until their update check begins and completes, helping prevent outdated launches.
  * Update controls are hidden while a game is launching or already running.
* **Bug Fixes**
  * Prevented update checks from remaining stuck when the addon service is unavailable.
  * Improved reliability of individual game update status tracking.
  * Game launching no longer fails when the play control is temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->