### PR TITLE
fix(updater): build exact bleeding-edge revisions and share game-art fallback

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -99,5 +99,8 @@ jobs:
         with:
           bun-version: '1'
       - run: bun install --frozen-lockfile
+        env:
+          # Updater build/tests never launch Electron; the binary download is flaky on Windows runners.
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
       - run: bun run --cwd updater build
       - run: bun run --cwd updater test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -84,3 +84,20 @@ jobs:
       - name: Fail if typecheck failed
         if: steps.typecheck.outcome == 'failure'
         run: exit 1
+
+  updater:
+    name: Updater (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1'
+      - run: bun install --frozen-lockfile
+      - run: bun run --cwd updater build
+      - run: bun run --cwd updater test

--- a/application/src/frontend/App.svelte
+++ b/application/src/frontend/App.svelte
@@ -10,6 +10,7 @@ import { onMount } from 'svelte';
 import { quintOut } from 'svelte/easing';
 import { derived } from 'svelte/store';
 import { fade, fly, slide } from 'svelte/transition';
+import GameImage from '@/frontend/components/GameImage.svelte';
 import GameLaunchOverlay from '@/frontend/components/GameLaunchOverlay.svelte';
 import ConfigurationModal from '@/frontend/components/modal/ConfigurationModal.svelte';
 import NotificationSideView from '@/frontend/components/NotificationSideView.svelte';
@@ -982,22 +983,10 @@ document.addEventListener('migration:event:install-steam-addon', async () => {
                                 delay: 50 * index,
                               }}
                             >
-                              <img
+                              <GameImage
                                 src={result.capsuleImage}
                                 alt={result.name}
                                 class="result-image"
-                                onerror={(ev) => {
-                                  result.capsuleImage = './favicon.png';
-                                  (ev.target as HTMLImageElement).src =
-                                    './favicon.png';
-                                  (
-                                    ev.target as HTMLImageElement
-                                  ).style.opacity = '0.5';
-                                  logger.sync.info(
-                                    'error loading image',
-                                    result.name
-                                  );
-                                }}
                               />
                               <div class="result-content">
                                 <h4 class="result-title">{result.name}</h4>
@@ -1304,7 +1293,7 @@ document.addEventListener('migration:event:install-steam-addon', async () => {
     @apply -translate-y-0.5 shadow-lg;
   }
 
-  .result-image {
+  :global(.result-image) {
     @apply w-24 h-24 rounded object-cover shrink-0;
   }
 

--- a/application/src/frontend/components/GameImage.svelte
+++ b/application/src/frontend/components/GameImage.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+interface Props {
+  src?: string | null;
+  alt: string;
+  class?: string;
+  loading?: 'eager' | 'lazy';
+  fallbackTitle?: boolean;
+}
+
+let {
+  src,
+  alt,
+  class: className = '',
+  loading = 'eager',
+  fallbackTitle = false,
+}: Props = $props();
+let failedSrc: string | null | undefined = $state();
+const failed = $derived(!src || failedSrc === src);
+</script>
+
+{#if failed}
+  <div class="game-image-fallback {className}" role="img" aria-label={alt}>
+    <div class="fallback-logo" style="background-image: url('./favicon.png')" aria-hidden="true"></div>
+    {#if fallbackTitle}
+      <p class="fallback-title text-white text-base py-4 text-center font-archivo">{alt}</p>
+    {/if}
+  </div>
+{:else}
+  <img {src} {alt} {loading} class={className} onerror={(event) => (failedSrc = event.currentTarget.getAttribute('src'))} />
+{/if}
+
+<style>
+  .game-image-fallback {
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent), #181818;
+  }
+
+  .fallback-logo {
+    position: absolute;
+    inset: 20%;
+    background-position: center;
+    background-size: contain;
+    background-repeat: no-repeat;
+    opacity: 0.5;
+  }
+
+  .fallback-title {
+    position: absolute;
+    inset-inline: 0;
+    bottom: 0;
+    margin: 0;
+    padding-inline: 0.5rem;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
+  }
+</style>

--- a/application/src/frontend/components/Image.svelte
+++ b/application/src/frontend/components/Image.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import { electronRpc } from '@/frontend/lib/electron-rpc';
+import GameImage from './GameImage.svelte';
 
 interface Props {
   src: string;
   alt: string;
   classifier: string;
-  onerror?: (e: Event) => void;
+  fallbackTitle?: boolean;
   class?: string;
 }
 
@@ -14,7 +15,7 @@ let {
   src,
   alt,
   classifier,
-  onerror = () => {},
+  fallbackTitle = false,
   class: className = '',
 }: Props = $props();
 
@@ -46,6 +47,11 @@ async function loadImage(currentSrc: string, currentClassifier: string) {
   loading = true;
   error = null;
   imageData = undefined;
+  if (!currentSrc) {
+    error = 'Missing image';
+    loading = false;
+    return;
+  }
 
   try {
     const cachePath = './images/' + currentClassifier + '.cached';
@@ -77,10 +83,14 @@ async function loadImage(currentSrc: string, currentClassifier: string) {
     if (version !== requestVersion) return;
     imageData = resolvedImageData;
     // Ensure cache dir exists
-    if (!window.electronAPI.fs.exists('./images')) {
-      window.electronAPI.fs.mkdir('./images');
+    try {
+      if (!window.electronAPI.fs.exists('./images')) {
+        window.electronAPI.fs.mkdir('./images');
+      }
+      window.electronAPI.fs.write(cachePath, resolvedImageData);
+    } catch {
+      // A read-only cache must not hide an image that loaded successfully.
     }
-    window.electronAPI.fs.write(cachePath, resolvedImageData);
     loading = false;
   } catch (e) {
     if (version !== requestVersion) return;
@@ -95,13 +105,11 @@ $effect(() => {
 </script>
 
 {#if loading}
-  <div class="w-full h-full flex items-center justify-center">
-    <div class="loading-spinner"></div>
-  </div>
-{:else if error}
-  <div class="w-full h-full flex items-center justify-center text-red-500">
-    {error}
+  <div class={className}>
+    <div class="w-full h-full flex items-center justify-center">
+      <div class="loading-spinner"></div>
+    </div>
   </div>
 {:else}
-  <img src={imageData} {alt} class={className} {onerror} />
+  <GameImage src={error ? undefined : imageData} {alt} class={className} {fallbackTitle} />
 {/if}

--- a/application/src/frontend/components/StorePage.svelte
+++ b/application/src/frontend/components/StorePage.svelte
@@ -4,6 +4,7 @@ import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { onMount } from 'svelte';
 import { fly, slide } from 'svelte/transition';
 import AddonPicture from '@/frontend/components/AddonPicture.svelte';
+import GameImage from '@/frontend/components/GameImage.svelte';
 import HeaderModal from '@/frontend/components/modal/HeaderModal.svelte';
 import Modal from '@/frontend/components/modal/Modal.svelte';
 import SectionModal from '@/frontend/components/modal/SectionModal.svelte';
@@ -483,7 +484,7 @@ $effect(() => {
       <!-- Hero Banner Section -->
       <div class="">
         <div class="relative w-full h-64 overflow-hidden rounded-lg">
-          <img
+          <GameImage
             src={gameData.headerImage}
             alt={gameData.name}
             class="w-full h-full object-cover rounded-lg"

--- a/application/src/frontend/views/DiscoverView.svelte
+++ b/application/src/frontend/views/DiscoverView.svelte
@@ -11,6 +11,7 @@ import type {
 import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import { onMount } from 'svelte';
 import AddonPicture from '@/frontend/components/AddonPicture.svelte';
+import GameImage from '@/frontend/components/GameImage.svelte';
 import { runFrontendEffect } from '@/frontend/lib/core/runtime';
 import {
   createNotification,
@@ -433,21 +434,13 @@ onMount(() => {
                 class={`featured-carousel-slide ${isActive ? 'is-active' : ''}`}
                 aria-hidden={!isActive}
               >
-                <img
+                <GameImage
                   src={getFeaturedImage(item)}
                   alt={item.name}
                   class="w-full h-full object-cover"
                   loading={shouldPrioritizeFeaturedImage(index)
                     ? 'eager'
                     : 'lazy'}
-                  onerror={(e) => {
-                    const fallback = './favicon.png';
-                    const img = e.currentTarget as HTMLImageElement;
-                    if (img.src !== fallback) {
-                      img.src = fallback;
-                      img.style.opacity = '0.5';
-                    }
-                  }}
                 />
 
                 <div
@@ -629,19 +622,11 @@ onMount(() => {
                           tabindex={pageIndex === currentPage ? 0 : -1}
                         >
                           <div class="relative">
-                            <img
+                            <GameImage
                               src={game.capsuleImage}
                               alt={game.name}
                               class="w-32 h-48 object-cover"
                               loading={prioritizePage ? 'eager' : 'lazy'}
-                              onerror={(e) => {
-                                const fallback = './favicon.png';
-                                const img = e.currentTarget as HTMLImageElement;
-                                if (img.src !== fallback) {
-                                  img.src = fallback;
-                                  img.style.opacity = '0.5';
-                                }
-                              }}
                             />
                             <!-- Overlay with game info -->
                             <div

--- a/application/src/frontend/views/DownloadView.svelte
+++ b/application/src/frontend/views/DownloadView.svelte
@@ -3,6 +3,7 @@ import { createLogger, LOGGER_PREFIXES } from '@ogi-sdk/logger';
 import * as d3 from 'd3';
 import { Effect } from 'effect';
 import { onDestroy, onMount } from 'svelte';
+import GameImage from '@/frontend/components/GameImage.svelte';
 import RedistributablesProgress from '@/frontend/components/RedistributablesProgress.svelte';
 import SetupPrompt from '@/frontend/components/SetupPrompt.svelte';
 import { runDetached, runFrontendEffect } from '@/frontend/lib/core/runtime';
@@ -390,9 +391,9 @@ onDestroy(() => {
   {#if targetDownload}
     <div class="w-full flex flex-row gap-4 pl-1 mb-8">
       <div class="h-auto w-5/12 relative">
-        <img
+        <GameImage
           src={targetDownload.coverImage}
-          alt="Game cover"
+          alt={targetDownload.name}
           class="rounded-lg object-cover bg-no-repeat w-full h-full min-w-0 shadow-lg"
         />
         {#if isQueued(targetDownload)}
@@ -588,10 +589,10 @@ onDestroy(() => {
       >
         <div class="flex flex-row gap-4 w-full">
           <div class="download-image">
-            <img
-              src={download.coverImage || './favicon.png'}
-              alt="Game cover"
-              class="game-cover"
+            <GameImage
+              src={download.coverImage}
+              alt={download.name}
+              class="w-full h-full object-cover"
             />
             <div class="status-indicator status-{download.status}"></div>
           </div>
@@ -962,10 +963,10 @@ onDestroy(() => {
         <div class="failed-setup-compact">
           <div class="failed-setup-header">
             <div class="failed-setup-image">
-              <img
-                src={failedSetup.downloadInfo.coverImage || './favicon.png'}
-                alt="Game cover"
-                class="game-cover"
+              <GameImage
+                src={failedSetup.downloadInfo.coverImage}
+                alt={failedSetup.downloadInfo.name}
+                class="w-full h-full object-cover"
               />
               <div class="status-indicator status-error"></div>
             </div>
@@ -1104,10 +1105,6 @@ onDestroy(() => {
       var(--theme-border),
       var(--theme-border-strong)
     );
-  }
-
-  .game-cover {
-    @apply w-full h-full object-cover;
   }
 
   .status-indicator {

--- a/application/src/frontend/views/LibraryView.svelte
+++ b/application/src/frontend/views/LibraryView.svelte
@@ -247,34 +247,10 @@ onDestroy(() => {
                       src={app.capsuleImage}
                       alt={app.name}
                       classifier={app.appID.toString() + '-capsule'}
-                      onerror={(e) => {
-                        const fallback = './favicon.png';
-                        const img = e.currentTarget as HTMLImageElement;
-                        if (img.src !== fallback) {
-                          img.src = fallback;
-                          img.style.opacity = '0.5';
-                          (
-                            (img.parentElement as HTMLElement)
-                              .children[1]! as HTMLElement
-                          ).dataset.backup = 'enabled';
-                        }
-                      }}
+                      fallbackTitle
                       class="w-full aspect-2/3 object-cover"
                     />
-                    <div
-                      data-backup="disabled"
-                      class="absolute inset-0 flex items-end justify-center data-[backup=disabled]:hidden"
-                    >
-                      <div
-                        class="absolute inset-x-0 bottom-0 w-full h-1/2 pointer-events-none"
-                        style="background: linear-gradient(to top, rgba(0,0,0,0.7), transparent);"
-                      ></div>
-                      <p
-                        class="text-white text-base py-4 text-center font-archivo z-1"
-                      >
-                        {app.name}
-                      </p>
-                    </div>
+
                   </button>
                 </div>
               {/each}
@@ -379,34 +355,10 @@ onDestroy(() => {
                       src={app.capsuleImage}
                       alt={app.name}
                       classifier={app.appID.toString() + '-capsule'}
-                      onerror={(e) => {
-                        const fallback = './favicon.png';
-                        const img = e.currentTarget as HTMLImageElement;
-                        if (img.src !== fallback) {
-                          img.src = fallback;
-                          img.style.opacity = '0.5';
-                          (
-                            (img.parentElement as HTMLElement)
-                              .children[1]! as HTMLElement
-                          ).dataset.backup = 'enabled';
-                        }
-                      }}
+                      fallbackTitle
                       class="w-full aspect-2/3 object-cover"
                     />
-                    <div
-                      data-backup="disabled"
-                      class="absolute inset-0 flex items-end justify-center data-[backup=disabled]:hidden"
-                    >
-                      <div
-                        class="absolute inset-x-0 bottom-0 w-full h-1/2 pointer-events-none"
-                        style="background: linear-gradient(to top, rgba(0,0,0,0.7), transparent);"
-                      ></div>
-                      <p
-                        class="text-white text-base py-4 text-center font-archivo z-1"
-                      >
-                        {app.name}
-                      </p>
-                    </div>
+
                   </button>
                 </div>
               {/each}

--- a/application/tests/handler.ddl.test.ts
+++ b/application/tests/handler.ddl.test.ts
@@ -95,6 +95,8 @@ mock.module('@/electron/manager/manager.queue.js', () => ({
   },
 }));
 mock.module('@/lib/download-handshake.js', () => ({
+  consumeDownloadReplayEvents: mock(() => []),
+  getDownloadHandshakeState: mock(() => undefined),
   clearDownloadHandshake: mock(() => {}),
   registerDownloadHandshake,
   updateDownloadHandshake: mock(() => {}),

--- a/updater/package.json
+++ b/updater/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "test": "bun test",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "bun run --cwd ../packages/logger build && tsc -p tsconfig.json",
     "dev": "bun run build && electron .",
     "preelectron-pack": "bun run build",

--- a/updater/public/index.html
+++ b/updater/public/index.html
@@ -96,7 +96,11 @@
       : 'Stable uses normal releases. Unstable uses pre-releases. Bleeding Edge builds from source.';
   }
 
+  // Bumped whenever the picker resets so stale commit responses are ignored.
+  let commitRequestVersion = 0;
+
   function resetBleedingEdgePicker() {
+    commitRequestVersion++;
     document.querySelector('#commit-input').value = '';
     document.querySelector('#commit-list').style.display = 'none';
     document.querySelector('#commit-list').innerHTML = '';
@@ -145,12 +149,14 @@
   }
 
   async function loadCommitList() {
+    const requestVersion = ++commitRequestVersion;
     const list = document.querySelector('#commit-list');
     const branch = getSelectedBranch();
     list.style.display = 'block';
     list.textContent = `Loading commits for ${branch}...`;
     try {
       const result = await window.ogiUpdater.getRecentCommits(branch);
+      if (requestVersion !== commitRequestVersion) return;
       if (!result.ok || !result.commits.length) {
         list.textContent = result.error || 'No commits found.';
         return;
@@ -160,11 +166,13 @@
         const item = document.createElement('button');
         item.className = 'commit-item';
         item.type = 'button';
-        item.innerHTML = `
-          <strong>${commit.shortSha}</strong>
-          <span>${commit.message}</span>
-          <small>${commit.author} • ${new Date(commit.date).toLocaleDateString()}</small>
-        `;
+        const sha = document.createElement('strong');
+        sha.textContent = commit.shortSha;
+        const message = document.createElement('span');
+        message.textContent = commit.message;
+        const metadata = document.createElement('small');
+        metadata.textContent = `${commit.author} • ${new Date(commit.date).toLocaleDateString()}`;
+        item.append(sha, message, metadata);
         item.addEventListener('click', () => {
           document.querySelector('#commit-input').value = commit.sha;
           document.querySelectorAll('.commit-item').forEach((other) => {
@@ -175,11 +183,14 @@
         list.appendChild(item);
       });
     } catch (error) {
+      if (requestVersion !== commitRequestVersion) return;
       list.textContent = 'Failed to load commits.';
     }
   }
 
   document.querySelector('#branch-select').addEventListener('change', () => {
+    document.querySelector('#commit-input').value = '';
+    commitRequestVersion++;
     if (document.querySelector('#commit-list').style.display !== 'none') {
       loadCommitList();
     }

--- a/updater/src/bleeding-edge-flow.ts
+++ b/updater/src/bleeding-edge-flow.ts
@@ -5,6 +5,10 @@ export type BleedingEdgeSelection = {
   readonly commit: string;
 };
 
+export function normalizeBranch(branch: string): string {
+  return branch.trim().replace(/^refs\/(?:heads\/|remotes\/origin\/)/, '');
+}
+
 export function normalizeBleedingEdgeSelection(
   branch: unknown,
   commit: unknown,
@@ -12,7 +16,7 @@ export function normalizeBleedingEdgeSelection(
 ): BleedingEdgeSelection {
   const normalizedBranch = typeof branch === 'string' ? branch.trim() : '';
   return {
-    branch: normalizedBranch || defaultBranch,
+    branch: normalizeBranch(normalizedBranch) || defaultBranch,
     commit: typeof commit === 'string' ? commit.trim() : '',
   };
 }

--- a/updater/src/build-artifact.ts
+++ b/updater/src/build-artifact.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Stage the complete build before replacing a working installation. */
+export function installBleedingEdgeArtifact(
+  repoDir: string,
+  destination: string,
+  platform: NodeJS.Platform,
+  preservedEntries: ReadonlySet<string>
+): void {
+  const dist = path.join(repoDir, 'application', 'dist');
+  const windows = platform === 'win32';
+  if (!windows && platform !== 'linux') {
+    throw new Error(`Bleeding-edge builds are unsupported on ${platform}`);
+  }
+  const source = windows
+    ? path.join(dist, 'win-unpacked')
+    : path.join(dist, 'OpenGameInstaller-linux-pt.AppImage');
+  const executable = windows
+    ? path.join(source, 'OpenGameInstaller.exe')
+    : source;
+  if (!fs.statSync(executable).isFile()) {
+    throw new Error(`Built application not found: ${executable}`);
+  }
+  const parent = path.dirname(destination);
+  fs.mkdirSync(parent, { recursive: true });
+  const temporary = fs.mkdtempSync(path.join(parent, '.ogi-build-'));
+  const staged = path.join(temporary, 'staged');
+  const backup = path.join(temporary, 'previous');
+  try {
+    fs.mkdirSync(staged);
+    if (windows) {
+      fs.cpSync(source, staged, { recursive: true });
+    } else {
+      const target = path.join(staged, 'OpenGameInstaller.AppImage');
+      fs.copyFileSync(source, target);
+      fs.chmodSync(target, 0o755);
+    }
+    for (const entry of preservedEntries) {
+      const previous = path.join(destination, entry);
+      if (fs.existsSync(previous)) {
+        fs.cpSync(previous, path.join(staged, entry), { recursive: true });
+      }
+    }
+    const hadInstallation = fs.existsSync(destination);
+    if (hadInstallation) fs.renameSync(destination, backup);
+    try {
+      fs.renameSync(staged, destination);
+    } catch (error) {
+      if (hadInstallation) fs.renameSync(backup, destination);
+      throw error;
+    }
+  } finally {
+    // Keep the previous install if rollback itself failed.
+    if (fs.existsSync(destination)) {
+      fs.rmSync(temporary, { recursive: true, force: true });
+    }
+  }
+}

--- a/updater/src/git-sync.ts
+++ b/updater/src/git-sync.ts
@@ -111,6 +111,29 @@ export function syncBleedingEdgeRepo(
       )
     );
     const targetSha = resolved.stdout.trim();
+    // Refuse revisions that only survive locally after a force push or tag deletion.
+    const reachable = yield* withOperation(
+      'checkout',
+      runCommand(
+        'git',
+        [
+          'for-each-ref',
+          '--count=1',
+          `--contains=${targetSha}`,
+          'refs/remotes/origin',
+          'refs/tags',
+        ],
+        { cwd: repoDir }
+      )
+    );
+    if (!reachable.stdout.trim()) {
+      return yield* Effect.fail(
+        new GitSyncError({
+          message: `Revision ${targetSha} is no longer available from origin`,
+          operation: 'checkout',
+        })
+      );
+    }
     const status = yield* withOperation(
       'stash',
       runCommand('git', ['status', '--porcelain'], { cwd: repoDir })

--- a/updater/src/git-sync.ts
+++ b/updater/src/git-sync.ts
@@ -82,35 +82,43 @@ export function syncBleedingEdgeRepo(
       )
     );
     const beforeSyncSha = yield* getRepoHeadSha(repoDir);
-    // Resolve branch names against the fetched remote, never stale local branches.
-    let revision = remoteBranch;
-    if (commit) {
-      const remoteCommit = yield* Effect.either(
+    // Resolve names against fetched remote refs or tags only. A bare local
+    // branch name must never win, since it may outlive its deleted upstream.
+    const name = normalizeBranch(commit).replace(/^refs\/tags\//, '');
+    const candidates = commit
+      ? [
+          `refs/remotes/origin/${name}`,
+          `refs/tags/${name}`,
+          ...(/^[0-9a-f]{4,40}$/i.test(commit) ? [commit] : []),
+        ]
+      : [remoteBranch];
+    let targetSha = '';
+    for (const candidate of candidates) {
+      const resolved = yield* Effect.either(
         runCommand(
           'git',
           [
             'rev-parse',
             '--verify',
             '--end-of-options',
-            `refs/remotes/origin/${normalizeBranch(commit)}^{commit}`,
+            `${candidate}^{commit}`,
           ],
           { cwd: repoDir }
         )
       );
-      revision =
-        remoteCommit._tag === 'Right'
-          ? remoteCommit.right.stdout.trim()
-          : commit;
+      if (resolved._tag === 'Right') {
+        targetSha = resolved.right.stdout.trim();
+        break;
+      }
     }
-    const resolved = yield* withOperation(
-      'checkout',
-      runCommand(
-        'git',
-        ['rev-parse', '--verify', '--end-of-options', `${revision}^{commit}`],
-        { cwd: repoDir }
-      )
-    );
-    const targetSha = resolved.stdout.trim();
+    if (!targetSha) {
+      return yield* Effect.fail(
+        new GitSyncError({
+          message: `Revision ${commit || targetBranch} was not found on origin`,
+          operation: 'checkout',
+        })
+      );
+    }
     // Refuse revisions that only survive locally after a force push or tag deletion.
     const reachable = yield* withOperation(
       'checkout',

--- a/updater/src/git-sync.ts
+++ b/updater/src/git-sync.ts
@@ -1,15 +1,11 @@
 import { Data, Effect } from 'effect';
+import { normalizeBranch } from './bleeding-edge-flow.js';
 
 export type CommandResult = { stdout: string; stderr: string };
 
 export class GitSyncError extends Data.TaggedError('GitSyncError')<{
   readonly message: string;
-  readonly operation:
-    | 'fetch'
-    | 'resolve-head'
-    | 'checkout'
-    | 'rebase'
-    | 'stash';
+  readonly operation: 'fetch' | 'resolve-head' | 'checkout' | 'stash';
   readonly cause?: unknown;
 }> {}
 
@@ -51,64 +47,84 @@ export function syncBleedingEdgeRepo(
   branch: string,
   defaultBranch: string,
   runCommand: GitCommandRunner,
-  getRepoHeadSha: (repoDir: string) => Effect.Effect<string, GitSyncError>
+  getRepoHeadSha: (repoDir: string) => Effect.Effect<string, GitSyncError>,
+  commit = ''
 ): Effect.Effect<BleedingEdgeSyncResult, GitSyncError> {
-  const targetBranch = branch || defaultBranch;
+  const targetBranch = normalizeBranch(branch) || defaultBranch;
   const remoteBranch = `refs/remotes/origin/${targetBranch}`;
 
   return Effect.gen(function* () {
     yield* withOperation(
-      'fetch',
-      runCommand(
-        'git',
-        ['fetch', '--prune', '--tags', 'origin', ALL_ORIGIN_HEADS_REFSPEC],
-        { cwd: repoDir }
-      )
-    );
-    const beforeSyncSha = yield* withOperation(
-      'resolve-head',
-      getRepoHeadSha(repoDir)
-    );
-    const remoteBranchResult = yield* Effect.either(
-      runCommand('git', ['rev-parse', '--verify', remoteBranch], {
+      'checkout',
+      runCommand('git', ['check-ref-format', `refs/heads/${targetBranch}`], {
         cwd: repoDir,
       })
     );
-    if (remoteBranchResult._tag === 'Left') {
-      return yield* withOperation(
-        'checkout',
-        Effect.fail(remoteBranchResult.left)
-      );
-    }
-    const checkoutExisting = yield* Effect.either(
-      runCommand('git', ['checkout', targetBranch], { cwd: repoDir })
-    );
-    const checkoutResult =
-      checkoutExisting._tag === 'Right'
-        ? checkoutExisting
-        : yield* Effect.either(
-            runCommand(
-              'git',
-              ['checkout', '--track', '-b', targetBranch, remoteBranch],
-              { cwd: repoDir }
-            )
-          );
-    const rebaseResult =
-      checkoutResult._tag === 'Right'
-        ? yield* Effect.either(
-            runCommand('git', ['rebase', remoteBranch], { cwd: repoDir })
-          )
-        : checkoutResult;
-
-    if (rebaseResult._tag === 'Left') {
-      yield* runCommand('git', ['rebase', '--abort'], {
+    const shallow = yield* withOperation(
+      'fetch',
+      runCommand('git', ['rev-parse', '--is-shallow-repository'], {
         cwd: repoDir,
-      }).pipe(Effect.ignore);
+      })
+    );
+    yield* withOperation(
+      'fetch',
+      runCommand(
+        'git',
+        [
+          'fetch',
+          '--prune',
+          ...(shallow.stdout.trim() === 'true' ? ['--unshallow'] : []),
+          'origin',
+          ALL_ORIGIN_HEADS_REFSPEC,
+          '+refs/tags/*:refs/tags/*',
+        ],
+        { cwd: repoDir }
+      )
+    );
+    const beforeSyncSha = yield* getRepoHeadSha(repoDir);
+    // Resolve branch names against the fetched remote, never stale local branches.
+    let revision = remoteBranch;
+    if (commit) {
+      const remoteCommit = yield* Effect.either(
+        runCommand(
+          'git',
+          [
+            'rev-parse',
+            '--verify',
+            '--end-of-options',
+            `refs/remotes/origin/${normalizeBranch(commit)}^{commit}`,
+          ],
+          { cwd: repoDir }
+        )
+      );
+      revision =
+        remoteCommit._tag === 'Right'
+          ? remoteCommit.right.stdout.trim()
+          : commit;
+    }
+    const resolved = yield* withOperation(
+      'checkout',
+      runCommand(
+        'git',
+        ['rev-parse', '--verify', '--end-of-options', `${revision}^{commit}`],
+        { cwd: repoDir }
+      )
+    );
+    const targetSha = resolved.stdout.trim();
+    const status = yield* withOperation(
+      'stash',
+      runCommand('git', ['status', '--porcelain'], { cwd: repoDir })
+    );
+    if (status.stdout.trim()) {
       yield* withOperation(
         'stash',
         runCommand(
           'git',
           [
+            '-c',
+            'user.name=OpenGameInstaller updater',
+            '-c',
+            'user.email=updater@opengameinstaller.local',
             'stash',
             'push',
             '--include-untracked',
@@ -118,22 +134,14 @@ export function syncBleedingEdgeRepo(
           { cwd: repoDir }
         )
       );
-      // Rebase could not safely preserve the cache. Keep dirty files in the
-      // stash, then force-align the updater branch to the fetched remote.
-      yield* withOperation(
-        'checkout',
-        runCommand(
-          'git',
-          ['checkout', '--force', '-B', targetBranch, remoteBranch],
-          { cwd: repoDir }
-        )
-      );
     }
-    const afterSyncSha = yield* withOperation(
-      'resolve-head',
-      getRepoHeadSha(repoDir)
+    // This is a build cache. Rebasing can resurrect commits removed by a force push.
+    // Detached checkout preserves local branches while building the exact selected revision.
+    yield* withOperation(
+      'checkout',
+      runCommand('git', ['checkout', '--detach', targetSha], { cwd: repoDir })
     );
-
+    const afterSyncSha = yield* getRepoHeadSha(repoDir);
     return {
       beforeSyncSha,
       afterSyncSha,

--- a/updater/src/main.ts
+++ b/updater/src/main.ts
@@ -13,10 +13,11 @@ import zlib from 'zlib';
 import pjson from '../package.json' with { type: 'json' };
 import {
   normalizeBleedingEdgeSelection,
+  normalizeBranch,
   selectAndBuildBleedingEdge,
 } from './bleeding-edge-flow.js';
+import { installBleedingEdgeArtifact } from './build-artifact.js';
 import {
-  type BleedingEdgeSyncResult,
   GitSyncError,
   syncBleedingEdgeRepo as syncBleedingEdgeGitRepo,
 } from './git-sync.js';
@@ -140,7 +141,6 @@ const PRESERVED_UPDATE_ENTRIES = new Set([
   'favicon.png',
 ]);
 const OGI_REPO_URL = 'https://github.com/Nat3z/OpenGameInstaller';
-const ALL_ORIGIN_HEADS_REFSPEC = '+refs/heads/*:refs/remotes/origin/*';
 const HTTP_RANGE_AGENTS = {
   http: new http.Agent({
     keepAlive: true,
@@ -212,9 +212,8 @@ function writeCommitEdgeFile(branch: string, commit: string, built = '') {
   const lines = [`branch=${branch || DEFAULT_BLEEDING_EDGE_BRANCH}`];
   if (commit) {
     lines.push(`commit=${commit}`);
-  } else if (built) {
-    lines.push(`built=${built}`);
   }
+  if (built) lines.push(`built=${built}`);
   fs.writeFileSync('./COMMIT_EDGE.txt', `${lines.join('\n')}\n`);
 }
 
@@ -248,13 +247,14 @@ function getRepoHeadSha(repoDir: string): Effect.Effect<string, GitSyncError> {
   );
 }
 
-function shouldSkipBranchOnlyBleedingEdgeBuild(
+function shouldSkipBleedingEdgeBuild(
   targetBranch: string,
+  commit: string,
   headSha: string
 ) {
   const stored = readStoredCommitEdgeTarget();
   const artifactPath = getBleedingEdgeArtifactPath();
-  if (!stored || stored.commit || stored.branch !== targetBranch) {
+  if (!stored || stored.commit !== commit || stored.branch !== targetBranch) {
     return false;
   }
   if (!stored.built || stored.built !== headSha) {
@@ -292,7 +292,10 @@ function getBleedingEdgeRepoDir() {
 
 function getApplicationBuildCommand(): [string, string[]] {
   return process.platform === 'win32'
-    ? ['bun', ['run', '--cwd', 'application', 'electron-pack']]
+    ? [
+        'bun',
+        ['run', '--cwd', 'application', 'electron-pack', '--win', '--dir'],
+      ]
     : ['bun', ['run', '--cwd', 'application', 'electron-pack:linux']];
 }
 
@@ -363,7 +366,7 @@ function runCommand(
           ? Effect.succeed({ stdout, stderr })
           : Effect.fail(
               new UpdateError({
-                message: `${command} exited with code ${code}`,
+                message: `${command} exited with code ${code}: ${(stderr || stdout).trim().slice(-2000)}`,
                 phase: 'run-command',
               })
             )
@@ -378,10 +381,7 @@ function runCommand(
   });
 }
 
-function syncBleedingEdgeRepo(
-  repoDir: string,
-  branch: string
-): Effect.Effect<BleedingEdgeSyncResult, GitSyncError> {
+function syncBleedingEdgeRepo(repoDir: string, branch: string, commit: string) {
   return syncBleedingEdgeGitRepo(
     repoDir,
     branch,
@@ -393,7 +393,8 @@ function syncBleedingEdgeRepo(
           cause: cause.cause ?? cause,
         }))
       ),
-    getRepoHeadSha
+    getRepoHeadSha,
+    commit
   );
 }
 
@@ -429,20 +430,22 @@ function ensureBleedingEdgeBuild(
 ) {
   return Effect.gen(function* () {
     const repoDir = getBleedingEdgeRepoDir();
-    const targetBranch = branch || DEFAULT_BLEEDING_EDGE_BRANCH;
+    const targetBranch =
+      normalizeBranch(branch) || DEFAULT_BLEEDING_EDGE_BRANCH;
     sendUpdaterStatus('Preparing Bleeding Edge');
-    let syncResult: BleedingEdgeSyncResult | null = null;
+    if (process.platform !== 'win32' && process.platform !== 'linux') {
+      return yield* Effect.fail(
+        new UpdateError({
+          message: 'Bleeding-edge builds require Windows or Linux',
+          phase: 'build-platform',
+        })
+      );
+    }
     if (!fs.existsSync(path.join(repoDir, '.git'))) {
       yield* tryUpdate('clone-repository', () =>
-        fs.rmSync(repoDir, { recursive: true, force: true })
+        fs.mkdirSync(path.dirname(repoDir), { recursive: true })
       );
-      yield* runCommand('git', [
-        'clone',
-        '--branch',
-        targetBranch,
-        OGI_REPO_URL,
-        repoDir,
-      ]).pipe(
+      yield* runCommand('git', ['clone', OGI_REPO_URL, repoDir]).pipe(
         Effect.mapError(
           (cause) =>
             new UpdateError({
@@ -452,28 +455,13 @@ function ensureBleedingEdgeBuild(
             })
         )
       );
-    } else {
-      syncResult = yield* syncBleedingEdgeRepo(repoDir, targetBranch);
     }
-    if (commit) {
-      yield* runCommand('git', ['checkout', commit], { cwd: repoDir }).pipe(
-        Effect.mapError(
-          (cause) =>
-            new UpdateError({
-              message: cause.message,
-              phase: 'checkout-commit',
-              cause,
-            })
-        )
-      );
-    }
-
-    const headSha = yield* getRepoHeadSha(repoDir);
-    if (
-      !commit &&
-      syncResult?.syncWasNoop &&
-      shouldSkipBranchOnlyBleedingEdgeBuild(targetBranch, headSha)
-    ) {
+    const { afterSyncSha: headSha } = yield* syncBleedingEdgeRepo(
+      repoDir,
+      targetBranch,
+      commit
+    );
+    if (shouldSkipBleedingEdgeBuild(targetBranch, commit, headSha)) {
       sendUpdaterStatus(
         'Bleeding Edge up to date',
         undefined,
@@ -481,14 +469,24 @@ function ensureBleedingEdgeBuild(
         'Skipping build'
       );
       yield* tryUpdate('write-commit-state', () =>
-        writeCommitEdgeFile(targetBranch, '', headSha)
+        writeCommitEdgeFile(targetBranch, commit, headSha)
       );
       return;
     }
 
-    yield* runCommand('bun', ['install', '--linker=hoisted'], {
-      cwd: repoDir,
-    }).pipe(
+    yield* runCommand(
+      'bun',
+      [
+        'install',
+        '--frozen-lockfile',
+        '--linker=hoisted',
+        '--concurrent-scripts',
+        '1',
+      ],
+      {
+        cwd: repoDir,
+      }
+    ).pipe(
       Effect.mapError(
         (cause) =>
           new UpdateError({
@@ -508,16 +506,15 @@ function ensureBleedingEdgeBuild(
           })
       )
     );
-    yield* runCommand('bun', ['run', 'build'], { cwd: repoDir }).pipe(
-      Effect.mapError(
-        (cause) =>
-          new UpdateError({
-            message: cause.message,
-            phase: 'build-packages',
-            cause,
-          })
-      )
-    );
+    // Remove old output so packaging cannot accidentally reuse a previous revision.
+    yield* tryUpdate('clean-build-output', () => {
+      for (const output of ['out', 'dist']) {
+        fs.rmSync(path.join(repoDir, 'application', output), {
+          recursive: true,
+          force: true,
+        });
+      }
+    });
     const [buildCommand, buildArgs] = getApplicationBuildCommand();
     yield* runCommand(buildCommand, buildArgs, { cwd: repoDir }).pipe(
       Effect.mapError(
@@ -530,54 +527,16 @@ function ensureBleedingEdgeBuild(
       )
     );
 
-    const destRoot = path.join(__dirname, 'update');
-    yield* tryUpdate('prepare-update', () =>
-      prepareUpdateDestination(destRoot)
+    yield* tryUpdate('install-build', () =>
+      installBleedingEdgeArtifact(
+        repoDir,
+        path.join(__dirname, 'update'),
+        process.platform,
+        PRESERVED_UPDATE_ENTRIES
+      )
     );
-    if (process.platform === 'win32') {
-      const exe = yield* tryUpdate('find-build', () =>
-        findFirstFile(
-          path.join(repoDir, 'application', 'dist'),
-          (name) =>
-            name.toLowerCase().endsWith('.exe') &&
-            !name.toLowerCase().includes('setup')
-        )
-      );
-      if (!exe) {
-        return yield* Effect.fail(
-          new UpdateError({
-            message: 'Built Windows executable not found',
-            phase: 'find-build',
-          })
-        );
-      }
-      yield* tryUpdate('copy-build', () =>
-        fs.copyFileSync(exe, path.join(destRoot, 'OpenGameInstaller.exe'))
-      );
-    } else {
-      const appImage = yield* tryUpdate('find-build', () =>
-        findFirstFile(path.join(repoDir, 'application', 'dist'), (name) =>
-          name.toLowerCase().endsWith('.appimage')
-        )
-      );
-      if (!appImage) {
-        return yield* Effect.fail(
-          new UpdateError({
-            message: 'Built Linux AppImage not found',
-            phase: 'find-build',
-          })
-        );
-      }
-      yield* tryUpdate('copy-build', () => {
-        fs.copyFileSync(
-          appImage,
-          path.join(destRoot, 'OpenGameInstaller.AppImage')
-        );
-        fs.chmodSync(path.join(destRoot, 'OpenGameInstaller.AppImage'), '755');
-      });
-    }
     yield* tryUpdate('write-commit-state', () =>
-      writeCommitEdgeFile(targetBranch, commit, commit ? '' : headSha)
+      writeCommitEdgeFile(targetBranch, commit, headSha)
     );
   });
 }
@@ -595,7 +554,6 @@ function parseRemoteBranchName(ref: string): string | null {
 }
 
 function getBranches(): Effect.Effect<string[], UpdateError> {
-  const repoDir = getBleedingEdgeRepoDir();
   const remoteBranches = Effect.gen(function* () {
     const { stdout } = yield* runCommand(
       'git',
@@ -618,50 +576,7 @@ function getBranches(): Effect.Effect<string[], UpdateError> {
     return unique.includes('main') ? ['main', ...others] : others;
   });
 
-  if (!fs.existsSync(path.join(repoDir, '.git'))) {
-    return remoteBranches;
-  }
-
-  return Effect.gen(function* () {
-    yield* runCommand(
-      'git',
-      ['fetch', '--prune', 'origin', ALL_ORIGIN_HEADS_REFSPEC],
-      { cwd: repoDir, quiet: true }
-    );
-    const { stdout } = yield* runCommand(
-      'git',
-      [
-        'for-each-ref',
-        'refs/remotes/origin',
-        '--format=%(refname:short)\t%(committerdate:iso8601)',
-        '--sort=-committerdate',
-      ],
-      { cwd: repoDir, quiet: true }
-    );
-    const datedBranches: { name: string; date: string }[] = [];
-    for (const line of stdout.split('\n')) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      const tab = trimmed.indexOf('\t');
-      const ref = tab === -1 ? trimmed : trimmed.slice(0, tab);
-      const date = tab === -1 ? '' : trimmed.slice(tab + 1);
-      const name = parseRemoteBranchName(ref);
-      if (name && name !== 'HEAD') datedBranches.push({ name, date });
-    }
-    if (!datedBranches.length) return yield* remoteBranches;
-    const others = datedBranches
-      .filter((branch) => branch.name !== 'main')
-      .map((branch) => branch.name);
-    return datedBranches.some((branch) => branch.name === 'main')
-      ? ['main', ...others]
-      : others;
-  }).pipe(
-    Effect.catchAll((error) =>
-      logger
-        .info('Local git branch listing failed, using ls-remote:', error)
-        .pipe(Effect.zipRight(remoteBranches))
-    )
-  );
+  return remoteBranches;
 }
 
 type RecentCommit = {
@@ -697,19 +612,13 @@ function parseGitLogCommits(stdout: string): RecentCommit[] {
 function getRecentCommits(
   branch = DEFAULT_BLEEDING_EDGE_BRANCH
 ): Effect.Effect<RecentCommit[], UpdaterError> {
-  const targetBranch = branch || DEFAULT_BLEEDING_EDGE_BRANCH;
+  const targetBranch = normalizeBranch(branch) || DEFAULT_BLEEDING_EDGE_BRANCH;
   const logFormat = '%H%x1f%an%x1f%cI%x1f%s';
-  const repoDir = getBleedingEdgeRepoDir();
 
   const cloneAndRead = Effect.acquireUseRelease(
-    tryFileSystem('remove-temporary-repository', undefined, () => {
-      const tmpDir = path.join(
-        app.getPath('temp'),
-        `ogi-updater-commits-${process.pid}-${Date.now()}`
-      );
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-      return tmpDir;
-    }),
+    tryFileSystem('create-temporary-repository', undefined, () =>
+      fs.mkdtempSync(path.join(app.getPath('temp'), 'ogi-updater-commits-'))
+    ),
     (tmpDir) =>
       Effect.gen(function* () {
         yield* runCommand(
@@ -718,6 +627,8 @@ function getRecentCommits(
             'clone',
             '--depth',
             '12',
+            '--no-checkout',
+            '--filter=blob:none',
             '--branch',
             targetBranch,
             '--single-branch',
@@ -739,30 +650,7 @@ function getRecentCommits(
       ).pipe(Effect.orElseSucceed(() => undefined))
   );
 
-  if (!fs.existsSync(path.join(repoDir, '.git'))) {
-    return cloneAndRead;
-  }
-
-  return Effect.gen(function* () {
-    yield* runCommand(
-      'git',
-      [
-        'fetch',
-        'origin',
-        `+refs/heads/${targetBranch}:refs/remotes/origin/${targetBranch}`,
-        '--depth',
-        '12',
-      ],
-      { cwd: repoDir, quiet: true }
-    );
-    const { stdout } = yield* runCommand(
-      'git',
-      ['log', `origin/${targetBranch}`, '-12', `--format=${logFormat}`],
-      { cwd: repoDir, quiet: true }
-    );
-    const commits = parseGitLogCommits(stdout);
-    return commits.length ? commits : yield* cloneAndRead;
-  });
+  return cloneAndRead;
 }
 
 ipcMain.handle('get-branches', async () => {
@@ -798,20 +686,6 @@ ipcMain.handle('get-recent-commits', async (_event, branch) => {
     };
   }
 });
-
-function findFirstFile(root, predicate) {
-  if (!fs.existsSync(root)) return null;
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    const fullPath = path.join(root, entry.name);
-    if (entry.isDirectory()) {
-      const found = findFirstFile(fullPath, predicate);
-      if (found) return found;
-    } else if (predicate(entry.name, fullPath)) {
-      return fullPath;
-    }
-  }
-  return null;
-}
 
 function getEffectiveOnlineState(requestedOnline = getRequestedOnlineState()) {
   const networkOnline = net.isOnline();
@@ -1152,9 +1026,17 @@ function createWindow(): Effect.Effect<void, UpdaterError> {
             selectAndBuildBleedingEdge(
               selection,
               (target) =>
-                tryFileSystem('write-commit-state', './COMMIT_EDGE.txt', () =>
-                  writeCommitEdgeFile(target.branch, target.commit)
-                ),
+                tryFileSystem('write-commit-state', './COMMIT_EDGE.txt', () => {
+                  const stored = readStoredCommitEdgeTarget();
+                  writeCommitEdgeFile(
+                    target.branch,
+                    target.commit,
+                    stored?.branch === target.branch &&
+                      stored?.commit === target.commit
+                      ? stored.built
+                      : ''
+                  );
+                }),
               (target) => ensureBleedingEdgeBuild(target.commit, target.branch)
             )
           );

--- a/updater/src/main.ts
+++ b/updater/src/main.ts
@@ -442,9 +442,11 @@ function ensureBleedingEdgeBuild(
       );
     }
     if (!fs.existsSync(path.join(repoDir, '.git'))) {
-      yield* tryUpdate('clone-repository', () =>
-        fs.mkdirSync(path.dirname(repoDir), { recursive: true })
-      );
+      // An interrupted clone leaves a directory without .git that git refuses to clone into.
+      yield* tryUpdate('clone-repository', () => {
+        fs.rmSync(repoDir, { recursive: true, force: true });
+        fs.mkdirSync(path.dirname(repoDir), { recursive: true });
+      });
       yield* runCommand('git', ['clone', OGI_REPO_URL, repoDir]).pipe(
         Effect.mapError(
           (cause) =>

--- a/updater/test/bleeding-edge-flow.test.ts
+++ b/updater/test/bleeding-edge-flow.test.ts
@@ -34,3 +34,15 @@ test('persists a bleeding-edge selection before a build can fail', async () => {
   expect(exit._tag).toBe('Failure');
   expect(events).toEqual(['persist:feature/test:abc123', 'build']);
 });
+
+test('normalizes fully qualified branch refs without stripping branch paths', () => {
+  for (const branch of [
+    'refs/heads/feature/test',
+    'refs/remotes/origin/feature/test',
+    'feature/test',
+  ]) {
+    expect(normalizeBleedingEdgeSelection(branch, '', 'main').branch).toBe(
+      'feature/test'
+    );
+  }
+});

--- a/updater/test/build-artifact.test.ts
+++ b/updater/test/build-artifact.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { installBleedingEdgeArtifact } from '../src/build-artifact.js';
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0))
+    fs.rmSync(root, { recursive: true, force: true });
+});
+function fixture(): { root: string; destination: string; dist: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ogi-artifact-'));
+  roots.push(root);
+  const destination = path.join(root, 'update');
+  const dist = path.join(root, 'application', 'dist');
+  fs.mkdirSync(destination);
+  fs.mkdirSync(dist, { recursive: true });
+  fs.writeFileSync(path.join(destination, 'old-build'), 'working build');
+  fs.writeFileSync(path.join(destination, 'latest.log'), 'keep log');
+  return { root, destination, dist };
+}
+
+test('installs the complete Windows directory including resources and DLLs', () => {
+  const { root, destination, dist } = fixture();
+  const unpacked = path.join(dist, 'win-unpacked');
+  fs.mkdirSync(path.join(unpacked, 'resources'), { recursive: true });
+  fs.writeFileSync(path.join(unpacked, 'OpenGameInstaller.exe'), 'exe');
+  fs.writeFileSync(path.join(unpacked, 'resources', 'app.asar'), 'app');
+  fs.writeFileSync(path.join(unpacked, 'ffmpeg.dll'), 'dll');
+  installBleedingEdgeArtifact(
+    root,
+    destination,
+    'win32',
+    new Set(['latest.log'])
+  );
+  expect(
+    fs.readFileSync(path.join(destination, 'resources', 'app.asar'), 'utf8')
+  ).toBe('app');
+  expect(fs.readFileSync(path.join(destination, 'ffmpeg.dll'), 'utf8')).toBe(
+    'dll'
+  );
+  expect(fs.readFileSync(path.join(destination, 'latest.log'), 'utf8')).toBe(
+    'keep log'
+  );
+  expect(fs.existsSync(path.join(destination, 'old-build'))).toBe(false);
+});
+
+test('keeps the working installation when the build output is missing', () => {
+  const { root, destination } = fixture();
+  expect(() =>
+    installBleedingEdgeArtifact(root, destination, 'linux', new Set())
+  ).toThrow();
+  expect(fs.readFileSync(path.join(destination, 'old-build'), 'utf8')).toBe(
+    'working build'
+  );
+});
+
+test('installs only the expected Linux artifact and makes it executable', () => {
+  const { root, destination, dist } = fixture();
+  fs.writeFileSync(path.join(dist, 'stale.AppImage'), 'stale');
+  fs.writeFileSync(
+    path.join(dist, 'OpenGameInstaller-linux-pt.AppImage'),
+    'new'
+  );
+  installBleedingEdgeArtifact(
+    root,
+    destination,
+    'linux',
+    new Set(['latest.log'])
+  );
+  const appImage = path.join(destination, 'OpenGameInstaller.AppImage');
+  expect(fs.readFileSync(appImage, 'utf8')).toBe('new');
+  if (process.platform !== 'win32')
+    expect(fs.statSync(appImage).mode & 0o777).toBe(0o755);
+});

--- a/updater/test/git-sync.test.ts
+++ b/updater/test/git-sync.test.ts
@@ -389,3 +389,33 @@ test('resolves branch overrides to the remote and accepts moved annotated tags',
     expect(result.afterSyncSha).toBe(head);
   }
 });
+
+test('rejects a branch override whose upstream was deleted but survives locally', async () => {
+  const { root, remote, seed, client } = await createRepository();
+  await git(seed, 'switch', '-c', 'feature');
+  await writeFile(path.join(seed, 'feature.txt'), 'feature\n');
+  await git(seed, 'add', '.');
+  await git(seed, 'commit', '-m', 'feature');
+  await git(seed, 'push', 'origin', 'feature');
+  await git(root, 'clone', '--branch', 'main', remote, client);
+  await git(client, 'switch', '-c', 'feature', '--track', 'origin/feature');
+  await git(client, 'switch', 'main');
+  await git(seed, 'switch', 'main');
+  await git(seed, 'merge', '--ff-only', 'feature');
+  await git(seed, 'push', 'origin', 'main');
+  await git(seed, 'push', 'origin', '--delete', 'feature');
+  const error = await Effect.runPromise(
+    Effect.flip(
+      syncBleedingEdgeRepo(
+        client,
+        'main',
+        'main',
+        runCommand,
+        getHeadSha,
+        'feature'
+      )
+    )
+  );
+  expect(error.operation).toBe('checkout');
+  expect(error.message).toContain('feature');
+});

--- a/updater/test/git-sync.test.ts
+++ b/updater/test/git-sync.test.ts
@@ -3,6 +3,7 @@ import { execFile } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { Effect } from 'effect';
 import {
@@ -101,7 +102,7 @@ test('synchronizes a cached branch after the remote branch is force-pushed', asy
   expect(await Effect.runPromise(getHeadSha(client))).toBe(remoteSha);
 });
 
-test('rebases local branch commits onto the fetched remote branch', async () => {
+test('builds the remote revision while preserving local commits on their branch', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'ogi-git-sync-'));
   temporaryDirectories.push(root);
   const remote = path.join(root, 'remote.git');
@@ -134,14 +135,14 @@ test('rebases local branch commits onto the fetched remote branch', async () => 
     syncBleedingEdgeRepo(client, 'main', 'main', runCommand, getHeadSha)
   );
 
-  expect(result.afterSyncSha).not.toBe(remoteSha);
+  expect(result.afterSyncSha).toBe(remoteSha);
   expect(
     (await git(client, 'merge-base', 'HEAD', `origin/main`)).stdout.trim()
   ).toBe(remoteSha);
-  expect((await git(client, 'show', 'HEAD:local.txt')).stdout).toBe('local\n');
+  expect((await git(client, 'show', 'main:local.txt')).stdout).toBe('local\n');
 });
 
-test('stashes dirty files before force-aligning when rebase cannot start', async () => {
+test('stashes dirty files without requiring user Git identity', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'ogi-git-sync-'));
   temporaryDirectories.push(root);
   const remote = path.join(root, 'remote.git');
@@ -210,7 +211,7 @@ test('returns a missing remote branch error without starting recovery', async ()
   );
 
   expect(error.operation).toBe('checkout');
-  expect(commands.some((args) => args[0] === 'stash')).toBe(false);
+  expect(commands.some((args) => args.includes('stash'))).toBe(false);
   expect(commands.some((args) => args.includes('--force'))).toBe(false);
 });
 
@@ -258,9 +259,103 @@ test('recovers a dirty detached cache when the target branch exists', async () =
   );
 
   expect(result.afterSyncSha).toBe(remoteSha);
-  expect(commands.some((args) => args[0] === 'stash')).toBe(true);
-  expect(commands.some((args) => args.includes('--force'))).toBe(true);
+  expect(commands.some((args) => args.includes('stash'))).toBe(true);
+  expect(commands.some((args) => args.includes('--detach'))).toBe(true);
   expect(
     (await git(client, 'stash', 'show', '-p', 'stash@{0}')).stdout
   ).toContain('dirty detached change');
+});
+
+async function createRepository(): Promise<{
+  root: string;
+  remote: string;
+  seed: string;
+  client: string;
+}> {
+  const root = await mkdtemp(path.join(tmpdir(), 'ogi-git-sync-'));
+  temporaryDirectories.push(root);
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const client = path.join(root, 'client');
+  await git(root, 'init', '--bare', remote);
+  await git(root, 'init', '-b', 'main', seed);
+  await git(seed, 'config', 'user.email', 'updater-test@example.invalid');
+  await git(seed, 'config', 'user.name', 'updater-test');
+  await writeFile(path.join(seed, 'base.txt'), 'base\n');
+  await git(seed, 'add', '.');
+  await git(seed, 'commit', '-m', 'base');
+  await git(seed, 'remote', 'add', 'origin', remote);
+  await git(seed, 'push', 'origin', 'main');
+  return { root, remote, seed, client };
+}
+
+test('does not resurrect a non-conflicting commit removed by a force push', async () => {
+  const { root, remote, seed, client } = await createRepository();
+  const base = await Effect.runPromise(getHeadSha(seed));
+  await writeFile(path.join(seed, 'removed.txt'), 'removed upstream\n');
+  await git(seed, 'add', '.');
+  await git(seed, 'commit', '-m', 'removed commit');
+  await git(seed, 'push', 'origin', 'main');
+  await git(root, 'clone', '--branch', 'main', remote, client);
+  await git(seed, 'checkout', '--detach', base);
+  await writeFile(path.join(seed, 'new.txt'), 'new upstream\n');
+  await git(seed, 'add', '.');
+  await git(seed, 'commit', '-m', 'replacement');
+  await git(seed, 'push', '--force', 'origin', 'HEAD:main');
+  const result = await Effect.runPromise(
+    syncBleedingEdgeRepo(client, 'main', 'main', runCommand, getHeadSha)
+  );
+  expect(result.afterSyncSha).toBe(await Effect.runPromise(getHeadSha(seed)));
+  expect(
+    (await git(client, 'ls-tree', '--name-only', 'HEAD')).stdout
+  ).not.toContain('removed.txt');
+});
+
+test('unshallows old picker caches and builds an older pinned commit', async () => {
+  const { root, remote, seed, client } = await createRepository();
+  const base = await Effect.runPromise(getHeadSha(seed));
+  await writeFile(path.join(seed, 'base.txt'), 'new\n');
+  await git(seed, 'commit', '-am', 'new');
+  await git(seed, 'push', 'origin', 'main');
+  await git(
+    root,
+    'clone',
+    '--depth',
+    '1',
+    '--branch',
+    'main',
+    pathToFileURL(remote).href,
+    client
+  );
+  const result = await Effect.runPromise(
+    syncBleedingEdgeRepo(client, 'main', 'main', runCommand, getHeadSha, base)
+  );
+  expect(result.afterSyncSha).toBe(base);
+  expect(
+    (await git(client, 'rev-parse', '--is-shallow-repository')).stdout.trim()
+  ).toBe('false');
+});
+
+test('resolves branch overrides to the remote and accepts moved annotated tags', async () => {
+  const { root, remote, seed, client } = await createRepository();
+  await git(seed, 'tag', '-a', 'preview', '-m', 'old preview');
+  await git(seed, 'push', 'origin', 'preview');
+  await git(root, 'clone', '--branch', 'main', remote, client);
+  await writeFile(path.join(seed, 'base.txt'), 'new\n');
+  await git(seed, 'commit', '-am', 'new');
+  await git(seed, 'tag', '-f', '-a', 'preview', '-m', 'new preview');
+  await git(seed, 'push', '--force', 'origin', 'main', 'preview');
+  const head = await Effect.runPromise(getHeadSha(seed));
+  for (const ref of [
+    'main',
+    'refs/heads/main',
+    'refs/remotes/origin/main',
+    'preview',
+    'refs/tags/preview',
+  ]) {
+    const result = await Effect.runPromise(
+      syncBleedingEdgeRepo(client, 'main', 'main', runCommand, getHeadSha, ref)
+    );
+    expect(result.afterSyncSha).toBe(head);
+  }
 });

--- a/updater/test/git-sync.test.ts
+++ b/updater/test/git-sync.test.ts
@@ -311,6 +311,36 @@ test('does not resurrect a non-conflicting commit removed by a force push', asyn
   ).not.toContain('removed.txt');
 });
 
+test('rejects a pinned commit that a force push removed from the remote', async () => {
+  const { root, remote, seed, client } = await createRepository();
+  const base = await Effect.runPromise(getHeadSha(seed));
+  await writeFile(path.join(seed, 'removed.txt'), 'removed upstream\n');
+  await git(seed, 'add', '.');
+  await git(seed, 'commit', '-m', 'removed commit');
+  await git(seed, 'push', 'origin', 'main');
+  const removed = await Effect.runPromise(getHeadSha(seed));
+  await git(root, 'clone', '--branch', 'main', remote, client);
+  await git(seed, 'checkout', '--detach', base);
+  await writeFile(path.join(seed, 'new.txt'), 'new upstream\n');
+  await git(seed, 'add', '.');
+  await git(seed, 'commit', '-m', 'replacement');
+  await git(seed, 'push', '--force', 'origin', 'HEAD:main');
+  const error = await Effect.runPromise(
+    Effect.flip(
+      syncBleedingEdgeRepo(
+        client,
+        'main',
+        'main',
+        runCommand,
+        getHeadSha,
+        removed
+      )
+    )
+  );
+  expect(error.operation).toBe('checkout');
+  expect(error.message).toContain(removed);
+});
+
 test('unshallows old picker caches and builds an older pinned commit', async () => {
   const { root, remote, seed, client } = await createRepository();
   const base = await Effect.runPromise(getHeadSha(seed));


### PR DESCRIPTION
# Description

Bleeding-edge builds could end up on the wrong revision: the cache was rebased onto the remote (resurrecting force-pushed commits), picker caches were shallow so older pinned commits failed to check out, and fully qualified branch refs or moved tags were rejected. The updater now fetches, resolves the exact requested revision against the remote, and checks it out detached, stashing dirty files with a fixed Git identity. Windows installs copy the whole `win-unpacked` directory (resources, DLLs) through a staged rename with rollback instead of a lone `.exe`, and the commit picker uses isolated clones with stale-response protection.

Game artwork now shares one fallback. `GameImage` renders the library's gradient-and-OGI-logo placeholder whenever a cover URL is missing or fails to load, so downloads, discover, search, store, and library all degrade the same way instead of showing broken images or a raw favicon.

Also adds an updater build/test job to CI on Windows and Linux, and fixes two missing exports in the download handler test mock.

# Example

```
$ bun run --cwd updater test
 14 pass, 0 fail (git-sync force-push, shallow-unshallow, moved-tag, artifact install)
```

Frontend: five failure cases (empty URL, 404, invalid host, aborted load, later swap to a valid URL) render the shared fallback with no broken image icons.

# Next Steps

- Verify a real bleeding-edge build end-to-end on a Windows machine
- Consider a size cap on the updater's git cache directory


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent artwork handling across search, discovery, store, downloads, and library views.
  - Missing artwork now displays a branded fallback with optional game titles.
  - Bleeding-edge updates support normalized branches and pinned commits.
  - Updates use staged installation with rollback protection.

- **Bug Fixes**
  - Prevented outdated branch and commit responses from replacing current selections.
  - Improved recovery from interrupted downloads and invalid repository states.
  - Improved handling of read-only caches and failed image loads.
  - Preserved selected installation data during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->