### PR TITLE
fix(executor): pass Windows command line verbatim to cmd.exe

### DIFF
--- a/application/src/electron/handlers/handler.addon.ts
+++ b/application/src/electron/handlers/handler.addon.ts
@@ -502,7 +502,11 @@ export default function AddonManagerHandler(mainWindow: BrowserWindow) {
                   if (clonedThisInstall) {
                     yield* Effect.try({
                       try: () =>
-                        fs.rmSync(addonPath, { recursive: true, force: true }),
+                        fs.rmSync(addonPath, {
+                          recursive: true,
+                          force: true,
+                          maxRetries: 5,
+                        }),
                       catch: (cause) =>
                         new AddonError({
                           message: `Failed to clean up addon ${addonName}: ${String(cause)}`,
@@ -548,7 +552,11 @@ export default function AddonManagerHandler(mainWindow: BrowserWindow) {
               if (clonedThisInstall) {
                 yield* Effect.try({
                   try: () =>
-                    fs.rmSync(addonPath, { recursive: true, force: true }),
+                    fs.rmSync(addonPath, {
+                      recursive: true,
+                      force: true,
+                      maxRetries: 5,
+                    }),
                   catch: (cause) =>
                     new AddonError({
                       message: `Failed to clean up addon ${addonName}: ${String(cause)}`,
@@ -584,7 +592,11 @@ export default function AddonManagerHandler(mainWindow: BrowserWindow) {
                   // Clean up a partial clone so retries do not install from an unpinned default branch.
                   yield* Effect.try({
                     try: () =>
-                      fs.rmSync(addonPath, { recursive: true, force: true }),
+                      fs.rmSync(addonPath, {
+                        recursive: true,
+                        force: true,
+                        maxRetries: 5,
+                      }),
                     catch: (cause) =>
                       new AddonError({
                         message: `Failed to clean up addon ${addonName}: ${String(cause)}`,
@@ -666,7 +678,11 @@ export default function AddonManagerHandler(mainWindow: BrowserWindow) {
                     ? parsedAddon.path
                     : join(__dirname, 'addons', parsedAddon.addonName);
                 if (fs.existsSync(addonPath)) {
-                  fs.rmSync(addonPath, { recursive: true, force: true });
+                  fs.rmSync(addonPath, {
+                    recursive: true,
+                    force: true,
+                    maxRetries: 5,
+                  });
                 }
               },
               catch: (cause) =>

--- a/packages/executor/lib/addon-setup.test.ts
+++ b/packages/executor/lib/addon-setup.test.ts
@@ -34,7 +34,8 @@ describe('Addon setup scripts', () => {
       expect(invocation.command).toBe(
         process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe'
       );
-      expect(invocation.args.at(-1)).toContain('&&');
+      expect(invocation.args.at(-1)).toMatch(/^".*&&.*"$/s);
+      expect(invocation.windowsVerbatimArguments).toBe(true);
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform });
     }

--- a/packages/executor/lib/addon-setup.ts
+++ b/packages/executor/lib/addon-setup.ts
@@ -76,7 +76,7 @@ export class AddonSetup {
         );
       }
 
-      const { command, args } =
+      const { command, args, windowsVerbatimArguments } =
         process.platform === 'win32'
           ? yield* Addon.getScriptSpawnCommand(script)
           : { command: '/bin/sh', args: ['-c', startCommand] };
@@ -87,6 +87,7 @@ export class AddonSetup {
             cwd: this.config.path,
             env,
             stdio: ['ignore', 'pipe', 'pipe'],
+            windowsVerbatimArguments,
           }),
         catch: (cause) =>
           new AddonError({

--- a/packages/executor/lib/addon.ts
+++ b/packages/executor/lib/addon.ts
@@ -37,6 +37,8 @@ export type AddonConfig = {
 export type ScriptSpawnCommand = {
   readonly command: string;
   readonly args: string[];
+  /** cmd.exe gets one pre-quoted command line, so Node must not re-escape it. */
+  readonly windowsVerbatimArguments?: boolean;
 };
 
 type AddonLifecycleError = AddonError | FileSystemError | ValidationError;
@@ -123,9 +125,12 @@ export class Addon {
           scriptCommand,
           ...extraArgs.map(Addon.quoteWindowsShellArgument),
         ].join(' ');
+        // Same shape Node uses for `shell: true`: `/s` strips the outer quotes and
+        // leaves the inner quoting (e.g. the bun path) exactly as written.
         return {
           command: process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe',
-          args: ['/d', '/s', '/c', command],
+          args: ['/d', '/s', '/c', `"${command}"`],
+          windowsVerbatimArguments: true,
         };
       }
 
@@ -147,10 +152,11 @@ export class Addon {
     });
   }
 
-  private spawnProcess(
-    command: string,
-    args: string[]
-  ): Effect.Effect<ChildProcess, AddonError> {
+  private spawnProcess({
+    command,
+    args,
+    windowsVerbatimArguments,
+  }: ScriptSpawnCommand): Effect.Effect<ChildProcess, AddonError> {
     // Strip any inherited flag so only the session config decides the value
     const { OGI_GAME_LAUNCH: _inheritedFlag, ...inheritedEnv } = process.env;
     return Effect.try({
@@ -163,6 +169,7 @@ export class Addon {
             ...(this.config.gameSpecificLaunch ? { OGI_GAME_LAUNCH: '1' } : {}),
           },
           stdio: ['ignore', 'pipe', 'pipe'],
+          windowsVerbatimArguments,
         }),
       catch: (cause) =>
         new AddonError({
@@ -255,7 +262,7 @@ export class Addon {
         this.config.scripts = addonConfig.scripts;
       }
 
-      const { command, args } = yield* Addon.getScriptSpawnCommand(
+      const spawnCommand = yield* Addon.getScriptSpawnCommand(
         this.config.scripts.run,
         [
           `--addonPort=${this.config.port}`,
@@ -268,7 +275,7 @@ export class Addon {
           const child = yield* Effect.gen(this, function* () {
             const started = yield* Deferred.make<ChildProcess, AddonError>();
             const lifecycle = Effect.acquireUseRelease(
-              this.spawnProcess(command, args),
+              this.spawnProcess(spawnCommand),
               (child) =>
                 Effect.sync(() => {
                   this.childProcess = child;


### PR DESCRIPTION
# Description

On Windows, addon setup scripts failed with `'\"C:\Users\...\bun.exe\"' is not recognized as an internal or external command`. The executor builds a `cmd.exe /d /s /c <command>` invocation where the command already contains the quoted bun path, and Node's default Windows argument escaping re-quoted it, turning the inner quotes into `\"`.

- `getScriptSpawnCommand` now returns `windowsVerbatimArguments: true` and wraps the command line in one outer pair of quotes that `/s` strips, matching what Node does for `shell: true`. Both setup scripts and the addon run command use it.
- Partial-clone cleanup in the addon install handler now passes `maxRetries: 5` to `rmSync`, so the `EPERM` from a directory still held open on Windows no longer masks the real install error.
- The existing Windows shell test asserts the outer quoting and the verbatim flag.

# Example

Before:

```
[executor INFO] [steam-integration@pre-setup] Running script: "C:\Users\zlaja\.bun\bin\bun.exe" install --frozen-lockfile
[executor ERROR] [steam-integration@pre-setup] '\"C:\Users\zlaja\.bun\bin\bun.exe\"' is not recognized as an internal or external command
```

After, cmd.exe receives:

```
cmd.exe /d /s /c ""C:\Users\zlaja\.bun\bin\bun.exe" install --frozen-lockfile"
```

# Next Steps

- Smoke test a marketplace addon install on Windows (verified via tests and typecheck on Linux only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows add-on setup by preserving command-line quoting when running setup scripts.
  - Increased reliability when removing add-on files and directories by retrying cleanup operations up to five times after temporary failures.
  - Fixed Windows command execution behavior for add-on installation and setup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->