### PR TITLE
feat(application): show lazy game removal progress

### DIFF
--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -48,13 +48,18 @@ import {
   saveLibraryInfo,
   stageLibraryRemoval,
 } from '@/electron/handlers/helpers.app/library.js';
-import { generateNotificationId } from '@/electron/handlers/helpers.app/notifications.js';
+import {
+  generateNotificationId,
+  notifyError,
+  notifySuccess,
+} from '@/electron/handlers/helpers.app/notifications.js';
 import { isLinux } from '@/electron/handlers/helpers.app/platform.js';
 import {
   appMetadataSubtrees,
   type DeleteGuardRoots,
   filesystemRoot,
   isProtectedDeletePath,
+  overlapsInstallDirectory,
   sharesDirectoryWithOtherGames,
   systemSubtrees,
 } from '@/electron/lib/delete-guards.js';
@@ -137,7 +142,9 @@ export function awaitPendingFileDeletions(): Promise<void> {
  * Deletes a removed game's files in the background, streaming throttled
  * `game:removal-progress` events to the renderer and keeping the latest
  * snapshot in `removalTasks`. The removal itself has already been committed;
- * this only cleans up the files on disk.
+ * this only cleans up the files on disk. Only files present when the task
+ * started are removed, and the task stops if a library entry reclaims the
+ * directory, so a reinstall mid-deletion keeps its files.
  */
 function startBackgroundFileDeletion(
   appid: number,
@@ -146,10 +153,24 @@ function startBackgroundFileDeletion(
 ): string {
   const taskId = `removal-${appid}-${++removalSequence}`;
   const base = { id: taskId, appID: appid, gameName };
+  // The main process owns the terminal notification so it fires exactly once
+  // even if the renderer reloads mid-deletion.
   const send = (payload: GameRemovalProgress) => {
     const task = removalTasks.get(taskId);
     if (task) task.snapshot = payload;
     void sendIPCMessage('game:removal-progress', payload);
+    if (payload.status === 'completed') {
+      notifySuccess(`${gameName} removed from library and files deleted`);
+    } else if (payload.status === 'error') {
+      notifyError(
+        `${gameName} was removed from the library, but its files could not be deleted: ${payload.error}`
+      );
+    }
+  };
+  const assertNotReclaimed = () => {
+    if (overlapsInstallDirectory(cwd, getAllLibraryFiles())) {
+      throw new Error('the folder is now used by a game in the library');
+    }
   };
 
   // Serialize against other per-game operations so a launch cannot
@@ -166,6 +187,11 @@ function startBackgroundFileDeletion(
         withFileTypes: true,
       });
       const files = entries.filter((entry) => !entry.isDirectory());
+      // Deepest first so each directory is empty by the time it is removed.
+      const directories = entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => join(entry.parentPath, entry.name))
+        .sort((a, b) => b.length - a.length);
       total = files.length;
       send({ ...base, status: 'running', progress: 0, deleted, total });
 
@@ -176,6 +202,7 @@ function startBackgroundFileDeletion(
         const now = Date.now();
         if (now - lastEmit >= 200) {
           lastEmit = now;
+          assertNotReclaimed();
           send({
             ...base,
             status: 'running',
@@ -185,8 +212,12 @@ function startBackgroundFileDeletion(
           });
         }
       }
-      // Sweep the now-empty directory tree.
-      await fsp.rm(cwd, { recursive: true, force: true });
+      // Sweep only directories that are now empty; anything written since the
+      // snapshot (e.g. a reinstall) is left alone.
+      assertNotReclaimed();
+      for (const directory of [...directories, cwd]) {
+        await fsp.rmdir(directory).catch(() => undefined);
+      }
       send({ ...base, status: 'completed', progress: 100, deleted, total });
     } catch (cause) {
       logger.sync.error(

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -138,15 +138,36 @@ export function awaitPendingFileDeletions(): Promise<void> {
 }
 
 /**
+ * Renames `from` to `to`, retrying briefly for transient holders such as a
+ * virus scanner. Throws when the directory still cannot be isolated.
+ */
+async function moveDirectoryAside(from: string, to: string): Promise<void> {
+  const attempts = 5;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await fsp.rename(from, to);
+      return;
+    } catch (cause) {
+      if (attempt === attempts) {
+        throw new Error(
+          `its folder could not be moved aside for deletion (${cause instanceof Error ? cause.message : String(cause)})`
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+}
+
+/**
  * Deletes a removed game's files in the background, streaming throttled
  * `game:removal-progress` events to the renderer and keeping the latest
  * snapshot in `removalTasks`. The removal itself has already been committed;
  * this only cleans up the files on disk.
  *
  * The directory is first renamed to a hidden sibling so a reinstall into the
- * original path can never collide with the deletion. If the rename fails
- * (Windows refuses it while any file inside is open), deletion proceeds in
- * place and skips files changed since the snapshot was taken.
+ * original path can never collide with the deletion. If the rename keeps
+ * failing (Windows refuses it while any file inside is open) the task fails
+ * without touching the directory rather than deleting in place.
  */
 function startBackgroundFileDeletion(
   appid: number,
@@ -179,16 +200,12 @@ function startBackgroundFileDeletion(
       if (runningGames.has(appid)) {
         throw new Error('the game is currently running');
       }
-      const startedAt = Date.now();
       const aside = join(
         dirname(cwd),
-        `.${basename(cwd)}.ogi-removing-${startedAt}`
+        `.${basename(cwd)}.ogi-removing-${Date.now()}`
       );
-      const movedAside = await fsp.rename(cwd, aside).then(
-        () => true,
-        () => false
-      );
-      const root = movedAside ? aside : cwd;
+      await moveDirectoryAside(cwd, aside);
+      const root = aside;
       const entries = await fsp.readdir(root, {
         recursive: true,
         withFileTypes: true,
@@ -204,17 +221,7 @@ function startBackgroundFileDeletion(
 
       let lastEmit = Date.now();
       for (const file of files) {
-        const path = join(file.parentPath, file.name);
-        // In place, a file rewritten since the snapshot belongs to whoever
-        // rewrote it (e.g. a reinstall); ctime cannot be backdated.
-        if (!movedAside) {
-          const changed = await fsp.stat(path).then(
-            (stat) => stat.ctimeMs >= startedAt,
-            () => true
-          );
-          if (changed) continue;
-        }
-        await fsp.rm(path, { force: true });
+        await fsp.rm(join(file.parentPath, file.name), { force: true });
         deleted++;
         const now = Date.now();
         if (now - lastEmit >= 200) {
@@ -228,8 +235,7 @@ function startBackgroundFileDeletion(
           });
         }
       }
-      // Sweep only directories that are now empty; anything written since the
-      // snapshot is left alone.
+      // Sweep the now-empty directory tree.
       for (const directory of [...directories, root]) {
         await fsp.rmdir(directory).catch(() => undefined);
       }

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -159,37 +159,19 @@ async function moveDirectoryAside(from: string, to: string): Promise<void> {
 }
 
 /**
- * Claims a removed game's directory by renaming it to a hidden sibling before
- * the removal RPC returns, so a later reinstall into the original path can
- * never collide with the background deletion. Serialized against other
- * per-game operations so a launch cannot interleave with the rename. Resolves
- * with the new path.
- */
-function moveGameDirectoryAside(appid: number, cwd: string): Promise<string> {
-  return enqueueGameOperation(appid, async () => {
-    if (runningGames.has(appid)) {
-      throw new Error('the game is currently running');
-    }
-    const aside = join(
-      dirname(cwd),
-      `.${basename(cwd)}.ogi-removing-${Date.now()}`
-    );
-    await moveDirectoryAside(cwd, aside);
-    return aside;
-  });
-}
-
-/**
- * Deletes an already-isolated game directory in the background, streaming
- * throttled `game:removal-progress` events to the renderer and keeping the
- * latest snapshot in `removalTasks`. Nothing else can reach the moved-aside
- * directory, so no per-game queue is needed here.
+ * Removes a game's files in the background. The task is registered before any
+ * filesystem work so shutdown always waits for it. It first claims the
+ * directory by renaming it to a hidden sibling (serialized on the per-game
+ * queue so a launch cannot interleave), then deletes the isolated copy while
+ * streaming throttled `game:removal-progress` events and keeping the latest
+ * snapshot in `removalTasks`. `claimed` settles once the original path is free
+ * so callers can return before a reinstall could collide with the deletion.
  */
 function startBackgroundFileDeletion(
   appid: number,
-  root: string,
+  cwd: string,
   gameName: string
-): string {
+): { taskId: string; claimed: Promise<void> } {
   const taskId = `removal-${appid}-${++removalSequence}`;
   const base = { id: taskId, appID: appid, gameName };
   // The main process owns the terminal notification so it fires exactly once
@@ -206,8 +188,41 @@ function startBackgroundFileDeletion(
       );
     }
   };
+  const fail = (cause: unknown, deleted: number, total: number) => {
+    logger.sync.error(
+      `[library] Background file deletion failed for ${appid}:`,
+      cause
+    );
+    send({
+      ...base,
+      status: 'error',
+      progress: total === 0 ? 0 : (deleted / total) * 100,
+      deleted,
+      total,
+      error: cause instanceof Error ? cause.message : String(cause),
+    });
+  };
+
+  const claim = enqueueGameOperation(appid, async () => {
+    if (runningGames.has(appid)) {
+      throw new Error('the game is currently running');
+    }
+    const aside = join(
+      dirname(cwd),
+      `.${basename(cwd)}.ogi-removing-${Date.now()}`
+    );
+    await moveDirectoryAside(cwd, aside);
+    return aside;
+  });
 
   const done = (async () => {
+    let root: string;
+    try {
+      root = await claim;
+    } catch (cause) {
+      fail(cause, 0, 0);
+      return;
+    }
     let deleted = 0;
     let total = 0;
     try {
@@ -246,25 +261,20 @@ function startBackgroundFileDeletion(
       }
       send({ ...base, status: 'completed', progress: 100, deleted, total });
     } catch (cause) {
-      logger.sync.error(
-        `[library] Background file deletion failed for ${appid}:`,
-        cause
-      );
-      send({
-        ...base,
-        status: 'error',
-        progress: total === 0 ? 0 : (deleted / total) * 100,
-        deleted,
-        total,
-        error: cause instanceof Error ? cause.message : String(cause),
-      });
+      fail(cause, deleted, total);
     }
   })();
   removalTasks.set(taskId, {
     snapshot: { ...base, status: 'running', progress: 0, deleted: 0, total: 0 },
     done,
   });
-  return taskId;
+  return {
+    taskId,
+    claimed: claim.then(
+      () => undefined,
+      () => undefined
+    ),
+  };
 }
 
 /**
@@ -802,10 +812,11 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
 
               yield* Effect.sync(removal.commit);
 
-              // Claim the game folder now, then delete it lazily in the
-              // background; a skipped or refused deletion is a warning, not a
-              // failed removal (the library entry is already gone). Deletion
-              // progress streams to the renderer via `game:removal-progress`.
+              // Delete the game folder lazily in the background; a skipped
+              // deletion is a warning, not a failed removal (the library entry
+              // is already gone), and a failed one is reported by the task.
+              // Wait only for the folder to be claimed so a reinstall started
+              // after this returns can never collide with the deletion.
               let fileWarning: string | undefined;
               let deletionTaskId: string | undefined;
               if (appInfo.cwd) {
@@ -827,24 +838,15 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                   fileWarning =
                     'The game was removed from the library, but its files were not deleted because the directory contains other games.';
                 } else if (fs.existsSync(appInfo.cwd)) {
-                  const claimed = yield* Effect.either(
-                    Effect.tryPromise({
-                      try: () => moveGameDirectoryAside(appid, appInfo.cwd),
-                      catch: (cause) =>
-                        cause instanceof Error ? cause.message : String(cause),
-                    })
+                  const deletion = yield* Effect.sync(() =>
+                    startBackgroundFileDeletion(
+                      appid,
+                      appInfo.cwd,
+                      appInfo.name
+                    )
                   );
-                  if (claimed._tag === 'Left') {
-                    fileWarning = `The game was removed from the library, but its files could not be deleted: ${claimed.left}`;
-                  } else {
-                    deletionTaskId = yield* Effect.sync(() =>
-                      startBackgroundFileDeletion(
-                        appid,
-                        claimed.right,
-                        appInfo.name
-                      )
-                    );
-                  }
+                  yield* Effect.promise(() => deletion.claimed);
+                  deletionTaskId = deletion.taskId;
                 }
               }
 

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -18,7 +18,7 @@ import { Effect } from 'effect';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import { homedir } from 'os';
-import { join } from 'path';
+import { basename, dirname, join } from 'path';
 import { parse as shellQuoteParse } from 'shell-quote';
 import {
   addDeckGameToSteam,
@@ -59,7 +59,6 @@ import {
   type DeleteGuardRoots,
   filesystemRoot,
   isProtectedDeletePath,
-  overlapsInstallDirectory,
   sharesDirectoryWithOtherGames,
   systemSubtrees,
 } from '@/electron/lib/delete-guards.js';
@@ -142,9 +141,12 @@ export function awaitPendingFileDeletions(): Promise<void> {
  * Deletes a removed game's files in the background, streaming throttled
  * `game:removal-progress` events to the renderer and keeping the latest
  * snapshot in `removalTasks`. The removal itself has already been committed;
- * this only cleans up the files on disk. Only files present when the task
- * started are removed, and the task stops if a library entry reclaims the
- * directory, so a reinstall mid-deletion keeps its files.
+ * this only cleans up the files on disk.
+ *
+ * The directory is first renamed to a hidden sibling so a reinstall into the
+ * original path can never collide with the deletion. If the rename fails
+ * (Windows refuses it while any file inside is open), deletion proceeds in
+ * place and skips files changed since the snapshot was taken.
  */
 function startBackgroundFileDeletion(
   appid: number,
@@ -167,11 +169,6 @@ function startBackgroundFileDeletion(
       );
     }
   };
-  const assertNotReclaimed = () => {
-    if (overlapsInstallDirectory(cwd, getAllLibraryFiles())) {
-      throw new Error('the folder is now used by a game in the library');
-    }
-  };
 
   // Serialize against other per-game operations so a launch cannot
   // interleave with the deletion.
@@ -182,7 +179,17 @@ function startBackgroundFileDeletion(
       if (runningGames.has(appid)) {
         throw new Error('the game is currently running');
       }
-      const entries = await fsp.readdir(cwd, {
+      const startedAt = Date.now();
+      const aside = join(
+        dirname(cwd),
+        `.${basename(cwd)}.ogi-removing-${startedAt}`
+      );
+      const movedAside = await fsp.rename(cwd, aside).then(
+        () => true,
+        () => false
+      );
+      const root = movedAside ? aside : cwd;
+      const entries = await fsp.readdir(root, {
         recursive: true,
         withFileTypes: true,
       });
@@ -197,12 +204,21 @@ function startBackgroundFileDeletion(
 
       let lastEmit = Date.now();
       for (const file of files) {
-        await fsp.rm(join(file.parentPath, file.name), { force: true });
+        const path = join(file.parentPath, file.name);
+        // In place, a file rewritten since the snapshot belongs to whoever
+        // rewrote it (e.g. a reinstall); ctime cannot be backdated.
+        if (!movedAside) {
+          const changed = await fsp.stat(path).then(
+            (stat) => stat.ctimeMs >= startedAt,
+            () => true
+          );
+          if (changed) continue;
+        }
+        await fsp.rm(path, { force: true });
         deleted++;
         const now = Date.now();
         if (now - lastEmit >= 200) {
           lastEmit = now;
-          assertNotReclaimed();
           send({
             ...base,
             status: 'running',
@@ -213,9 +229,8 @@ function startBackgroundFileDeletion(
         }
       }
       // Sweep only directories that are now empty; anything written since the
-      // snapshot (e.g. a reinstall) is left alone.
-      assertNotReclaimed();
-      for (const directory of [...directories, cwd]) {
+      // snapshot is left alone.
+      for (const directory of [...directories, root]) {
         await fsp.rmdir(directory).catch(() => undefined);
       }
       send({ ...base, status: 'completed', progress: 100, deleted, total });

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -59,9 +59,9 @@ import {
   systemSubtrees,
 } from '@/electron/lib/delete-guards.js';
 import { resolveSpawnInvocation } from '@/electron/lib/spawn-shell.js';
-import { sendNotification } from '@/electron/main.js';
+import { sendIPCMessage, sendNotification } from '@/electron/main.js';
 import { __dirname } from '@/electron/manager/manager.paths.js';
-import { ElectronRpc } from '@/lib/electron-rpc.js';
+import { ElectronRpc, type GameRemovalProgress } from '@/lib/electron-rpc.js';
 
 const logger = createLogger(LOGGER_PREFIXES.electron);
 
@@ -95,39 +95,63 @@ const deleteGuardRoots = (): DeleteGuardRoots => ({
   subtrees: [...appMetadataSubtrees(__dirname), ...systemSubtrees()],
 });
 
-type RemovalProgressPayload = {
-  id: string;
-  appID: number;
-  gameName: string;
-  status: 'running' | 'completed' | 'error';
-  progress: number;
-  deleted: number;
-  total: number;
-  error?: string;
-};
+/**
+ * Background deletions keyed by task id. Snapshots outlive the renderer so a
+ * reload can re-query them; `done` lets shutdown wait for in-flight work.
+ */
+const removalTasks = new Map<
+  string,
+  { snapshot: GameRemovalProgress; done: Promise<void> }
+>();
+
+function removalTaskSnapshots(): GameRemovalProgress[] {
+  return [...removalTasks.values()].map((task) => task.snapshot);
+}
+
+/** Drops finished tasks the renderer has dismissed; running ones stay. */
+function dismissRemovalTasks(ids: string[]): void {
+  for (const id of ids) {
+    if (removalTasks.get(id)?.snapshot.status !== 'running') {
+      removalTasks.delete(id);
+    }
+  }
+}
+
+export function hasPendingFileDeletions(): boolean {
+  return [...removalTasks.values()].some(
+    (task) => task.snapshot.status === 'running'
+  );
+}
+
+/** Resolves once every in-flight deletion has settled. */
+export function awaitPendingFileDeletions(): Promise<void> {
+  return Promise.all([...removalTasks.values()].map((task) => task.done)).then(
+    () => undefined
+  );
+}
 
 /**
  * Deletes a removed game's files in the background, streaming throttled
- * `game:removal-progress` events to the renderer. The removal itself has
- * already been committed; this only cleans up the files on disk.
+ * `game:removal-progress` events to the renderer and keeping the latest
+ * snapshot in `removalTasks`. The removal itself has already been committed;
+ * this only cleans up the files on disk.
  */
 function startBackgroundFileDeletion(
   appid: number,
   cwd: string,
-  gameName: string,
-  mainWindow: Electron.BrowserWindow
+  gameName: string
 ): string {
   const taskId = `removal-${appid}`;
   const base = { id: taskId, appID: appid, gameName };
-  const send = (payload: RemovalProgressPayload) => {
-    if (!mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('game:removal-progress', payload);
-    }
+  const send = (payload: GameRemovalProgress) => {
+    const task = removalTasks.get(taskId);
+    if (task) task.snapshot = payload;
+    void sendIPCMessage('game:removal-progress', payload);
   };
 
   // Serialize against other per-game operations so a launch cannot
   // interleave with the deletion.
-  void enqueueGameOperation(appid, async () => {
+  const done = enqueueGameOperation(appid, async () => {
     let deleted = 0;
     let total = 0;
     try {
@@ -175,6 +199,10 @@ function startBackgroundFileDeletion(
         error: cause instanceof Error ? cause.message : String(cause),
       });
     }
+  });
+  removalTasks.set(taskId, {
+    snapshot: { ...base, status: 'running', progress: 0, deleted: 0, total: 0 },
+    done,
   });
   return taskId;
 }
@@ -743,8 +771,7 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                     startBackgroundFileDeletion(
                       appid,
                       appInfo.cwd,
-                      appInfo.name,
-                      mainWindow
+                      appInfo.name
                     )
                   );
                 }
@@ -772,6 +799,18 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
             )
         );
       })
+    )
+  );
+
+  const getRemovalTasks = ipcProcedure(
+    ElectronRpc.app.getRemovalTasks,
+    ipcBoundary(() => Effect.succeed(removalTaskSnapshots()))
+  );
+
+  const clearRemovalTasks = ipcProcedure(
+    ElectronRpc.app.clearRemovalTasks,
+    ipcBoundary((_, ids: string[]) =>
+      Effect.sync(() => dismissRemovalTasks(ids))
     )
   );
 
@@ -1056,6 +1095,8 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
     launchGame,
     executeWrapperCommand,
     removeApp,
+    getRemovalTasks,
+    clearRemovalTasks,
     insertApp,
     getAllApps,
     updateAppVersion,

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -159,19 +159,35 @@ async function moveDirectoryAside(from: string, to: string): Promise<void> {
 }
 
 /**
- * Deletes a removed game's files in the background, streaming throttled
- * `game:removal-progress` events to the renderer and keeping the latest
- * snapshot in `removalTasks`. The removal itself has already been committed;
- * this only cleans up the files on disk.
- *
- * The directory is first renamed to a hidden sibling so a reinstall into the
- * original path can never collide with the deletion. If the rename keeps
- * failing (Windows refuses it while any file inside is open) the task fails
- * without touching the directory rather than deleting in place.
+ * Claims a removed game's directory by renaming it to a hidden sibling before
+ * the removal RPC returns, so a later reinstall into the original path can
+ * never collide with the background deletion. Serialized against other
+ * per-game operations so a launch cannot interleave with the rename. Resolves
+ * with the new path.
+ */
+function moveGameDirectoryAside(appid: number, cwd: string): Promise<string> {
+  return enqueueGameOperation(appid, async () => {
+    if (runningGames.has(appid)) {
+      throw new Error('the game is currently running');
+    }
+    const aside = join(
+      dirname(cwd),
+      `.${basename(cwd)}.ogi-removing-${Date.now()}`
+    );
+    await moveDirectoryAside(cwd, aside);
+    return aside;
+  });
+}
+
+/**
+ * Deletes an already-isolated game directory in the background, streaming
+ * throttled `game:removal-progress` events to the renderer and keeping the
+ * latest snapshot in `removalTasks`. Nothing else can reach the moved-aside
+ * directory, so no per-game queue is needed here.
  */
 function startBackgroundFileDeletion(
   appid: number,
-  cwd: string,
+  root: string,
   gameName: string
 ): string {
   const taskId = `removal-${appid}-${++removalSequence}`;
@@ -191,21 +207,10 @@ function startBackgroundFileDeletion(
     }
   };
 
-  // Serialize against other per-game operations so a launch cannot
-  // interleave with the deletion.
-  const done = enqueueGameOperation(appid, async () => {
+  const done = (async () => {
     let deleted = 0;
     let total = 0;
     try {
-      if (runningGames.has(appid)) {
-        throw new Error('the game is currently running');
-      }
-      const aside = join(
-        dirname(cwd),
-        `.${basename(cwd)}.ogi-removing-${Date.now()}`
-      );
-      await moveDirectoryAside(cwd, aside);
-      const root = aside;
       const entries = await fsp.readdir(root, {
         recursive: true,
         withFileTypes: true,
@@ -254,7 +259,7 @@ function startBackgroundFileDeletion(
         error: cause instanceof Error ? cause.message : String(cause),
       });
     }
-  });
+  })();
   removalTasks.set(taskId, {
     snapshot: { ...base, status: 'running', progress: 0, deleted: 0, total: 0 },
     done,
@@ -797,10 +802,10 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
 
               yield* Effect.sync(removal.commit);
 
-              // Kick off file deletion lazily in the background; a skipped or
-              // refused deletion is a warning, not a failed removal (the
-              // library entry is already gone). Deletion progress streams to
-              // the renderer via `game:removal-progress`.
+              // Claim the game folder now, then delete it lazily in the
+              // background; a skipped or refused deletion is a warning, not a
+              // failed removal (the library entry is already gone). Deletion
+              // progress streams to the renderer via `game:removal-progress`.
               let fileWarning: string | undefined;
               let deletionTaskId: string | undefined;
               if (appInfo.cwd) {
@@ -822,13 +827,24 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                   fileWarning =
                     'The game was removed from the library, but its files were not deleted because the directory contains other games.';
                 } else if (fs.existsSync(appInfo.cwd)) {
-                  deletionTaskId = yield* Effect.sync(() =>
-                    startBackgroundFileDeletion(
-                      appid,
-                      appInfo.cwd,
-                      appInfo.name
-                    )
+                  const claimed = yield* Effect.either(
+                    Effect.tryPromise({
+                      try: () => moveGameDirectoryAside(appid, appInfo.cwd),
+                      catch: (cause) =>
+                        cause instanceof Error ? cause.message : String(cause),
+                    })
                   );
+                  if (claimed._tag === 'Left') {
+                    fileWarning = `The game was removed from the library, but its files could not be deleted: ${claimed.left}`;
+                  } else {
+                    deletionTaskId = yield* Effect.sync(() =>
+                      startBackgroundFileDeletion(
+                        appid,
+                        claimed.right,
+                        appInfo.name
+                      )
+                    );
+                  }
                 }
               }
 

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -18,6 +18,7 @@ import { Effect } from 'effect';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import { homedir } from 'os';
+import { join } from 'path';
 import { parse as shellQuoteParse } from 'shell-quote';
 import {
   addDeckGameToSteam,
@@ -93,6 +94,90 @@ const deleteGuardRoots = (): DeleteGuardRoots => ({
   exact: [filesystemRoot(), homedir(), __dirname],
   subtrees: [...appMetadataSubtrees(__dirname), ...systemSubtrees()],
 });
+
+type RemovalProgressPayload = {
+  id: string;
+  appID: number;
+  gameName: string;
+  status: 'running' | 'completed' | 'error';
+  progress: number;
+  deleted: number;
+  total: number;
+  error?: string;
+};
+
+/**
+ * Deletes a removed game's files in the background, streaming throttled
+ * `game:removal-progress` events to the renderer. The removal itself has
+ * already been committed; this only cleans up the files on disk.
+ */
+function startBackgroundFileDeletion(
+  appid: number,
+  cwd: string,
+  gameName: string,
+  mainWindow: Electron.BrowserWindow
+): string {
+  const taskId = `removal-${appid}`;
+  const base = { id: taskId, appID: appid, gameName };
+  const send = (payload: RemovalProgressPayload) => {
+    if (!mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('game:removal-progress', payload);
+    }
+  };
+
+  // Serialize against other per-game operations so a launch cannot
+  // interleave with the deletion.
+  void enqueueGameOperation(appid, async () => {
+    let deleted = 0;
+    let total = 0;
+    try {
+      if (runningGames.has(appid)) {
+        throw new Error('the game is currently running');
+      }
+      const entries = await fsp.readdir(cwd, {
+        recursive: true,
+        withFileTypes: true,
+      });
+      const files = entries.filter((entry) => !entry.isDirectory());
+      total = files.length;
+      send({ ...base, status: 'running', progress: 0, deleted, total });
+
+      let lastEmit = Date.now();
+      for (const file of files) {
+        await fsp.rm(join(file.parentPath, file.name), { force: true });
+        deleted++;
+        const now = Date.now();
+        if (now - lastEmit >= 200) {
+          lastEmit = now;
+          send({
+            ...base,
+            status: 'running',
+            progress: (deleted / total) * 100,
+            deleted,
+            total,
+          });
+        }
+      }
+      // Sweep the now-empty directory tree.
+      await fsp.rm(cwd, { recursive: true, force: true });
+      send({ ...base, status: 'completed', progress: 100, deleted, total });
+    } catch (cause) {
+      logger.sync.error(
+        `[library] Background file deletion failed for ${appid}:`,
+        cause
+      );
+      send({
+        ...base,
+        status: 'error',
+        progress: total === 0 ? 0 : (deleted / total) * 100,
+        deleted,
+        total,
+        error: cause instanceof Error ? cause.message : String(cause),
+      });
+    }
+  });
+  return taskId;
+}
 
 /**
  * Determine if a game should use UMU mode
@@ -629,11 +714,12 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
 
               yield* Effect.sync(removal.commit);
 
-              // Delete the game files from disk; a failed, skipped, or
+              // Kick off file deletion lazily in the background; a skipped or
               // refused deletion is a warning, not a failed removal (the
-              // library entry is already gone).
+              // library entry is already gone). Deletion progress streams to
+              // the renderer via `game:removal-progress`.
               let fileWarning: string | undefined;
-              let filesDeleted = false;
+              let deletionTaskId: string | undefined;
               if (appInfo.cwd) {
                 if (runningGames.has(appid)) {
                   fileWarning =
@@ -653,29 +739,14 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                   fileWarning =
                     'The game was removed from the library, but its files were not deleted because the directory contains other games.';
                 } else if (fs.existsSync(appInfo.cwd)) {
-                  const deletion = yield* Effect.either(
-                    Effect.tryPromise({
-                      try: () =>
-                        // Serialize against other per-game operations so a
-                        // launch cannot interleave with the recursive rm
-                        enqueueGameOperation(appid, async () => {
-                          if (runningGames.has(appid)) {
-                            throw new Error('the game is currently running');
-                          }
-                          await fsp.rm(appInfo.cwd, {
-                            recursive: true,
-                            force: true,
-                          });
-                        }),
-                      catch: (cause) =>
-                        cause instanceof Error ? cause.message : String(cause),
-                    })
+                  deletionTaskId = yield* Effect.sync(() =>
+                    startBackgroundFileDeletion(
+                      appid,
+                      appInfo.cwd,
+                      appInfo.name,
+                      mainWindow
+                    )
                   );
-                  if (deletion._tag === 'Left') {
-                    fileWarning = `The game was removed from the library, but its files could not be deleted: ${deletion.left}`;
-                  } else {
-                    filesDeleted = true;
-                  }
                 }
               }
 
@@ -683,7 +754,7 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                 status: 'success' as const,
                 warning:
                   [warning, fileWarning].filter(Boolean).join(' ') || undefined,
-                filesDeleted,
+                deletionTaskId,
               };
             }),
           (removal) =>

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -103,6 +103,9 @@ const removalTasks = new Map<
   string,
   { snapshot: GameRemovalProgress; done: Promise<void> }
 >();
+// Task ids stay unique when a game is re-added and removed again while its
+// earlier task is still displayed.
+let removalSequence = 0;
 
 function removalTaskSnapshots(): GameRemovalProgress[] {
   return [...removalTasks.values()].map((task) => task.snapshot);
@@ -141,7 +144,7 @@ function startBackgroundFileDeletion(
   cwd: string,
   gameName: string
 ): string {
-  const taskId = `removal-${appid}`;
+  const taskId = `removal-${appid}-${++removalSequence}`;
   const base = { id: taskId, appID: appid, gameName };
   const send = (payload: GameRemovalProgress) => {
     const task = removalTasks.get(taskId);

--- a/application/src/electron/lib/delete-guards.ts
+++ b/application/src/electron/lib/delete-guards.ts
@@ -63,15 +63,16 @@ export const isProtectedDeletePath = (
   return matches(roots.exact, false) || matches(roots.subtrees, true);
 };
 
-/** Whether `target` equals, contains, or sits inside any listed install directory. */
-export const overlapsInstallDirectory = (
+/** Refuse deletion when the directory overlaps another game's install directory. */
+export const sharesDirectoryWithOtherGames = (
+  appID: number,
   target: string,
-  games: ReadonlyArray<{ cwd?: string }>
+  otherGames: ReadonlyArray<{ appID: number; cwd?: string }>
 ): boolean => {
   const resolvedTarget = normalizeDeletePath(target);
-  return games.some((game) => {
-    if (!game.cwd) return false;
-    const otherCwd = normalizeDeletePath(game.cwd);
+  return otherGames.some((other) => {
+    if (other.appID === appID || !other.cwd) return false;
+    const otherCwd = normalizeDeletePath(other.cwd);
     return (
       resolvedTarget === otherCwd ||
       resolvedTarget.startsWith(withTrailingSep(otherCwd)) ||
@@ -79,17 +80,6 @@ export const overlapsInstallDirectory = (
     );
   });
 };
-
-/** Refuse deletion when the directory overlaps another game's install directory. */
-export const sharesDirectoryWithOtherGames = (
-  appID: number,
-  target: string,
-  otherGames: ReadonlyArray<{ appID: number; cwd?: string }>
-): boolean =>
-  overlapsInstallDirectory(
-    target,
-    otherGames.filter((other) => other.appID !== appID)
-  );
 
 /** App-owned directories that must never be wiped by a game removal. */
 export const appMetadataSubtrees = (dataDir: string): string[] => [

--- a/application/src/electron/lib/delete-guards.ts
+++ b/application/src/electron/lib/delete-guards.ts
@@ -63,16 +63,15 @@ export const isProtectedDeletePath = (
   return matches(roots.exact, false) || matches(roots.subtrees, true);
 };
 
-/** Refuse deletion when the directory overlaps another game's install directory. */
-export const sharesDirectoryWithOtherGames = (
-  appID: number,
+/** Whether `target` equals, contains, or sits inside any listed install directory. */
+export const overlapsInstallDirectory = (
   target: string,
-  otherGames: ReadonlyArray<{ appID: number; cwd?: string }>
+  games: ReadonlyArray<{ cwd?: string }>
 ): boolean => {
   const resolvedTarget = normalizeDeletePath(target);
-  return otherGames.some((other) => {
-    if (other.appID === appID || !other.cwd) return false;
-    const otherCwd = normalizeDeletePath(other.cwd);
+  return games.some((game) => {
+    if (!game.cwd) return false;
+    const otherCwd = normalizeDeletePath(game.cwd);
     return (
       resolvedTarget === otherCwd ||
       resolvedTarget.startsWith(withTrailingSep(otherCwd)) ||
@@ -80,6 +79,17 @@ export const sharesDirectoryWithOtherGames = (
     );
   });
 };
+
+/** Refuse deletion when the directory overlaps another game's install directory. */
+export const sharesDirectoryWithOtherGames = (
+  appID: number,
+  target: string,
+  otherGames: ReadonlyArray<{ appID: number; cwd?: string }>
+): boolean =>
+  overlapsInstallDirectory(
+    target,
+    otherGames.filter((other) => other.appID !== appID)
+  );
 
 /** App-owned directories that must never be wiped by a game removal. */
 export const appMetadataSubtrees = (dataDir: string): string[] => [

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -7,8 +7,10 @@ import fs, { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { startAddons } from '@/electron/handlers/handler.addon.js';
 import {
+  awaitPendingFileDeletions,
   type ExecuteWrapperResult,
   executeWrapperCommandForApp,
+  hasPendingFileDeletions,
   launchGameFromLibrary,
 } from '@/electron/handlers/handler.library.js';
 import { loadLibraryInfo } from '@/electron/handlers/helpers.app/library.js';
@@ -778,6 +780,17 @@ app.on('window-all-closed', () => {
   ).finally(() => {
     void disposeElectronRuntime().finally(() => app.quit());
   });
+});
+
+// A lazy game removal may still be deleting files; finish it before exiting so
+// no half-deleted directory is left behind with its library entry gone.
+let quitAfterDeletions = false;
+app.on('will-quit', (event) => {
+  if (quitAfterDeletions || !hasPendingFileDeletions()) return;
+  event.preventDefault();
+  quitAfterDeletions = true;
+  logger.sync.info('Waiting for pending game file deletions before quitting');
+  void awaitPendingFileDeletions().finally(() => app.quit());
 });
 
 app.on('activate', async function () {

--- a/application/src/electron/main.ts
+++ b/application/src/electron/main.ts
@@ -783,12 +783,12 @@ app.on('window-all-closed', () => {
 });
 
 // A lazy game removal may still be deleting files; finish it before exiting so
-// no half-deleted directory is left behind with its library entry gone.
-let quitAfterDeletions = false;
+// no half-deleted directory is left behind with its library entry gone. Every
+// quit attempt re-checks, so a deletion started after a deferred quit is
+// still awaited by the retry.
 app.on('will-quit', (event) => {
-  if (quitAfterDeletions || !hasPendingFileDeletions()) return;
+  if (!hasPendingFileDeletions()) return;
   event.preventDefault();
-  quitAfterDeletions = true;
   logger.sync.info('Waiting for pending game file deletions before quitting');
   void awaitPendingFileDeletions().finally(() => app.quit());
 });

--- a/application/src/electron/preload.mts
+++ b/application/src/electron/preload.mts
@@ -266,6 +266,14 @@ ipcRenderer.on(
   })
 );
 ipcRenderer.on(
+  'game:removal-progress',
+  wrap((_, arg) => {
+    document.dispatchEvent(
+      new CustomEvent('game:removal-progress', { detail: arg })
+    );
+  })
+);
+ipcRenderer.on(
   'addon:update-available',
   wrap((_, arg) => {
     document.dispatchEvent(

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -175,7 +175,7 @@ let isRemoving = $derived(
 );
 
 // Close the play page once the background deletion we started finishes;
-// GameManager handles the completion/error notification globally.
+// the main process sends the completion/error notification.
 $effect(() => {
   if (removalStarted && removalTask && removalTask.status !== 'running') {
     exitPlayPage();

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -161,10 +161,13 @@ function handleDllOverridesSave(dllOverrides: string[]) {
 let canEditDllOverrides = $derived(
   (platform === 'linux' || platform === 'darwin') && !!gameInfo.umu
 );
-// Background file deletion started by this window's removal, if any.
-let removalStarted = $state(false);
+// Background file deletion started by this window's removal, if any. Bound
+// by task id so a stale task from an earlier removal of the same game is
+// never mistaken for this one.
+let removalTaskId: string | undefined = $state();
+let removalStarted = $derived(removalTaskId !== undefined);
 let removalTask = $derived(
-  $gameRemovalTasks.find((task) => task.appID === gameInfo.appID)
+  $gameRemovalTasks.find((task) => task.id === removalTaskId)
 );
 // Treat the moment before the first progress event lands as removing too.
 let isRemoving = $derived(
@@ -232,7 +235,7 @@ async function removeFromList() {
   if (result.deletionTaskId) {
     // Files are deleted lazily in the background; keep the window open to
     // show progress. Closing it leaves the deletion visible as a task.
-    removalStarted = true;
+    removalTaskId = result.deletionTaskId;
     if (result.warning) {
       createNotification({
         id: Math.random().toString(36).substring(7),

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -27,6 +27,7 @@ import {
 import {
   createNotification,
   currentDownloads,
+  gameRemovalTasks,
   gamesLaunched,
 } from '@/frontend/store.svelte';
 
@@ -140,6 +141,12 @@ function pushChanges() {
 }
 
 function closeModal() {
+  // The game is already removed from the library while its files delete in
+  // the background; the deletion stays visible as a task in the side view.
+  if (removalStarted) {
+    exitPlayPage();
+    return;
+  }
   onFinish(undefined);
 }
 
@@ -154,6 +161,23 @@ function handleDllOverridesSave(dllOverrides: string[]) {
 let canEditDllOverrides = $derived(
   (platform === 'linux' || platform === 'darwin') && !!gameInfo.umu
 );
+// Background file deletion started by this window's removal, if any.
+let removalStarted = $state(false);
+let removalTask = $derived(
+  $gameRemovalTasks.find((task) => task.appID === gameInfo.appID)
+);
+// Treat the moment before the first progress event lands as removing too.
+let isRemoving = $derived(
+  removalStarted && (!removalTask || removalTask.status === 'running')
+);
+
+// Close the play page once the background deletion we started finishes;
+// GameManager handles the completion/error notification globally.
+$effect(() => {
+  if (removalStarted && removalTask && removalTask.status !== 'running') {
+    exitPlayPage();
+  }
+});
 let dllOverridesCount = $derived.by(() => {
   const dllOverrides = Array.isArray(formData.dllOverrides)
     ? formData.dllOverrides
@@ -201,18 +225,29 @@ async function removeFromList() {
   }
 
   completeRequiredReadd(gameInfo.appID);
-  createNotification({
-    id: Math.random().toString(36).substring(7),
-    message:
-      result.warning ??
-      (result.filesDeleted
-        ? 'Game removed from library and files deleted'
-        : 'Game removed from library'),
-    type: result.warning ? 'info' : 'success',
-  });
   currentDownloads.update((downloads) =>
     downloads.filter((download) => download.appID !== gameInfo.appID)
   );
+
+  if (result.deletionTaskId) {
+    // Files are deleted lazily in the background; keep the window open to
+    // show progress. Closing it leaves the deletion visible as a task.
+    removalStarted = true;
+    if (result.warning) {
+      createNotification({
+        id: Math.random().toString(36).substring(7),
+        message: result.warning,
+        type: 'info',
+      });
+    }
+    return;
+  }
+
+  createNotification({
+    id: Math.random().toString(36).substring(7),
+    message: result.warning ?? 'Game removed from library',
+    type: result.warning ? 'info' : 'success',
+  });
   exitPlayPage();
 }
 
@@ -329,11 +364,17 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
     {/each}
 
     <div class="pt-4 flex flex-row flex-wrap gap-3">
-      <ButtonModal text="Save" variant="primary" onclick={pushChanges} />
+      <ButtonModal
+        text="Save"
+        variant="primary"
+        onclick={pushChanges}
+        disabled={removalStarted}
+      />
       {#if platform === 'linux' || platform === 'darwin'}
         <ButtonModal
           text="Add to Steam"
           variant="secondary"
+          disabled={removalStarted}
           onclick={(event) => {
             addToSteam(event.currentTarget as HTMLButtonElement);
           }}
@@ -343,15 +384,35 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
         text="Show in Folder"
         variant="secondary"
         onclick={showInFolder}
-        disabled={!gameInfo.cwd}
+        disabled={!gameInfo.cwd || removalStarted}
       />
       <ButtonModal
-        text="Remove Game"
+        text={isRemoving ? 'Removing…' : 'Remove Game'}
         variant="danger"
+        disabled={removalStarted}
         onclick={() => (showRemoveConfirm = true)}
       />
       <ButtonModal text="Cancel" variant="secondary" onclick={closeModal} />
     </div>
+
+    {#if isRemoving && removalTask}
+      <div class="pt-3">
+        <div class="flex items-center justify-between mb-1">
+          <span class="text-xs text-text-secondary">
+            Deleting files ({removalTask.deleted}/{removalTask.total})
+          </span>
+          <span class="text-xs text-text-secondary">
+            {Math.floor(removalTask.progress)}%
+          </span>
+        </div>
+        <div class="w-full bg-border rounded-full h-1.5">
+          <div
+            class="bg-error h-1.5 rounded-full transition-all duration-300"
+            style="width: {removalTask.progress}%"
+          ></div>
+        </div>
+      </div>
+    {/if}
   </Modal>
 
   {#if showRemoveConfirm}

--- a/application/src/frontend/components/NotificationSideView.svelte
+++ b/application/src/frontend/components/NotificationSideView.svelte
@@ -6,7 +6,9 @@ import { quintOut } from 'svelte/easing';
 import { fade, fly } from 'svelte/transition';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import {
+  type DeferredTask,
   deferredTasks,
+  gameRemovalTasks,
   type Notification,
   notificationHistory,
   removedTasks,
@@ -23,6 +25,31 @@ let scrollContainer: HTMLDivElement | null = $state(null);
 let logContainers: Map<string, HTMLDivElement> = $state(new Map());
 let previousLogLengths: Map<string, number> = new Map();
 let closeTimeout = $state(false);
+
+// Game-file removal tasks merged into the deferred-task card shape so the
+// Tasks tab renders both through the same markup.
+let removalAsDeferred = $derived(
+  $gameRemovalTasks.map(
+    (task): DeferredTask => ({
+      id: task.id,
+      name: `Removing ${task.gameName}`,
+      description:
+        task.status === 'running'
+          ? `Deleting files (${task.deleted}/${task.total})`
+          : task.status === 'completed'
+            ? 'Files deleted'
+            : 'File deletion failed',
+      addonOwner: 'OpenGameInstaller',
+      status: task.status,
+      progress: task.progress,
+      logs: [],
+      timestamp: task.timestamp,
+      error: task.error,
+      type: 'cleanup',
+    })
+  )
+);
+let allTasks = $derived([...removalAsDeferred, ...$deferredTasks]);
 
 function refreshDeferredTasks(tasksToRemove: string[] = []) {
   return loadDeferredTasks(tasksToRemove).pipe(
@@ -175,7 +202,14 @@ function clearAllNotifications() {
   notificationHistory.set([]);
 }
 
+function clearFinishedRemovalTasks() {
+  gameRemovalTasks.update((tasks) =>
+    tasks.filter((task) => task.status === 'running')
+  );
+}
+
 function handleClearCompletedTasks() {
+  clearFinishedRemovalTasks();
   clearAllTasks(
     $deferredTasks
       .map((task) => {
@@ -194,6 +228,9 @@ function handleClearCompletedTasks() {
 }
 
 function handleClearAllTasks() {
+  // Running removal tasks stay visible; an in-flight deletion can't be
+  // dismissed from the view.
+  clearFinishedRemovalTasks();
   clearAllTasks($deferredTasks.map((task) => task.id));
 }
 
@@ -316,9 +353,9 @@ function registerLogContainer(element: HTMLDivElement, taskId: string) {
           onclick={() => (currentTab = 'tasks')}
         >
           Tasks
-          {#if $deferredTasks.length > 0}
+          {#if allTasks.length > 0}
             <span class="ml-2 bg-overlay-text/20 px-1.5 py-0.5 rounded text-xs">
-              {$deferredTasks.length}
+              {allTasks.length}
             </span>
           {/if}
         </button>
@@ -429,7 +466,7 @@ function registerLogContainer(element: HTMLDivElement, taskId: string) {
             {/if}
           {:else}
             <!-- Tasks Content -->
-            {#if $deferredTasks.length === 0}
+            {#if allTasks.length === 0}
               <div
                 class="flex flex-col items-center justify-center h-full text-center p-8"
               >
@@ -459,8 +496,7 @@ function registerLogContainer(element: HTMLDivElement, taskId: string) {
               <div class="p-4 space-y-3">
                 <div class="flex items-center justify-between mb-3">
                   <span class="text-sm text-text-secondary">
-                    {$deferredTasks.length} active task{$deferredTasks.length !==
-                    1
+                    {allTasks.length} active task{allTasks.length !== 1
                       ? 's'
                       : ''}
                   </span>
@@ -479,7 +515,7 @@ function registerLogContainer(element: HTMLDivElement, taskId: string) {
                     </button>
                   </div>
                 </div>
-                {#each $deferredTasks as task, index (task.id)}
+                {#each allTasks as task, index (task.id)}
                   <div
                     class="flex gap-3 p-4 bg-surface rounded-lg border border-border shadow-sm hover:shadow-md transition-all duration-200"
                     data-task-id={task.id}

--- a/application/src/frontend/components/NotificationSideView.svelte
+++ b/application/src/frontend/components/NotificationSideView.svelte
@@ -4,7 +4,8 @@ import { Effect } from 'effect';
 import { onDestroy, onMount } from 'svelte';
 import { quintOut } from 'svelte/easing';
 import { fade, fly } from 'svelte/transition';
-import { runFrontendEffect } from '@/frontend/lib/core/runtime';
+import { runDetached, runFrontendEffect } from '@/frontend/lib/core/runtime';
+import { electronRpc } from '@/frontend/lib/electron-rpc';
 import {
   type DeferredTask,
   deferredTasks,
@@ -202,9 +203,19 @@ function clearAllNotifications() {
   notificationHistory.set([]);
 }
 
+// Finished removal tasks are also dropped on the main side so they don't
+// reappear from the startup snapshot after a reload.
 function clearFinishedRemovalTasks() {
+  const finished = $gameRemovalTasks
+    .filter((task) => task.status !== 'running')
+    .map((task) => task.id);
+  if (finished.length === 0) return;
   gameRemovalTasks.update((tasks) =>
     tasks.filter((task) => task.status === 'running')
+  );
+  runDetached(
+    electronRpc.app.clearRemovalTasks(finished),
+    'Failed to clear finished game removals'
   );
 }
 

--- a/application/src/frontend/managers/GameManager.svelte
+++ b/application/src/frontend/managers/GameManager.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
+import { Effect } from 'effect';
 import { getAllApps } from '@/frontend/lib/core/library';
-import { runFrontendEffect } from '@/frontend/lib/core/runtime';
+import { runDetached, runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
 import {
   createNotification,
-  type GameRemovalTask,
   gameRemovalTasks,
   gamesLaunched,
 } from '@/frontend/store.svelte';
 import { runLaunchAppAddons } from '@/frontend/utils';
+import type { GameRemovalProgress } from '@/lib/electron-rpc.js';
 
 const logger = createLogger(LOGGER_PREFIXES.frontend);
 
@@ -52,13 +53,15 @@ document.addEventListener('game:launch-error', (event: Event) => {
   });
 });
 
-document.addEventListener('game:removal-progress', (event: Event) => {
-  const payload = (event as CustomEvent).detail as Omit<
-    GameRemovalTask,
-    'timestamp'
-  >;
+// Upserts a removal task and notifies once when it reaches a terminal state,
+// whether that arrives by IPC event or from the startup snapshot. A terminal
+// task is final: stale progress events queued during a reload are ignored.
+function recordRemovalProgress(payload: GameRemovalProgress) {
+  let previousStatus: GameRemovalProgress['status'] | undefined;
   gameRemovalTasks.update((tasks) => {
     const existing = tasks.find((task) => task.id === payload.id);
+    previousStatus = existing?.status;
+    if (existing && existing.status !== 'running') return tasks;
     if (existing) {
       return tasks.map((task) =>
         task.id === payload.id ? { ...task, ...payload } : task
@@ -66,6 +69,7 @@ document.addEventListener('game:removal-progress', (event: Event) => {
     }
     return [...tasks, { ...payload, timestamp: Date.now() }];
   });
+  if (previousStatus !== undefined && previousStatus !== 'running') return;
   if (payload.status === 'completed') {
     createNotification({
       id: Math.random().toString(36).substring(7),
@@ -79,7 +83,23 @@ document.addEventListener('game:removal-progress', (event: Event) => {
       type: 'error',
     });
   }
+}
+
+document.addEventListener('game:removal-progress', (event: Event) => {
+  recordRemovalProgress((event as CustomEvent).detail as GameRemovalProgress);
 });
+
+// Deletions that started or finished before this renderer loaded (e.g. a
+// reload mid-removal) only live in the main process; pull them in so the
+// Tasks view and terminal notifications survive.
+runDetached(
+  electronRpc.app.getRemovalTasks().pipe(
+    Effect.map((tasks) => {
+      for (const task of tasks) recordRemovalProgress(task);
+    })
+  ),
+  'Failed to load pending game removals'
+);
 
 document.addEventListener('game:exit', async (event: Event) => {
   const appID = (event as CustomEvent).detail.id;

--- a/application/src/frontend/managers/GameManager.svelte
+++ b/application/src/frontend/managers/GameManager.svelte
@@ -4,11 +4,7 @@ import { Effect } from 'effect';
 import { getAllApps } from '@/frontend/lib/core/library';
 import { runDetached, runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
-import {
-  createNotification,
-  gameRemovalTasks,
-  gamesLaunched,
-} from '@/frontend/store.svelte';
+import { gameRemovalTasks, gamesLaunched } from '@/frontend/store.svelte';
 import { runLaunchAppAddons } from '@/frontend/utils';
 import type { GameRemovalProgress } from '@/lib/electron-rpc.js';
 
@@ -53,14 +49,12 @@ document.addEventListener('game:launch-error', (event: Event) => {
   });
 });
 
-// Upserts a removal task and notifies once when it reaches a terminal state,
-// whether that arrives by IPC event or from the startup snapshot. A terminal
-// task is final: stale progress events queued during a reload are ignored.
+// Upserts a removal task from an IPC event or the startup snapshot. A terminal
+// task is final: stale progress events queued during a reload are ignored. The
+// main process sends the completion/failure notification itself.
 function recordRemovalProgress(payload: GameRemovalProgress) {
-  let previousStatus: GameRemovalProgress['status'] | undefined;
   gameRemovalTasks.update((tasks) => {
     const existing = tasks.find((task) => task.id === payload.id);
-    previousStatus = existing?.status;
     if (existing && existing.status !== 'running') return tasks;
     if (existing) {
       return tasks.map((task) =>
@@ -69,20 +63,6 @@ function recordRemovalProgress(payload: GameRemovalProgress) {
     }
     return [...tasks, { ...payload, timestamp: Date.now() }];
   });
-  if (previousStatus !== undefined && previousStatus !== 'running') return;
-  if (payload.status === 'completed') {
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: `${payload.gameName} removed from library and files deleted`,
-      type: 'success',
-    });
-  } else if (payload.status === 'error') {
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: `${payload.gameName} was removed from the library, but its files could not be deleted: ${payload.error}`,
-      type: 'error',
-    });
-  }
 }
 
 document.addEventListener('game:removal-progress', (event: Event) => {
@@ -91,7 +71,7 @@ document.addEventListener('game:removal-progress', (event: Event) => {
 
 // Deletions that started or finished before this renderer loaded (e.g. a
 // reload mid-removal) only live in the main process; pull them in so the
-// Tasks view and terminal notifications survive.
+// Tasks view survives.
 runDetached(
   electronRpc.app.getRemovalTasks().pipe(
     Effect.map((tasks) => {

--- a/application/src/frontend/managers/GameManager.svelte
+++ b/application/src/frontend/managers/GameManager.svelte
@@ -3,7 +3,12 @@ import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { getAllApps } from '@/frontend/lib/core/library';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
-import { gamesLaunched } from '@/frontend/store.svelte';
+import {
+  createNotification,
+  type GameRemovalTask,
+  gameRemovalTasks,
+  gamesLaunched,
+} from '@/frontend/store.svelte';
 import { runLaunchAppAddons } from '@/frontend/utils';
 
 const logger = createLogger(LOGGER_PREFIXES.frontend);
@@ -45,6 +50,35 @@ document.addEventListener('game:launch-error', (event: Event) => {
     delete games[appID];
     return games;
   });
+});
+
+document.addEventListener('game:removal-progress', (event: Event) => {
+  const payload = (event as CustomEvent).detail as Omit<
+    GameRemovalTask,
+    'timestamp'
+  >;
+  gameRemovalTasks.update((tasks) => {
+    const existing = tasks.find((task) => task.id === payload.id);
+    if (existing) {
+      return tasks.map((task) =>
+        task.id === payload.id ? { ...task, ...payload } : task
+      );
+    }
+    return [...tasks, { ...payload, timestamp: Date.now() }];
+  });
+  if (payload.status === 'completed') {
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message: `${payload.gameName} removed from library and files deleted`,
+      type: 'success',
+    });
+  } else if (payload.status === 'error') {
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message: `${payload.gameName} was removed from the library, but its files could not be deleted: ${payload.error}`,
+      type: 'error',
+    });
+  }
 });
 
 document.addEventListener('game:exit', async (event: Event) => {

--- a/application/src/frontend/store.svelte.ts
+++ b/application/src/frontend/store.svelte.ts
@@ -101,6 +101,19 @@ export type DeferredTask = {
     | 'other';
 };
 
+/** Background game-file deletion started by a lazy library removal. */
+export type GameRemovalTask = {
+  id: string;
+  appID: number;
+  gameName: string;
+  status: 'running' | 'completed' | 'error';
+  progress: number;
+  deleted: number;
+  total: number;
+  error?: string;
+  timestamp: number;
+};
+
 export type FailedSetup = {
   id: string;
   timestamp: number;
@@ -125,6 +138,7 @@ export const currentDownloads: Writable<DownloadStatusAndInfo[]> = writable([]);
 export const failedSetups: Writable<FailedSetup[]> = writable([]);
 export const deferredTasks: Writable<DeferredTask[]> = writable([]);
 export const removedTasks: Writable<string[]> = writable([]);
+export const gameRemovalTasks: Writable<GameRemovalTask[]> = writable([]);
 export const notifications: Writable<Notification[]> = writable([]);
 export const notificationHistory: Writable<Notification[]> = writable([]);
 export const readNotificationIds: Writable<Set<string>> = writable(new Set());

--- a/application/src/frontend/store.svelte.ts
+++ b/application/src/frontend/store.svelte.ts
@@ -14,6 +14,7 @@ import {
 } from '@/electron/lib/marketplace-schema';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
+import type { GameRemovalProgress } from '@/lib/electron-rpc.js';
 
 const logger = createLogger(LOGGER_PREFIXES.frontend);
 
@@ -102,17 +103,7 @@ export type DeferredTask = {
 };
 
 /** Background game-file deletion started by a lazy library removal. */
-export type GameRemovalTask = {
-  id: string;
-  appID: number;
-  gameName: string;
-  status: 'running' | 'completed' | 'error';
-  progress: number;
-  deleted: number;
-  total: number;
-  error?: string;
-  timestamp: number;
-};
+export type GameRemovalTask = GameRemovalProgress & { timestamp: number };
 
 export type FailedSetup = {
   id: string;

--- a/application/src/lib/electron-rpc.ts
+++ b/application/src/lib/electron-rpc.ts
@@ -35,6 +35,18 @@ export interface ElectronRpcTransport {
 
 export const OperatingSystem = Schema.Literal('darwin', 'linux', 'win32');
 
+/** Progress of a background game-file deletion started by a lazy removal. */
+export type GameRemovalProgress = {
+  id: string;
+  appID: number;
+  gameName: string;
+  status: 'running' | 'completed' | 'error';
+  progress: number;
+  deleted: number;
+  total: number;
+  error?: string;
+};
+
 export type OperatingSystem = typeof OperatingSystem.Type;
 
 export class ElectronRpcError extends Schema.TaggedError<ElectronRpcError>()(
@@ -164,6 +176,12 @@ export const ElectronRpc = {
         | { status: 'error'; error: string }
       >()
     ),
+    getRemovalTasks: rpc(
+      'app.getRemovalTasks',
+      [],
+      opaque<GameRemovalProgress[]>()
+    ),
+    clearRemovalTasks: rpc('app.clearRemovalTasks', [StringArray], Void),
     insertApp: rpc(
       'app.insertApp',
       [

--- a/application/src/lib/electron-rpc.ts
+++ b/application/src/lib/electron-rpc.ts
@@ -157,7 +157,8 @@ export const ElectronRpc = {
         | {
             status: 'success';
             warning?: string;
-            filesDeleted?: boolean;
+            /** Set when file deletion was started lazily in the background. */
+            deletionTaskId?: string;
           }
         | { status: 'cancelled'; message: string }
         | { status: 'error'; error: string }


### PR DESCRIPTION
# Description

Game removal no longer blocks on deleting files. The removal RPC commits the library change, claims the game folder by renaming it to a hidden `.ogi-removing-*` sibling (on the per-game queue so a launch can't interleave), and returns a `deletionTaskId`. A background task then deletes the isolated folder file by file, streaming throttled `game:removal-progress` events to the renderer and keeping the latest snapshot in the main process.

The renderer shows the deletion as a progress bar in the game configuration modal and as a task in the Tasks tab. On load it pulls the main-process snapshots through `app.getRemovalTasks`, so a reload mid-deletion keeps the task visible, and dismissing finished tasks clears them on the main side via `app.clearRemovalTasks`. The main process sends the completion or failure notification itself so it fires exactly once. `will-quit` re-checks for running deletions on every attempt and defers exit until they settle.

# Example

```ts
// removal RPC result
{ status: 'success', deletionTaskId: 'removal-620-1' }

// streamed to the renderer while the isolated folder is deleted
{ id: 'removal-620-1', appID: 620, gameName: 'Portal 2',
  status: 'running', progress: 42.5, deleted: 17, total: 40 }
```

# Next Steps

- Consider a startup sweep for orphaned `.ogi-removing-*` directories left by a crash mid-deletion.
- Confirm the rename-aside behaves on Windows when a file inside the game folder is held open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Game file removal now runs safely in the background with visible progress tracking.
  - Added removal tasks to the Tasks view, including status, completion, and error handling.
  - Removal progress is restored after restarting the application.
  - The app now waits for pending file removals to finish before closing.

- **Bug Fixes**
  - Prevented stale removal tasks from affecting a new removal.
  - Improved cleanup for completed and cancelled removal tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
