### PR TITLE
feat(ogi-addon): expose launch mode and type-check required option setters

### DIFF
--- a/application/src/frontend/views/FocusedAddonView.svelte
+++ b/application/src/frontend/views/FocusedAddonView.svelte
@@ -394,6 +394,8 @@ async function handleActionClick(key: string) {
     __taskName: taskName,
     ...actionOption.manifest,
   };
+  // Actions only need a name and button text, so fall back for the task label
+  const actionName = actionOption.displayName || actionOption.buttonText || key;
 
   runningActions = { ...runningActions, [key]: true };
   await runFrontendEffect(
@@ -402,7 +404,7 @@ async function handleActionClick(key: string) {
         addonSource: selectedAddon.id,
         addonName: selectedAddon.name,
         manifest,
-        name: actionOption.displayName,
+        name: actionName,
         downloadType: 'task' as const,
         taskName,
         capsuleImage: '',
@@ -542,18 +544,23 @@ async function handleActionClick(key: string) {
         <div class="options">
           <div class="hidden outline-red-500 outline-4"></div>
           {#each Object.keys(selectedAddon.configTemplate) as key}
+            {@const optionDescription =
+              selectedAddon.configTemplate[key].description}
             <div
               class="flex flex-row gap-2 items-center relative"
               data-input-parent
             >
-              <label
-                for={key}
-                onmouseover={showDescription}
-                onfocus={showDescription}
-                onmouseleave={hideDescription}
-                class="config-label"
-                >{selectedAddon.configTemplate[key].displayName}</label
-              >
+              <!-- Actions without a display name are labelled by their button alone -->
+              {#if selectedAddon.configTemplate[key].displayName}
+                <label
+                  for={key}
+                  onmouseover={optionDescription ? showDescription : undefined}
+                  onfocus={optionDescription ? showDescription : undefined}
+                  onmouseleave={optionDescription ? hideDescription : undefined}
+                  class="config-label"
+                  >{selectedAddon.configTemplate[key].displayName}</label
+                >
+              {/if}
               {#if isStringOption(selectedAddon.configTemplate[key])}
                 {@const option = selectedAddon.configTemplate[key]}
                 {#if (option.allowedValues?.length ?? 0) > 0}
@@ -699,7 +706,7 @@ async function handleActionClick(key: string) {
                   /></svg
                 >
                 <p class="text-blue-400 leading-relaxed relative top-[0.1rem]">
-                  {selectedAddon.configTemplate[key].description}
+                  {optionDescription}
                 </p>
               </div>
             </div>

--- a/application/src/frontend/views/FocusedAddonView.svelte
+++ b/application/src/frontend/views/FocusedAddonView.svelte
@@ -654,12 +654,18 @@ async function handleActionClick(key: string) {
               {/if}
               {#if isActionOption(selectedAddon.configTemplate[key])}
                 {@const option = selectedAddon.configTemplate[key]}
+                <!-- With no label, the button itself is the description trigger -->
+                {@const buttonShowsDescription =
+                  !option.displayName && Boolean(optionDescription)}
                 <button
                   type="button"
                   onclick={(event) => {
                     event.stopPropagation();
                     handleActionClick(key);
                   }}
+                  onmouseover={buttonShowsDescription ? showDescription : undefined}
+                  onfocus={buttonShowsDescription ? showDescription : undefined}
+                  onmouseleave={buttonShowsDescription ? hideDescription : undefined}
                   class="action-button ml-auto"
                   disabled={runningActions[key]}
                   aria-busy={runningActions[key]}

--- a/bun.lock
+++ b/bun.lock
@@ -132,7 +132,7 @@
     },
     "packages/connection": {
       "name": "@ogi-sdk/connect",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@ogi-sdk/errors": "^1.0.0",
         "@ogi-sdk/logger": "^1.0.0",
@@ -195,7 +195,7 @@
     },
     "packages/ogi-addon": {
       "name": "ogi-addon",
-      "version": "4.2.1",
+      "version": "5.2.0",
       "dependencies": {
         "@ogi-sdk/connect": "^1.0.2",
         "@ogi-sdk/errors": "^1.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "application": {
       "name": "opengameinstaller-gui",
-      "version": "4.2.3",
+      "version": "4.3.0",
       "dependencies": {
         "@ctrl/qbittorrent": "^9.11.0",
         "@effect/platform": "0.97.0",
@@ -80,7 +80,7 @@
         "@ogi-sdk/logger": "^1.0.0",
         "effect": "^3.22.0",
         "elysia": "^1.4.28",
-        "ogi-addon": "^4.1.0",
+        "ogi-addon": "^5.0.0",
         "websocket": "^1.0.35",
         "ws": "^8.20.0",
       },
@@ -118,7 +118,7 @@
         "@ogi-sdk/errors": "^1.0.0",
         "@ogi-sdk/logger": "^1.0.0",
         "effect": "^3.22.0",
-        "ogi-addon": "^4.1.0",
+        "ogi-addon": "^5.0.0",
         "ws": "^8.20.0",
       },
       "devDependencies": {
@@ -167,7 +167,7 @@
     },
     "packages/executor": {
       "name": "@ogi-sdk/executor",
-      "version": "1.4.2",
+      "version": "1.4.4",
       "dependencies": {
         "@ogi-sdk/errors": "^1.0.0",
         "@ogi-sdk/logger": "^1.0.0",
@@ -240,7 +240,7 @@
     },
     "updater": {
       "name": "ogi-updater",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "dependencies": {
         "@ogi-sdk/logger": "workspace:*",
         "axios": "^1.13.4",

--- a/packages/connection/lib/protocol.ts
+++ b/packages/connection/lib/protocol.ts
@@ -627,11 +627,19 @@ export type AddonSDKLifecycleEventListenerTypes<EventResponse> = {
 };
 
 /**
- * Context passed to the addon SDK `connect` listener. `gameSpecificLaunch` is
- * true when this session was started for a specific game (Steam shortcut
- * launch), so addons can selectively start only the components they need.
+ * How the OGI session hosting the addon was started.
+ * - `full`: the user opened OpenGameInstaller itself.
+ * - `game-launch`: OGI was started by a managed Steam shortcut to run one game
+ *   (including hook-only pre/post launches) and will exit when it is done.
+ */
+export type OGIAddonLaunchMode = 'full' | 'game-launch';
+
+/**
+ * Context passed to the addon SDK `connect` listener so addons can decide which
+ * components to start. `gameSpecificLaunch` mirrors `launchMode === 'game-launch'`.
  */
 export type OGIAddonConnectContext = {
+  launchMode: OGIAddonLaunchMode;
   gameSpecificLaunch: boolean;
 };
 

--- a/packages/connection/lib/protocol.ts
+++ b/packages/connection/lib/protocol.ts
@@ -620,7 +620,7 @@ export type AddonProtocolEventListenerTypes<
 
 /** Local SDK lifecycle hooks (not declared in `addonProtocol.serverToAddon`). */
 export type AddonSDKLifecycleEventListenerTypes<EventResponse> = {
-  connect: (event: EventResponse, context?: OGIAddonConnectContext) => void;
+  connect: (context: OGIAddonConnectContext, event: EventResponse) => void;
   disconnect: (reason: string) => void;
   exit: () => void;
   response: (response: unknown) => void;

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -2,7 +2,7 @@
   "name": "@ogi-sdk/connect",
   "module": "./build/index.mjs",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "exports": {
     ".": {
       "import": {

--- a/packages/ogi-addon/package.json
+++ b/packages/ogi-addon/package.json
@@ -3,7 +3,7 @@
   "module": "./build/main.mjs",
   "type": "module",
   "main": "./build/main.cjs",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "exports": {
     ".": {
       "import": {

--- a/packages/ogi-addon/src/config/ConfigurationBuilder.ts
+++ b/packages/ogi-addon/src/config/ConfigurationBuilder.ts
@@ -20,11 +20,42 @@ export type {
   StringConfigurationOption,
 } from '@ogi-sdk/connect';
 
-const ConfigValidationSchema = Schema.Struct({
-  name: Schema.NonEmptyString,
-  displayName: Schema.NonEmptyString,
-  description: Schema.NonEmptyString,
-});
+// Runtime mirror of RequiredInputSetters / RequiredActionSetters below.
+const ConfigValidationSchema = Schema.Union(
+  Schema.Struct({
+    type: Schema.Literal('string', 'number', 'boolean'),
+    name: Schema.NonEmptyString,
+    displayName: Schema.NonEmptyString,
+    description: Schema.NonEmptyString,
+  }),
+  Schema.Struct({
+    type: Schema.Literal('action'),
+    name: Schema.NonEmptyString,
+    buttonText: Schema.NonEmptyString,
+  })
+);
+
+/**
+ * Phantom record of which required setters have been called on an option. It
+ * only exists in the type system: required setters intersect it into their
+ * return type and `add*Option` demands the full set, so forgetting one fails
+ * to compile with an error naming the missing setter.
+ */
+export type Called<Setter extends string> = {
+  readonly __called: { readonly [S in Setter]: true };
+};
+
+/** Swaps an option's name type while keeping the setters already recorded on `this`. */
+type Renamed<Option, Self> = Option &
+  (Self extends Called<infer S> ? Called<S> : unknown);
+
+/** Setters every string, number, and boolean option must call. */
+export type RequiredInputSetters =
+  | 'setName'
+  | 'setDisplayName'
+  | 'setDescription';
+/** Setters every action option must call; the button text is its label. */
+export type RequiredActionSetters = 'setName' | 'setButtonText';
 
 export function isStringOption(
   option: ConfigurationOptionWire
@@ -63,12 +94,15 @@ export class ConfigurationBuilder<
   private options: ConfigurationOption<string>[] = [];
 
   /**
-   * Add a number option to the configuration builder and return the builder for chaining. You must provide a name, display name, and description for the option.
+   * Add a number option to the configuration builder and return the builder for chaining.
+   * The callback must call `setName`, `setDisplayName`, and `setDescription`; omitting one is a type error.
    * @param option { (option: NumberOption) => NumberOption<K> }
    * @returns A new ConfigurationBuilder with the number option's type added
    */
   public addNumberOption<K extends string>(
-    option: (option: NumberOption) => NumberOption<K>
+    option: (
+      option: NumberOption
+    ) => NumberOption<K> & Called<RequiredInputSetters>
   ): ConfigurationBuilder<T & { [P in K]: number }> {
     let newOption = new NumberOption();
     const configuredOption = option(newOption);
@@ -77,12 +111,15 @@ export class ConfigurationBuilder<
   }
 
   /**
-   * Add a string option to the configuration builder and return the builder for chaining. You must provide a name, display name, and description for the option.
+   * Add a string option to the configuration builder and return the builder for chaining.
+   * The callback must call `setName`, `setDisplayName`, and `setDescription`; omitting one is a type error.
    * @param option { (option: StringOption) => StringOption<K> }
    * @returns A new ConfigurationBuilder with the string option's type added
    */
   public addStringOption<K extends string>(
-    option: (option: StringOption) => StringOption<K>
+    option: (
+      option: StringOption
+    ) => StringOption<K> & Called<RequiredInputSetters>
   ): ConfigurationBuilder<T & { [P in K]: string }> {
     let newOption = new StringOption();
     const configuredOption = option(newOption);
@@ -91,12 +128,15 @@ export class ConfigurationBuilder<
   }
 
   /**
-   * Add a boolean option to the configuration builder and return the builder for chaining. You must provide a name, display name, and description for the option.
+   * Add a boolean option to the configuration builder and return the builder for chaining.
+   * The callback must call `setName`, `setDisplayName`, and `setDescription`; omitting one is a type error.
    * @param option { (option: BooleanOption) => BooleanOption<K> }
    * @returns A new ConfigurationBuilder with the boolean option's type added
    */
   public addBooleanOption<K extends string>(
-    option: (option: BooleanOption) => BooleanOption<K>
+    option: (
+      option: BooleanOption
+    ) => BooleanOption<K> & Called<RequiredInputSetters>
   ): ConfigurationBuilder<T & { [P in K]: boolean }> {
     let newOption = new BooleanOption();
     const configuredOption = option(newOption);
@@ -107,12 +147,15 @@ export class ConfigurationBuilder<
   /**
    * Add an action option to the configuration builder and return the builder for chaining.
    * Action options contribute a boolean to the return type (true if clicked, false if not).
-   * You must provide a name, display name, and description for the option.
+   * The callback must call `setName` and `setButtonText`; omitting one is a type error.
+   * Display name and description are optional for actions since the button is the label.
    * @param option { (option: ActionOption) => ActionOption<K> }
    * @returns A new ConfigurationBuilder with the action option's type added as boolean
    */
   public addActionOption<K extends string>(
-    option: (option: ActionOption) => ActionOption<K>
+    option: (
+      option: ActionOption
+    ) => ActionOption<K> & Called<RequiredActionSetters>
   ): ConfigurationBuilder<T & { [P in K]: boolean }> {
     let newOption = new ActionOption();
     const configuredOption = option(newOption);
@@ -155,29 +198,32 @@ export class ConfigurationOption<N extends string = string> {
    * Set the name of the option. **REQUIRED**
    * @param name {string} The name of the option. This is used to reference the option in the configuration file.
    */
-  setName<K extends string>(name: K): ConfigurationOption<K> {
+  setName<K extends string>(
+    name: K
+  ): Renamed<ConfigurationOption<K>, this> & Called<'setName'> {
     this.name = name as unknown as N;
-    return this as unknown as ConfigurationOption<K>;
+    return this as unknown as Renamed<ConfigurationOption<K>, this> &
+      Called<'setName'>;
   }
 
   /**
-   * Set the display name of the option. This is used to show the user a human readable version of what the option is. **REQUIRED**
+   * Set the display name of the option. This is used to show the user a human readable version of what the option is.
+   * **REQUIRED** for string, number, and boolean options; optional for actions.
    * @param displayName {string} The display name of the option.
-   * @returns
    */
-  setDisplayName(displayName: string): this {
+  setDisplayName(displayName: string): this & Called<'setDisplayName'> {
     this.displayName = displayName;
-    return this;
+    return this as this & Called<'setDisplayName'>;
   }
 
   /**
-   * Set the description of the option. This is to show the user a brief description of what this option does. **REQUIRED**
+   * Set the description of the option. This is to show the user a brief description of what this option does.
+   * **REQUIRED** for string, number, and boolean options; optional for actions.
    * @param description {string} The description of the option.
-   * @returns
    */
-  setDescription(description: string): this {
+  setDescription(description: string): this & Called<'setDescription'> {
     this.description = description;
-    return this;
+    return this as this & Called<'setDescription'>;
   }
 
   /**
@@ -203,9 +249,12 @@ export class StringOption<
    * Set the name of the option. **REQUIRED**
    * @param name {string} The name of the option. This is used to reference the option in the configuration file.
    */
-  override setName<K extends string>(name: K): StringOption<K> {
+  override setName<K extends string>(
+    name: K
+  ): Renamed<StringOption<K>, this> & Called<'setName'> {
     this.name = name as unknown as N;
-    return this as unknown as StringOption<K>;
+    return this as unknown as Renamed<StringOption<K>, this> &
+      Called<'setName'>;
   }
 
   /**
@@ -295,9 +344,12 @@ export class NumberOption<
    * Set the name of the option. **REQUIRED**
    * @param name {string} The name of the option. This is used to reference the option in the configuration file.
    */
-  override setName<K extends string>(name: K): NumberOption<K> {
+  override setName<K extends string>(
+    name: K
+  ): Renamed<NumberOption<K>, this> & Called<'setName'> {
     this.name = name as unknown as N;
-    return this as unknown as NumberOption<K>;
+    return this as unknown as Renamed<NumberOption<K>, this> &
+      Called<'setName'>;
   }
 
   /**
@@ -360,9 +412,12 @@ export class BooleanOption<
    * Set the name of the option. **REQUIRED**
    * @param name {string} The name of the option. This is used to reference the option in the configuration file.
    */
-  override setName<K extends string>(name: K): BooleanOption<K> {
+  override setName<K extends string>(
+    name: K
+  ): Renamed<BooleanOption<K>, this> & Called<'setName'> {
     this.name = name as unknown as N;
-    return this as unknown as BooleanOption<K>;
+    return this as unknown as Renamed<BooleanOption<K>, this> &
+      Called<'setName'>;
   }
 
   /**
@@ -387,16 +442,19 @@ export class ActionOption<
 > extends ConfigurationOption<N> {
   public type: ConfigurationOptionType = 'action';
   public manifest: Record<string, unknown> = {};
-  public buttonText: string = 'Run';
+  public buttonText: string = '';
   public taskName: string = '';
 
   /**
    * Set the name of the option. **REQUIRED**
    * @param name {string} The name of the option. This is used to reference the option in the configuration file.
    */
-  override setName<K extends string>(name: K): ActionOption<K> {
+  override setName<K extends string>(
+    name: K
+  ): Renamed<ActionOption<K>, this> & Called<'setName'> {
     this.name = name as unknown as N;
-    return this as unknown as ActionOption<K>;
+    return this as unknown as Renamed<ActionOption<K>, this> &
+      Called<'setName'>;
   }
 
   /**
@@ -418,12 +476,12 @@ export class ActionOption<
   }
 
   /**
-   * Set the text displayed on the action button.
+   * Set the text displayed on the action button. **REQUIRED**
    * @param text {string} The button text.
    */
-  setButtonText(text: string): this {
+  setButtonText(text: string): this & Called<'setButtonText'> {
     this.buttonText = text;
-    return this;
+    return this as this & Called<'setButtonText'>;
   }
 
   override validate(_input: unknown): [boolean, string] {

--- a/packages/ogi-addon/src/main.ts
+++ b/packages/ogi-addon/src/main.ts
@@ -1034,10 +1034,11 @@ class OGIAddonWSListener {
             // Tell the addon how OGI was started so it can selectively start
             // only the components a managed game launch needs.
             const { launchMode } = this.addon;
-            this.eventEmitter.emit('connect', connectEvent, {
-              launchMode,
-              gameSpecificLaunch: launchMode === 'game-launch',
-            });
+            this.eventEmitter.emit(
+              'connect',
+              { launchMode, gameSpecificLaunch: launchMode === 'game-launch' },
+              connectEvent
+            );
             this.schedule(this.runDeferred(connectEvent));
             yield* this.sendEventsAvailable();
           }

--- a/packages/ogi-addon/src/main.ts
+++ b/packages/ogi-addon/src/main.ts
@@ -16,6 +16,7 @@ import type {
   CatalogResponse,
   LibraryInfo,
   OGIAddonConfiguration,
+  OGIAddonLaunchMode,
   OGIAddonSDKEventListener,
   SearchResult,
   SetupResponse,
@@ -71,6 +72,8 @@ export type {
   ConfigurationOptionWire,
   LibraryInfo,
   OGIAddonConfiguration,
+  OGIAddonConnectContext,
+  OGIAddonLaunchMode,
   OGIAddonSDKEventListener,
   SearchResult,
   SetupCommandData,
@@ -222,6 +225,13 @@ export default class OGIAddon {
   public eventEmitter = new events.EventEmitter();
   private readonly addonWSListener: OGIAddonWSListener;
   public addonInfo: OGIAddonConfiguration;
+  /**
+   * How the hosting OGI session was started. The executor sets OGI_GAME_LAUNCH
+   * for managed Steam-shortcut sessions; anything else is a full app launch.
+   * Also handed to the `connect` listener, but readable here from any handler.
+   */
+  public readonly launchMode: OGIAddonLaunchMode =
+    process.env.OGI_GAME_LAUNCH === '1' ? 'game-launch' : 'full';
   public config: Configuration = new Configuration({});
   private eventsAvailable: OGIAddonSDKEventListener[] = [];
   private readonly runtime = makeWarmRuntime();
@@ -1021,10 +1031,12 @@ class OGIAddonWSListener {
           if (!this.configConnected) {
             this.configConnected = true;
             const connectEvent = this.makeEventResponse<void>();
-            // Game-specific launches (Steam shortcut) set OGI_GAME_LAUNCH so
-            // addons can selectively start only the components they need.
+            // Tell the addon how OGI was started so it can selectively start
+            // only the components a managed game launch needs.
+            const { launchMode } = this.addon;
             this.eventEmitter.emit('connect', connectEvent, {
-              gameSpecificLaunch: process.env.OGI_GAME_LAUNCH === '1',
+              launchMode,
+              gameSpecificLaunch: launchMode === 'game-launch',
             });
             this.schedule(this.runDeferred(connectEvent));
             yield* this.sendEventsAvailable();

--- a/test-addon/main.ts
+++ b/test-addon/main.ts
@@ -47,11 +47,10 @@ addon.on('configure', (config) =>
         .setButtonText('Run Custom Task')
         .setTaskName('custom-task-name')
     )
+    // Actions only need a name and button text
     .addActionOption((option) =>
       option
-        .setDisplayName('Download API Test')
         .setName('downloadTest')
-        .setDescription('Enqueue and track a download from the addon SDK')
         .setButtonText('Run Download Test')
         .setTaskName('download-test')
     )

--- a/test-addon/main.ts
+++ b/test-addon/main.ts
@@ -71,8 +71,12 @@ addon.on('configure', (config) =>
         .setDescription('A test boolean option')
     )
 );
-addon.on('connect', () => {
-  addon.notify({ type: 'info', message: 'Connected', id: 'connect' });
+addon.on('connect', (_event, context) => {
+  addon.notify({
+    type: 'info',
+    message: `Connected (${context?.launchMode ?? addon.launchMode} launch)`,
+    id: 'connect',
+  });
   new Promise(async (resolve) => {
     const task = await addon.task();
     task.log('test');

--- a/test-addon/main.ts
+++ b/test-addon/main.ts
@@ -70,10 +70,10 @@ addon.on('configure', (config) =>
         .setDescription('A test boolean option')
     )
 );
-addon.on('connect', (_event, context) => {
+addon.on('connect', ({ launchMode }) => {
   addon.notify({
     type: 'info',
-    message: `Connected (${context?.launchMode ?? addon.launchMode} launch)`,
+    message: `Connected (${launchMode} launch)`,
     id: 'connect',
   });
   new Promise(async (resolve) => {

--- a/web/src/pages/docs/first-addon/action-buttons-and-tasks.md
+++ b/web/src/pages/docs/first-addon/action-buttons-and-tasks.md
@@ -10,16 +10,15 @@ Action buttons let users trigger addon-specific jobs from configuration screens,
 
 ## Add an action button in `configure`
 
-Use `addActionOption(...)` with a task name and optional manifest payload:
+Use `addActionOption(...)` with a task name and optional manifest payload. Only `setName` and `setButtonText` are required (the button is the label); leaving either out is a type error. `setDisplayName` and `setDescription` are optional and add a label and hover hint beside the button:
 
 ```typescript
 addon.on('configure', (config) =>
   config.addActionOption((option) =>
     option
       .setName('clearCache')
-      .setDisplayName('Clear Cache')
-      .setDescription('Clear temporary addon cache files')
       .setButtonText('Run Cleanup')
+      .setDescription('Clear temporary addon cache files')
       .setTaskName('maintenance:clear-cache')
       .setManifest({
         scope: 'all',

--- a/web/src/pages/docs/first-addon/adding-configs.md
+++ b/web/src/pages/docs/first-addon/adding-configs.md
@@ -42,6 +42,8 @@ option.setDescription(string);
 
 `option.setDescription(string)` sets the description for your option when the user hovers over it for information. This should be human-readable and short.
 
+These requirements are enforced by the type system: the builder's return type records which required setters you called, so leaving one out fails to compile with an error naming the missing setter. Action options are the exception and only need `setName` and `setButtonText`; see [Action Buttons & Tasks](/docs/first-addon/action-buttons-and-tasks).
+
 You can see how the config looks by restarting OpenGameInstaller.
 
 ## How do I get configuration values?

--- a/web/src/pages/docs/first-addon/basic-addon.md
+++ b/web/src/pages/docs/first-addon/basic-addon.md
@@ -33,3 +33,19 @@ local:[THE PATH TO YOUR ADDON'S WORKING DIRECTORY]
 ```
 
 Then, press `Install All` and `Restart Addon Server` to initialize your addon!
+
+## Knowing how OGI was launched
+
+OpenGameInstaller can be started two ways: the user opens the app itself (`full`), or a managed Steam shortcut starts OGI just to run one game and then exits (`game-launch`). The `connect` event tells you which, so a game-launch session can skip work that only matters in the full app (indexing catalogs, background update checks, and so on).
+
+```typescript
+addon.on('connect', (_event, context) => {
+  if (context?.launchMode === 'game-launch') {
+    // only start what a single game launch needs
+    return;
+  }
+  startCatalogIndexer();
+});
+```
+
+The same value is available anywhere as `addon.launchMode`. `context.gameSpecificLaunch` is a boolean shorthand for `launchMode === 'game-launch'`.

--- a/web/src/pages/docs/first-addon/basic-addon.md
+++ b/web/src/pages/docs/first-addon/basic-addon.md
@@ -39,8 +39,8 @@ Then, press `Install All` and `Restart Addon Server` to initialize your addon!
 OpenGameInstaller can be started two ways: the user opens the app itself (`full`), or a managed Steam shortcut starts OGI just to run one game and then exits (`game-launch`). The `connect` event tells you which, so a game-launch session can skip work that only matters in the full app (indexing catalogs, background update checks, and so on).
 
 ```typescript
-addon.on('connect', (_event, context) => {
-  if (context?.launchMode === 'game-launch') {
+addon.on('connect', ({ launchMode }) => {
+  if (launchMode === 'game-launch') {
     // only start what a single game launch needs
     return;
   }
@@ -48,4 +48,4 @@ addon.on('connect', (_event, context) => {
 });
 ```
 
-The same value is available anywhere as `addon.launchMode`. `context.gameSpecificLaunch` is a boolean shorthand for `launchMode === 'game-launch'`.
+The same value is available anywhere as `addon.launchMode`. The context also carries `gameSpecificLaunch`, a boolean shorthand for `launchMode === 'game-launch'`. Like every other listener, the event response comes last: `(context, event)`.


### PR DESCRIPTION
# Description

Two addon SDK improvements, plus version bumps for `@ogi-sdk/connect` (v1.2.0) and `ogi-addon` (v5.2.0).

**Launch mode on connect.** Addons could only tell a managed Steam-shortcut session from a full app launch through the bare `gameSpecificLaunch` boolean on the `connect` context, and only inside that one listener. This adds a named `OGIAddonLaunchMode` (`'full' | 'game-launch'`) to `@ogi-sdk/connect`, passes it as the first argument of `connect` (`(context, event)`, event last like every other listener), and exposes it as `addon.launchMode` on the `OGIAddon` instance so any handler can branch on it. `gameSpecificLaunch` is kept as a shorthand so existing addons keep working.

**Required setters are now type errors.** Each required setter on a config option intersects a phantom `Called<'setX'>` marker into its return type, and `add*Option` demands the full set. Forgetting one no longer waits for a runtime `ValidationError` in `build()`; it fails to compile with a message naming the missing setter. Action options are relaxed to only require `setName` and `setButtonText`, since the button is the label. `setDisplayName` and `setDescription` stay optional on actions, and the addon view renders label-less actions cleanly. The runtime schema in `build()` was updated to match.

# Example

```typescript
addon.on('connect', ({ launchMode }) => {
  if (launchMode === 'game-launch') return;
  startCatalogIndexer();
});

config
  // ok: minimal action
  .addActionOption((o) => o.setName('clearCache').setButtonText('Run Cleanup'))
  // type error: missing setDescription
  .addStringOption((o) => o.setName('token').setDisplayName('API Token'));
```

# Next Steps

- Publish `@ogi-sdk/connect@1.2.0` and `ogi-addon@5.2.0`.
- Consider a third launch mode for hook-only pre/post launches if addons need to distinguish them at connect time.
- The `Called<>` marker pattern could extend to other builders (e.g. `SearchResult` shapes) if the same "forgot a required field" mistakes show up there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Addon integrations can detect full-app versus game-launch mode.
  - Configuration builders enforce required fields for input and action options.
  - Action options support names and button text without display names or descriptions.

- **Bug Fixes**
  - Action labels fall back appropriately when display names are unavailable.
  - Action descriptions remain accessible when display names are omitted.
  - Empty action button text no longer displays an incorrect default.

- **Documentation**
  - Added guidance for handling launch modes and required configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->