### PR TITLE
fix(application): show game removal confirmation above configuration

### DIFF
--- a/application/src/frontend/components/GameConfiguration.svelte
+++ b/application/src/frontend/components/GameConfiguration.svelte
@@ -457,6 +457,7 @@ function getInputOptions(option: ConfigurationOptionWire): string[] {
     <Modal
       open={true}
       size="small"
+      priority="urgent"
       closeOnOverlayClick={false}
       onClose={() => {
         if (!removeBusy) showRemoveConfirm = false;


### PR DESCRIPTION
# Description

Give the remove-game confirmation urgent modal priority, matching the existing DLL overrides dialog. Its default UI priority caused the already-open configuration modal to block it in the queue, so Remove Game appeared to do nothing and never reached the deletion RPC.

# Example

Game configuration -> Remove Game -> confirmation -> Delete Game now reaches the existing removal flow. Cancel dismisses the confirmation without removing the game.

Validation: full `bun run typecheck` passed (existing Svelte warnings remain); all 11 deletion-guard tests passed; exercised the actual modal queue visibility callback to reproduce the old blockage and verify the new priority. Full Electron click-through was not available in this environment.

# Next Steps

- Wait for CI and automated reviews before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Removal confirmations for games are now marked as urgent, making the importance of this action clearer to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->