### PR TITLE
fix(application): skip gone-folder deletes and surface removal feedback

### DIFF
--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -51,6 +51,7 @@ import {
 import {
   generateNotificationId,
   notifyError,
+  notifyInfo,
   notifySuccess,
 } from '@/electron/handlers/helpers.app/notifications.js';
 import { isLinux } from '@/electron/handlers/helpers.app/platform.js';
@@ -187,12 +188,21 @@ function startBackgroundFileDeletion(
   const base = { id: taskId, appID: appid, gameName };
   // The main process owns the terminal notification so it fires exactly once
   // even if the renderer reloads mid-deletion.
-  const send = (payload: GameRemovalProgress) => {
+  const send = (
+    payload: GameRemovalProgress,
+    options?: { alreadyGone?: boolean }
+  ) => {
     const task = removalTasks.get(taskId);
     if (task) task.snapshot = payload;
     void sendIPCMessage('game:removal-progress', payload);
     if (payload.status === 'completed') {
-      notifySuccess(`${gameName} removed from library and files deleted`);
+      if (options?.alreadyGone) {
+        notifyInfo(
+          `${gameName} was removed from the library. Install files were already gone.`
+        );
+      } else {
+        notifySuccess(`${gameName} removed from library and files deleted`);
+      }
     } else if (payload.status === 'error') {
       notifyError(
         `${gameName} was removed from the library, but its files could not be deleted: ${payload.error}`
@@ -243,13 +253,16 @@ function startBackgroundFileDeletion(
       return;
     }
     if (root === null) {
-      send({
-        ...base,
-        status: 'completed',
-        progress: 100,
-        deleted: 0,
-        total: 0,
-      });
+      send(
+        {
+          ...base,
+          status: 'completed',
+          progress: 100,
+          deleted: 0,
+          total: 0,
+        },
+        { alreadyGone: true }
+      );
       return;
     }
     let deleted = 0;

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -58,8 +58,7 @@ import {
   appMetadataSubtrees,
   type DeleteGuardRoots,
   filesystemRoot,
-  isProtectedDeletePath,
-  sharesDirectoryWithOtherGames,
+  planGameFileDeletion,
   systemSubtrees,
 } from '@/electron/lib/delete-guards.js';
 import { resolveSpawnInvocation } from '@/electron/lib/spawn-shell.js';
@@ -137,9 +136,20 @@ export function awaitPendingFileDeletions(): Promise<void> {
   );
 }
 
+function isNotFoundError(cause: unknown): boolean {
+  return (
+    typeof cause === 'object' &&
+    cause !== null &&
+    'code' in cause &&
+    (cause as { code: unknown }).code === 'ENOENT'
+  );
+}
+
 /**
  * Renames `from` to `to`, retrying briefly for transient holders such as a
- * virus scanner. Throws when the directory still cannot be isolated.
+ * virus scanner. Missing folders fail immediately so a gone install is not
+ * retried for seconds with no UI. Throws when the directory still cannot be
+ * isolated.
  */
 async function moveDirectoryAside(from: string, to: string): Promise<void> {
   const attempts = 5;
@@ -148,7 +158,8 @@ async function moveDirectoryAside(from: string, to: string): Promise<void> {
       await fsp.rename(from, to);
       return;
     } catch (cause) {
-      if (attempt === attempts) {
+      if (isNotFoundError(cause) || attempt === attempts) {
+        if (isNotFoundError(cause)) throw cause;
         throw new Error(
           `its folder could not be moved aside for deletion (${cause instanceof Error ? cause.message : String(cause)})`
         );
@@ -207,20 +218,38 @@ function startBackgroundFileDeletion(
     if (runningGames.has(appid)) {
       throw new Error('the game is currently running');
     }
+    if (!fs.existsSync(cwd)) {
+      return null;
+    }
     const aside = join(
       dirname(cwd),
       `.${basename(cwd)}.ogi-removing-${Date.now()}`
     );
-    await moveDirectoryAside(cwd, aside);
+    try {
+      await moveDirectoryAside(cwd, aside);
+    } catch (cause) {
+      if (isNotFoundError(cause)) return null;
+      throw cause;
+    }
     return aside;
   });
 
   const done = (async () => {
-    let root: string;
+    let root: string | null;
     try {
       root = await claim;
     } catch (cause) {
       fail(cause, 0, 0);
+      return;
+    }
+    if (root === null) {
+      send({
+        ...base,
+        status: 'completed',
+        progress: 100,
+        deleted: 0,
+        total: 0,
+      });
       return;
     }
     let deleted = 0;
@@ -317,6 +346,15 @@ export function launchGameFromLibrary(
     if (!appInfo) {
       logger.sync.info('[launch] Game not found');
       return { success: false, error: 'Game not found' };
+    }
+
+    if (appInfo.cwd && !fs.existsSync(appInfo.cwd)) {
+      logger.sync.info('[launch] Game folder is gone', appInfo.cwd);
+      return {
+        success: false,
+        error:
+          'The game folder is gone. Update the path in settings or remove the game from your library.',
+      };
     }
 
     if (
@@ -819,35 +857,23 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
               // after this returns can never collide with the deletion.
               let fileWarning: string | undefined;
               let deletionTaskId: string | undefined;
-              if (appInfo.cwd) {
-                if (runningGames.has(appid)) {
-                  fileWarning =
-                    'The game was removed from the library, but its files were not deleted because the game is currently running.';
-                } else if (
-                  isProtectedDeletePath(appInfo.cwd, deleteGuardRoots())
-                ) {
-                  fileWarning =
-                    'The game was removed from the library, but its files were not deleted because the path is a protected directory.';
-                } else if (
-                  sharesDirectoryWithOtherGames(
-                    appid,
-                    appInfo.cwd,
-                    getAllLibraryFiles()
-                  )
-                ) {
-                  fileWarning =
-                    'The game was removed from the library, but its files were not deleted because the directory contains other games.';
-                } else if (fs.existsSync(appInfo.cwd)) {
-                  const deletion = yield* Effect.sync(() =>
-                    startBackgroundFileDeletion(
-                      appid,
-                      appInfo.cwd,
-                      appInfo.name
-                    )
-                  );
-                  yield* Effect.promise(() => deletion.claimed);
-                  deletionTaskId = deletion.taskId;
-                }
+              const deletionPlan = planGameFileDeletion({
+                cwd: appInfo.cwd,
+                appID: appid,
+                running: runningGames.has(appid),
+                otherGames: getAllLibraryFiles(),
+                roots: deleteGuardRoots(),
+                pathExists: (path) => fs.existsSync(path),
+              });
+              if (deletionPlan.kind === 'skip' || !appInfo.cwd) {
+                fileWarning = deletionPlan.warning;
+              } else {
+                const cwd = appInfo.cwd;
+                const deletion = yield* Effect.sync(() =>
+                  startBackgroundFileDeletion(appid, cwd, appInfo.name)
+                );
+                yield* Effect.promise(() => deletion.claimed);
+                deletionTaskId = deletion.taskId;
               }
 
               return {

--- a/application/src/electron/handlers/handler.library.ts
+++ b/application/src/electron/handlers/handler.library.ts
@@ -865,9 +865,9 @@ export function registerLibraryHandlers(mainWindow: Electron.BrowserWindow) {
                 roots: deleteGuardRoots(),
                 pathExists: (path) => fs.existsSync(path),
               });
-              if (deletionPlan.kind === 'skip' || !appInfo.cwd) {
+              if (deletionPlan.kind === 'skip') {
                 fileWarning = deletionPlan.warning;
-              } else {
+              } else if (appInfo.cwd) {
                 const cwd = appInfo.cwd;
                 const deletion = yield* Effect.sync(() =>
                   startBackgroundFileDeletion(appid, cwd, appInfo.name)

--- a/application/src/electron/lib/delete-guards.test.ts
+++ b/application/src/electron/lib/delete-guards.test.ts
@@ -6,6 +6,7 @@ import {
   type DeleteGuardRoots,
   filesystemRoot,
   isProtectedDeletePath,
+  planGameFileDeletion,
   sharesDirectoryWithOtherGames,
   systemSubtrees,
 } from './delete-guards';
@@ -54,12 +55,13 @@ describe('isProtectedDeletePath', () => {
   });
 });
 
+const others = [
+  { appID: 1, cwd: '/games/alpha' },
+  { appID: 2, cwd: '/games/beta/nested' },
+  { appID: 3 },
+];
+
 describe('sharesDirectoryWithOtherGames', () => {
-  const others = [
-    { appID: 1, cwd: '/games/alpha' },
-    { appID: 2, cwd: '/games/beta/nested' },
-    { appID: 3 },
-  ];
 
   test('detects exact, parent, and child overlaps with other games', () => {
     expect(sharesDirectoryWithOtherGames(9, '/games/alpha', others)).toBe(true);
@@ -85,5 +87,60 @@ describe('sharesDirectoryWithOtherGames', () => {
     expect(sharesDirectoryWithOtherGames(9, '/somewhere', [{ appID: 3 }])).toBe(
       false
     );
+  });
+});
+
+describe('planGameFileDeletion', () => {
+  const exists = (present: Set<string>) => (path: string) => present.has(path);
+  const base = {
+    appID: 9,
+    running: false,
+    otherGames: others,
+    roots: roots(),
+  };
+
+  test('skips when there is no install path', () => {
+    expect(
+      planGameFileDeletion({
+        ...base,
+        cwd: undefined,
+        pathExists: exists(new Set()),
+      })
+    ).toEqual({ kind: 'skip' });
+  });
+
+  test('skips and explains when the folder is already gone', () => {
+    expect(
+      planGameFileDeletion({
+        ...base,
+        cwd: '/games/missing',
+        pathExists: exists(new Set()),
+      })
+    ).toEqual({
+      kind: 'skip',
+      warning:
+        'The game was removed from the library. Install files were already gone.',
+    });
+  });
+
+  test('skips a running game even if the folder still exists', () => {
+    expect(
+      planGameFileDeletion({
+        ...base,
+        cwd: '/games/gamma',
+        running: true,
+        pathExists: exists(new Set(['/games/gamma'])),
+      }).kind
+    ).toBe('skip');
+  });
+
+  test('deletes when the folder exists and is not guarded', () => {
+    expect(
+      planGameFileDeletion({
+        ...base,
+        cwd: '/games/gamma',
+        pathExists: exists(new Set(['/games/gamma'])),
+      })
+    ).toEqual({ kind: 'delete' });
   });
 });

--- a/application/src/electron/lib/delete-guards.ts
+++ b/application/src/electron/lib/delete-guards.ts
@@ -81,6 +81,54 @@ export const sharesDirectoryWithOtherGames = (
   });
 };
 
+export type GameFileDeletionPlan =
+  | { kind: 'delete' }
+  | { kind: 'skip'; warning?: string };
+
+const alreadyGoneWarning =
+  'The game was removed from the library. Install files were already gone.';
+
+/**
+ * Decide whether a lazy library removal should start deleting install files.
+ * A missing folder is a skip, not a delete — there is nothing to claim or wipe.
+ */
+export const planGameFileDeletion = (input: {
+  cwd: string | undefined;
+  appID: number;
+  running: boolean;
+  otherGames: ReadonlyArray<{ appID: number; cwd?: string }>;
+  roots: DeleteGuardRoots;
+  pathExists: (path: string) => boolean;
+}): GameFileDeletionPlan => {
+  const { cwd } = input;
+  if (!cwd) return { kind: 'skip' };
+  if (input.running) {
+    return {
+      kind: 'skip',
+      warning:
+        'The game was removed from the library, but its files were not deleted because the game is currently running.',
+    };
+  }
+  if (isProtectedDeletePath(cwd, input.roots)) {
+    return {
+      kind: 'skip',
+      warning:
+        'The game was removed from the library, but its files were not deleted because the path is a protected directory.',
+    };
+  }
+  if (sharesDirectoryWithOtherGames(input.appID, cwd, input.otherGames)) {
+    return {
+      kind: 'skip',
+      warning:
+        'The game was removed from the library, but its files were not deleted because the directory contains other games.',
+    };
+  }
+  if (!input.pathExists(cwd)) {
+    return { kind: 'skip', warning: alreadyGoneWarning };
+  }
+  return { kind: 'delete' };
+};
+
 /** App-owned directories that must never be wiped by a game removal. */
 export const appMetadataSubtrees = (dataDir: string): string[] => [
   join(dataDir, 'config'),

--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -4,6 +4,7 @@ import type {
   ConfigurationOptionWire,
   LibraryInfo,
 } from '@ogi-sdk/connect';
+import { formatError } from '@ogi-sdk/errors';
 import { Effect } from 'effect';
 import {
   ConfigurationBuilder,
@@ -165,13 +166,16 @@ let canEditDllOverrides = $derived(
 // by task id so a stale task from an earlier removal of the same game is
 // never mistaken for this one.
 let removalTaskId: string | undefined = $state();
+let removeBusy = $state(false);
 let removalStarted = $derived(removalTaskId !== undefined);
 let removalTask = $derived(
   $gameRemovalTasks.find((task) => task.id === removalTaskId)
 );
-// Treat the moment before the first progress event lands as removing too.
+// Treat the confirm-click wait and the moment before the first progress
+// event lands as removing too, so Delete Game is never a silent no-op.
 let isRemoving = $derived(
-  removalStarted && (!removalTask || removalTask.status === 'running')
+  removeBusy ||
+    (removalStarted && (!removalTask || removalTask.status === 'running'))
 );
 
 // Close the play page once the background deletion we started finishes;
@@ -214,49 +218,75 @@ async function removeFromList() {
     return;
   }
 
-  showRemoveConfirm = false;
-  const result = await runFrontendEffect(
-    electronRpc.app.removeApp(gameInfo.appID)
-  );
-  if (result.status !== 'success') {
-    createNotification({
-      id: Math.random().toString(36).substring(7),
-      message: result.status === 'cancelled' ? result.message : result.error,
-      type: result.status === 'cancelled' ? 'info' : 'error',
-    });
-    return;
-  }
-
-  completeRequiredReadd(gameInfo.appID);
-  currentDownloads.update((downloads) =>
-    downloads.filter((download) => download.appID !== gameInfo.appID)
-  );
-
-  if (result.deletionTaskId) {
-    // Files are deleted lazily in the background; keep the window open to
-    // show progress. Closing it leaves the deletion visible as a task.
-    removalTaskId = result.deletionTaskId;
-    if (result.warning) {
+  removeBusy = true;
+  try {
+    const result = await runFrontendEffect(
+      electronRpc.app.removeApp(gameInfo.appID)
+    );
+    showRemoveConfirm = false;
+    if (result.status !== 'success') {
       createNotification({
         id: Math.random().toString(36).substring(7),
-        message: result.warning,
-        type: 'info',
+        message: result.status === 'cancelled' ? result.message : result.error,
+        type: result.status === 'cancelled' ? 'info' : 'error',
       });
+      return;
     }
-    return;
-  }
 
-  createNotification({
-    id: Math.random().toString(36).substring(7),
-    message: result.warning ?? 'Game removed from library',
-    type: result.warning ? 'info' : 'success',
-  });
-  exitPlayPage();
+    completeRequiredReadd(gameInfo.appID);
+    currentDownloads.update((downloads) =>
+      downloads.filter((download) => download.appID !== gameInfo.appID)
+    );
+
+    if (result.deletionTaskId) {
+      // Files are deleted lazily in the background; keep the window open to
+      // show progress. Closing it leaves the deletion visible as a task.
+      removalTaskId = result.deletionTaskId;
+      if (result.warning) {
+        createNotification({
+          id: Math.random().toString(36).substring(7),
+          message: result.warning,
+          type: 'info',
+        });
+      }
+      return;
+    }
+
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message: result.warning ?? 'Game removed from library',
+      type: result.warning ? 'info' : 'success',
+    });
+    exitPlayPage();
+  } catch (error) {
+    showRemoveConfirm = false;
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message: formatError(error) || 'Failed to remove game',
+      type: 'error',
+    });
+  } finally {
+    if (!removalTaskId) removeBusy = false;
+  }
 }
 
 function showInFolder() {
-  if (gameInfo.cwd) {
-    window.electronAPI.fs.showFileLoc(gameInfo.cwd);
+  if (!gameInfo.cwd) {
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message: 'This game has no install folder set.',
+      type: 'error',
+    });
+    return;
+  }
+  const shown = window.electronAPI.fs.showFileLoc(gameInfo.cwd);
+  if (!shown) {
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message:
+        'The game folder is gone. Update the path in settings or remove the game from your library.',
+      type: 'error',
+    });
   }
 }
 
@@ -371,13 +401,13 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
         text="Save"
         variant="primary"
         onclick={pushChanges}
-        disabled={removalStarted}
+        disabled={removalStarted || removeBusy}
       />
       {#if platform === 'linux' || platform === 'darwin'}
         <ButtonModal
           text="Add to Steam"
           variant="secondary"
-          disabled={removalStarted}
+          disabled={removalStarted || removeBusy}
           onclick={(event) => {
             addToSteam(event.currentTarget as HTMLButtonElement);
           }}
@@ -387,15 +417,20 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
         text="Show in Folder"
         variant="secondary"
         onclick={showInFolder}
-        disabled={!gameInfo.cwd || removalStarted}
+        disabled={!gameInfo.cwd || removalStarted || removeBusy}
       />
       <ButtonModal
         text={isRemoving ? 'Removing…' : 'Remove Game'}
         variant="danger"
-        disabled={removalStarted}
+        disabled={removalStarted || removeBusy}
         onclick={() => (showRemoveConfirm = true)}
       />
-      <ButtonModal text="Cancel" variant="secondary" onclick={closeModal} />
+      <ButtonModal
+        text="Cancel"
+        variant="secondary"
+        onclick={closeModal}
+        disabled={removalStarted || removeBusy}
+      />
     </div>
 
     {#if isRemoving && removalTask}
@@ -423,23 +458,27 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
       open={true}
       size="small"
       closeOnOverlayClick={false}
-      onClose={() => (showRemoveConfirm = false)}
+      onClose={() => {
+        if (!removeBusy) showRemoveConfirm = false;
+      }}
     >
       <TitleModal title={`Remove ${gameInfo.name}?`} />
       <p class="mb-4 text-sm text-accent-dark">
         This removes the game from your library and permanently deletes its
-        files{gameInfo.cwd ? ` in ${gameInfo.cwd}` : ''}. This cannot be
-        undone.
+        files{gameInfo.cwd ? ` in ${gameInfo.cwd}` : ''}. If the folder is
+        already gone, only the library entry is removed. This cannot be undone.
       </p>
       <div class="flex flex-row gap-3">
         <ButtonModal
-          text="Delete Game"
+          text={removeBusy ? 'Removing…' : 'Delete Game'}
           variant="danger"
+          disabled={removeBusy}
           onclick={removeFromList}
         />
         <ButtonModal
           text="Cancel"
           variant="secondary"
+          disabled={removeBusy}
           onclick={() => (showRemoveConfirm = false)}
         />
       </div>

--- a/application/src/frontend/components/PlayPage.svelte
+++ b/application/src/frontend/components/PlayPage.svelte
@@ -121,6 +121,15 @@ const addonFailurePrompt = createLaunchPrompt();
 
 async function launchGame() {
   if ($gamesLaunched[libraryInfo.appID]) return;
+  if (libraryInfo.cwd && !window.electronAPI.fs.exists(libraryInfo.cwd)) {
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message:
+        'The game folder is gone. Update the path in settings or remove the game from your library.',
+      type: 'error',
+    });
+    return;
+  }
   logger.sync.info('Launching game with appID: ' + libraryInfo.appID);
   // playButton may be unbound (e.g. update-available button rendered instead);
   // launching still proceeds since gamesLaunched drives the button states
@@ -166,7 +175,25 @@ async function launchGame() {
 
   logger.sync.info('pre-launch complete');
 
-  await runFrontendEffect(electronRpc.app.launchGame('' + libraryInfo.appID));
+  try {
+    await runFrontendEffect(electronRpc.app.launchGame('' + libraryInfo.appID));
+  } catch (error) {
+    logger.sync.error(error);
+    createNotification({
+      id: Math.random().toString(36).substring(7),
+      message: formatError(error) || 'Failed to launch game',
+      type: 'error',
+    });
+    gamesLaunched.update((games) => {
+      delete games[libraryInfo.appID];
+      return games;
+    });
+    await tick();
+    if (playButton) {
+      playButton.setAttribute('data-error', 'true');
+    }
+    return;
+  }
 
   logger.sync.info('launchGame complete');
   if (!window.electronAPI.fs.exists('./internals')) {


### PR DESCRIPTION
# Description

If a game's install folder is already gone, Open / Delete / Remove no longer hang or fail silently. Removal skips file deletion, drops the library entry, and shows a toast. Show in Folder and Play report the missing path instead of doing nothing.

# Example

Delete Game on a library entry whose `cwd` is missing now shows **Removing…**, then a notification like "Install files were already gone," and returns to the library without that game.

# Next Steps

- Confirm CI is green
- Click through Play, Show in Folder, and Delete Game on a game whose folder was deleted outside OGI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a game’s installation folder is missing, including clearer notifications and safer removal behavior.
  * Prevented game launches when the configured working directory no longer exists.
  * Prevented duplicate or conflicting actions while removing a game.
  * Improved error reporting during game removal and launch failures.
  * Added safeguards to avoid deleting protected, shared, or actively used game files.
* **Tests**
  * Added coverage for missing folders, running games, protected paths, shared directories, and safe deletion decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->